### PR TITLE
docs: codify scope guardrails for future bundle additions

### DIFF
--- a/.codex-plugin/ycc/skills/bundle-author/references/when-not-to-scaffold.md
+++ b/.codex-plugin/ycc/skills/bundle-author/references/when-not-to-scaffold.md
@@ -80,4 +80,5 @@ can always add it later when the consuming skill is written.
 
 ---
 
-See also: `surface-map.md` (this directory), `AGENTS.md` (repo root).
+See also: `surface-map.md` (this directory), `AGENTS.md` (repo root), and the Scope &
+Guardrails section of `CONTRIBUTING.md` (repo root) for the policy-level view.

--- a/.cursor-plugin/skills/bundle-author/references/when-not-to-scaffold.md
+++ b/.cursor-plugin/skills/bundle-author/references/when-not-to-scaffold.md
@@ -80,4 +80,5 @@ can always add it later when the consuming skill is written.
 
 ---
 
-See also: `surface-map.md` (this directory), `CLAUDE.md` (repo root).
+See also: `surface-map.md` (this directory), `CLAUDE.md` (repo root), and the Scope &
+Guardrails section of `CONTRIBUTING.md` (repo root) for the policy-level view.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,8 @@ The marketplace registry at `.claude-plugin/marketplace.json` contains a single 
 ```
 
 Do not add additional plugin entries. New functionality goes into the existing `ycc`
-plugin as a new skill, command, or agent.
+plugin as a new skill, command, or agent. See `CONTRIBUTING.md` → Scope & Guardrails for
+the full policy on what belongs in `ycc` and what to reject.
 
 ## Generated Compatibility Targets
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,41 @@ This repo no longer accepts new top-level Claude plugins. All new functionality 
 existing `ycc` source plugin under `ycc/`, then flows through the generated Cursor and Codex
 compatibility bundles.
 
+## Scope & Guardrails
+
+New bundle additions are evaluated against written policy, not memory. These rules come from
+`research/plugin-additions/report.md` and apply to every proposal for a new skill, command,
+or agent.
+
+- **Do not add another wave of narrow expert skills.** The bundle already ships broad
+  coverage; the current bottleneck is maintenance integrity (drift, inventory accuracy,
+  generator sync), not missing subjects. Breadth additions without evidence are rejected.
+- **Do not create a new top-level plugin.** The repo contract is one plugin (`ycc`). All
+  new functionality goes under `ycc/` and is reached via the `ycc:` namespace. Adding
+  entries to `.claude-plugin/marketplace.json` breaks the 2.0 consolidation contract.
+- **Do not market hooks as uniform across targets.** Claude, Cursor, and Codex have
+  different hook support and maturity. Any hook-related addition must ship with a per-target
+  support matrix.
+- **Meta-skills and internal optimizations precede new domain coverage.** Authoring
+  workflows, release workflows, compatibility audits, validator CI, and source-driven
+  inventory come before any new subject-matter skill.
+
+### Proposing New Capabilities
+
+Before opening a PR for a new skill, command, or agent, answer each question below. If any
+answer points elsewhere, revise the proposal before writing code.
+
+- Could this extend an existing skill (a new phase, flag, or reference file) instead of
+  becoming a new one?
+- Would this require a new top-level plugin or a `marketplace.json` entry? If yes, stop —
+  this is rejected by policy.
+- Has a higher-priority meta-skill or drift fix been scheduled first?
+- For hook-related work: does the proposal include a per-target support matrix?
+
+See also: [`ycc/skills/bundle-author/references/when-not-to-scaffold.md`](ycc/skills/bundle-author/references/when-not-to-scaffold.md)
+for the skill-author-facing anti-patterns (duplication, one-off tasks, shared-logic
+misplacement, agents without consumers, etc.) that complement this policy.
+
 ## Structure Requirements
 
 - Claude source plugin manifest: `ycc/.claude-plugin/plugin.json`

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The plugin bundles **50** specialized agents covering codebase analysis, languag
 - **Cursor:** generated, Cursor-native copies live in [`.cursor-plugin/agents/`](.cursor-plugin/agents/) (produced from `ycc/agents/` — see [Cursor IDE sync](#cursor-ide-sync)).
 - **Codex:** generated, Codex-native custom-agent TOMLs live in [`.codex-plugin/agents/`](.codex-plugin/agents/) (produced from `ycc/agents/` and synced to `~/.codex/agents/` by `install.sh --target codex`).
 
+**Contributing:** before proposing a new skill, command, or agent, read the Scope & Guardrails policy in [`CONTRIBUTING.md`](CONTRIBUTING.md#scope--guardrails).
+
 ## Installation
 
 ```bash

--- a/ycc/skills/bundle-author/references/when-not-to-scaffold.md
+++ b/ycc/skills/bundle-author/references/when-not-to-scaffold.md
@@ -80,4 +80,5 @@ can always add it later when the consuming skill is written.
 
 ---
 
-See also: `surface-map.md` (this directory), `CLAUDE.md` (repo root).
+See also: `surface-map.md` (this directory), `CLAUDE.md` (repo root), and the Scope &
+Guardrails section of `CONTRIBUTING.md` (repo root) for the policy-level view.


### PR DESCRIPTION
## Summary

- Lifts the "What Not To Add" conclusions from `research/plugin-additions/report.md` into contributor-facing repo policy.
- Adds a `## Scope & Guardrails` section to `CONTRIBUTING.md` with 4 policy bullets and a "Proposing New Capabilities" evaluation checklist.
- Cross-links the new section from `CLAUDE.md` (Registration), `README.md` (before Installation), and `ycc/skills/bundle-author/references/when-not-to-scaffold.md` (See also footer) so future additions are evaluated against written policy rather than memory.

## Motivation

Per issue #13 and tracker #18, the research concluded that the repo's current bottleneck is maintenance integrity, not subject-matter breadth. Those "do not add" conclusions needed to move out of the research report and into guidance contributors actually read.

## Changes

- `CONTRIBUTING.md` — new `## Scope & Guardrails` section (+32 lines).
- `CLAUDE.md` — one-line pointer appended to the Registration section.
- `README.md` — one-line `**Contributing:**` pointer inserted between the generated agent region and `## Installation` (outside all `BEGIN:GENERATED` / `END:GENERATED` markers).
- `ycc/skills/bundle-author/references/when-not-to-scaffold.md` — "See also" footer extended to reference `CONTRIBUTING.md` (closes the bidirectional cross-link).
- Generated mirrors regenerated by `./scripts/sync.sh`:
  - `.cursor-plugin/skills/bundle-author/references/when-not-to-scaffold.md`
  - `.codex-plugin/ycc/skills/bundle-author/references/when-not-to-scaffold.md`

## Coverage Audit (vs research "What Not To Add")

- [x] "Do not add another wave of narrow expert skills" → `CONTRIBUTING.md` bullet 1
- [x] "Do not create a new top-level plugin" → `CONTRIBUTING.md` bullet 2
- [x] "Do not market hooks as uniform across all targets" → `CONTRIBUTING.md` bullet 3
- [x] Executive synthesis: meta-skills / internal optimizations precede breadth → `CONTRIBUTING.md` bullet 4

## Validation

- [x] `./scripts/sync.sh` — regenerated Cursor + Codex bundles
- [x] `./scripts/validate.sh` — all gates pass (inventory, Cursor agents/skills/rules, Codex agents/skills/plugin, marketplace/plugin JSON)
- [x] No generator markers in `README.md` were touched
- [x] `CONTRIBUTING.md` → `when-not-to-scaffold.md` cross-link verified bidirectional

Closes #13
Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced new "Scope & Guardrails" policy in CONTRIBUTING.md that defines constraints for proposing new skills, commands, and agents.
  * Added contributor checklist for new capability proposals.
  * Updated documentation across the repository to reference the scope and guardrails guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->