### PR TITLE
feat(yci): customer-profile skill (switch/whoami/init)

### DIFF
--- a/scripts/validate-yci-skills.sh
+++ b/scripts/validate-yci-skills.sh
@@ -1,44 +1,50 @@
 #!/usr/bin/env bash
-# validate-yci-skills.sh — Phase-0 validator for the yci plugin surface.
+# validate-yci-skills.sh — yci skill validator
 #
 # Checks:
 #   1. yci/.claude-plugin/plugin.json exists and parses as valid JSON.
-#   2. yci/skills/hello/SKILL.md exists.
-#   3. yci/skills/hello/SKILL.md has valid YAML frontmatter with:
-#      - Opening and closing "---" delimiters.
-#      - name: hello
-#      - description: <non-empty string>
+#   2. yci/skills/hello/SKILL.md exists with valid YAML frontmatter.
+#   3. yci/skills/customer-profile — full surface validation.
 #
-# Scope: Phase-0 only — intentionally narrow (two files).
-# Frontmatter parsing falls back to regex when pyyaml is unavailable,
-# mirroring the approach in scripts/validate-ycc-commands.sh.
-set -euo pipefail
+# Intentional: no -e flag; validator must aggregate failures.
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-PLUGIN_JSON="${REPO_ROOT}/yci/.claude-plugin/plugin.json"
-SKILL_MD="${REPO_ROOT}/yci/skills/hello/SKILL.md"
-SCRIPT_NAME="validate-yci-skills.sh"
+ERRORS=0
 
-# 1. Check plugin.json exists and parses as valid JSON.
-if [[ ! -f "${PLUGIN_JSON}" ]]; then
-    echo "${SCRIPT_NAME}: missing ${PLUGIN_JSON}" >&2
-    exit 1
-fi
-if ! python3 -m json.tool "${PLUGIN_JSON}" > /dev/null 2>&1; then
-    echo "${SCRIPT_NAME}: ${PLUGIN_JSON} is not valid JSON" >&2
-    exit 1
-fi
+fail() { printf '  ✗ fail: %s\n' "$*" >&2; ERRORS=$((ERRORS + 1)); }
+ok()   { printf '  ✓ ok:   %s\n' "$*"; }
+warn() { printf '  ! warn: %s\n' "$*" >&2; }
 
-# 2. Check SKILL.md exists.
-if [[ ! -f "${SKILL_MD}" ]]; then
-    echo "${SCRIPT_NAME}: missing ${SKILL_MD}" >&2
-    exit 1
-fi
+# ---------------------------------------------------------------------------
+# Phase-0 hello skill checks (preserved verbatim from original)
+# ---------------------------------------------------------------------------
+validate_hello_skill() {
+    echo "--- hello skill ---"
 
-# 3. Parse and validate frontmatter via Python (pyyaml or regex fallback).
-python3 - "${SKILL_MD}" <<'PY'
+    local plugin_json="${REPO_ROOT}/yci/.claude-plugin/plugin.json"
+    local skill_md="${REPO_ROOT}/yci/skills/hello/SKILL.md"
+
+    # 1. plugin.json
+    if [[ ! -f "${plugin_json}" ]]; then
+        fail "yci/.claude-plugin/plugin.json missing"
+    elif ! python3 -m json.tool "${plugin_json}" > /dev/null 2>&1; then
+        fail "yci/.claude-plugin/plugin.json is not valid JSON"
+    else
+        ok "yci/.claude-plugin/plugin.json valid JSON"
+    fi
+
+    # 2. SKILL.md exists
+    if [[ ! -f "${skill_md}" ]]; then
+        fail "yci/skills/hello/SKILL.md missing"
+        return
+    fi
+    ok "yci/skills/hello/SKILL.md present"
+
+    # 3. Validate frontmatter
+    if python3 - "${skill_md}" <<'PY'; then
 import re
 import sys
 from pathlib import Path
@@ -73,7 +79,6 @@ text = skill_md.read_text(encoding="utf-8")
 script_name = "validate-yci-skills.sh"
 errors: list[str] = []
 
-# Verify frontmatter delimiters are present.
 if not re.match(r"^---\n.*?\n---\n", text, re.DOTALL):
     errors.append(
         f"{skill_md}: frontmatter delimiters missing or malformed "
@@ -85,14 +90,12 @@ if not re.match(r"^---\n.*?\n---\n", text, re.DOTALL):
 
 fm = load_frontmatter(text)
 
-# Verify name: hello
 name_val = fm.get("name", "")
 if name_val != "hello":
     errors.append(
         f"{skill_md}: frontmatter 'name' must be 'hello', got {name_val!r}"
     )
 
-# Verify description: non-empty string
 desc_val = fm.get("description", "")
 if not isinstance(desc_val, str) or not desc_val.strip():
     errors.append(
@@ -104,5 +107,202 @@ if errors:
         print(f"{script_name}: {err}", file=sys.stderr)
     sys.exit(1)
 PY
+        ok "yci/skills/hello/SKILL.md frontmatter valid"
+    else
+        fail "yci/skills/hello/SKILL.md frontmatter invalid"
+    fi
+}
 
-echo "[validate-yci-skills] OK: yci/.claude-plugin/plugin.json and yci/skills/hello/SKILL.md valid."
+# ---------------------------------------------------------------------------
+# customer-profile skill checks
+# ---------------------------------------------------------------------------
+validate_customer_profile_skill() {
+    echo "--- customer-profile skill ---"
+
+    local skill_root="${REPO_ROOT}/yci/skills/customer-profile"
+    local shared_scripts="${REPO_ROOT}/yci/skills/_shared/scripts"
+    local commands_dir="${REPO_ROOT}/yci/commands"
+
+    # --- SKILL.md ---
+    if [ -f "${skill_root}/SKILL.md" ]; then
+        ok "customer-profile/SKILL.md present"
+        if python3 - "${skill_root}/SKILL.md" <<'PY'; then
+import yaml, sys
+src = open(sys.argv[1]).read()
+parts = src.split('---', 2)
+if len(parts) < 3:
+    sys.exit(1)
+fm = yaml.safe_load(parts[1])
+assert fm.get('name') == 'customer-profile', 'name must be customer-profile'
+assert fm.get('description') and len(fm['description']) >= 50, 'description too short'
+assert 'argument-hint' in fm, 'argument-hint missing'
+assert isinstance(fm.get('allowed-tools'), list) and fm['allowed-tools'], 'allowed-tools must be non-empty list'
+PY
+            ok "customer-profile/SKILL.md frontmatter valid"
+        else
+            fail "customer-profile/SKILL.md: frontmatter invalid"
+        fi
+    else
+        fail "customer-profile/SKILL.md missing"
+    fi
+
+    # --- references ---
+    for ref in schema.md precedence.md error-messages.md _template.yaml; do
+        if [ -s "${skill_root}/references/${ref}" ]; then
+            ok "reference ${ref} present and non-empty"
+        else
+            fail "reference ${ref} missing or empty"
+        fi
+    done
+
+    # error catalog count
+    local id_count
+    id_count="$(grep -c '^- \*\*ID\*\*:' "${skill_root}/references/error-messages.md" 2>/dev/null || echo 0)"
+    if [ "$id_count" -ge 10 ]; then
+        ok "error-messages.md has ${id_count} error IDs"
+    else
+        fail "error-messages.md too thin: ${id_count} IDs (expected >=10)"
+    fi
+
+    # _template.yaml parses
+    if python3 -c "import yaml; yaml.safe_load(open('${skill_root}/references/_template.yaml'))" 2>/dev/null; then
+        ok "_template.yaml parses as valid YAML"
+    else
+        fail "_template.yaml: YAML parse error"
+    fi
+
+    # --- skill scripts ---
+    local skill_scripts=(
+        resolve-customer.sh
+        state-io.sh
+        profile-schema.sh
+        load-profile.sh
+        switch-profile.sh
+        render-whoami.sh
+        init-profile.sh
+    )
+    for s in "${skill_scripts[@]}"; do
+        local p="${skill_root}/scripts/${s}"
+        if [ -x "$p" ] && head -1 "$p" | grep -q '^#!/usr/bin/env bash'; then
+            ok "script ${s} present, executable, correct shebang"
+        else
+            fail "script ${s}: missing, not executable, or wrong shebang"
+        fi
+    done
+
+    # shared data-root resolver
+    local rdr="${shared_scripts}/resolve-data-root.sh"
+    if [ -x "$rdr" ] && head -1 "$rdr" | grep -q '^#!/usr/bin/env bash'; then
+        ok "shared resolve-data-root.sh present, executable, correct shebang"
+    else
+        fail "shared resolve-data-root.sh: missing, not executable, or wrong shebang"
+    fi
+
+    # --- slash-command wrappers ---
+    for cmd in switch whoami init; do
+        local md="${commands_dir}/${cmd}.md"
+        if [ -f "$md" ]; then
+            if python3 - "$md" <<'PY'; then
+import yaml, sys
+src = open(sys.argv[1]).read()
+parts = src.split('---', 2)
+if len(parts) < 3: sys.exit(1)
+fm = yaml.safe_load(parts[1])
+assert fm.get('description'), 'description missing'
+PY
+                ok "command ${cmd}.md frontmatter valid"
+            else
+                fail "command ${cmd}.md: frontmatter invalid"
+            fi
+            if grep -q 'yci:customer-profile' "$md"; then
+                ok "command ${cmd}.md invokes yci:customer-profile"
+            else
+                fail "command ${cmd}.md does not reference yci:customer-profile"
+            fi
+        else
+            fail "command ${cmd}.md missing"
+        fi
+    done
+
+    # --- tests ---
+    local tests_dir="${skill_root}/tests"
+
+    if [ -x "${tests_dir}/run-all.sh" ]; then
+        ok "run-all.sh present and executable"
+    else
+        fail "run-all.sh missing or not executable"
+    fi
+
+    if [ -s "${tests_dir}/helpers.sh" ]; then
+        ok "helpers.sh present"
+    else
+        fail "helpers.sh missing"
+    fi
+
+    local test_count
+    test_count="$(ls "${tests_dir}"/test_*.sh 2>/dev/null | wc -l | tr -d ' ')"
+    if [ "$test_count" -ge 5 ]; then
+        ok "test files: ${test_count}"
+    else
+        fail "too few test files: ${test_count} (need >=5)"
+    fi
+
+    for fx in acme-example.yaml minimal.yaml; do
+        local fxp="${tests_dir}/fixtures/${fx}"
+        if python3 -c "import yaml; yaml.safe_load(open('${fxp}'))" 2>/dev/null; then
+            ok "fixture ${fx} parses as valid YAML"
+        else
+            fail "fixture ${fx} missing or invalid YAML"
+        fi
+    done
+
+    # --- run the test harness ---
+    printf '\n--- customer-profile test harness ---\n'
+    if bash "${tests_dir}/run-all.sh"; then
+        ok "test harness passed"
+    else
+        fail "test harness: one or more tests failed"
+    fi
+
+    # --- shellcheck ---
+    printf '\n--- shellcheck (customer-profile) ---\n'
+    if command -v shellcheck >/dev/null 2>&1; then
+        local sc_files=()
+        # collect skill scripts
+        while IFS= read -r f; do sc_files+=("$f"); done \
+            < <(ls "${skill_root}/scripts/"*.sh 2>/dev/null)
+        # shared script
+        sc_files+=("${shared_scripts}/resolve-data-root.sh")
+        # test files
+        while IFS= read -r f; do sc_files+=("$f"); done \
+            < <(ls "${tests_dir}/run-all.sh" "${tests_dir}/helpers.sh" \
+                    "${tests_dir}/"test_*.sh 2>/dev/null)
+
+        if shellcheck --severity=warning "${sc_files[@]}"; then
+            ok "shellcheck clean on ${#sc_files[@]} files"
+        else
+            fail "shellcheck reported warnings/errors"
+        fi
+    else
+        warn "shellcheck not installed — skipping"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    echo "=== validate-yci-skills.sh ==="
+    validate_hello_skill
+    echo
+    validate_customer_profile_skill
+    echo
+
+    if [ "$ERRORS" -eq 0 ]; then
+        echo "ALL CHECKS PASSED"
+        exit 0
+    else
+        printf 'FAILED: %d check(s)\n' "$ERRORS" >&2
+        exit 1
+    fi
+}
+
+main "$@"

--- a/scripts/validate-yci-skills.sh
+++ b/scripts/validate-yci-skills.sh
@@ -127,16 +127,25 @@ validate_customer_profile_skill() {
     if [ -f "${skill_root}/SKILL.md" ]; then
         ok "customer-profile/SKILL.md present"
         if python3 - "${skill_root}/SKILL.md" <<'PY'; then
-import yaml, sys
+import sys
+import yaml
 src = open(sys.argv[1]).read()
 parts = src.split('---', 2)
 if len(parts) < 3:
-    sys.exit(1)
+    sys.stderr.write("SKILL.md: missing YAML frontmatter\n"); sys.exit(1)
 fm = yaml.safe_load(parts[1])
-assert fm.get('name') == 'customer-profile', 'name must be customer-profile'
-assert fm.get('description') and len(fm['description']) >= 50, 'description too short'
-assert 'argument-hint' in fm, 'argument-hint missing'
-assert isinstance(fm.get('allowed-tools'), list) and fm['allowed-tools'], 'allowed-tools must be non-empty list'
+if not isinstance(fm, dict):
+    sys.stderr.write("SKILL.md: frontmatter is not a mapping\n"); sys.exit(1)
+if fm.get('name') != 'customer-profile':
+    sys.stderr.write("SKILL.md: name must be 'customer-profile'\n"); sys.exit(1)
+desc = fm.get('description')
+if not (isinstance(desc, str) and len(desc) >= 50):
+    sys.stderr.write("SKILL.md: description missing or too short (>=50 chars)\n"); sys.exit(1)
+if 'argument-hint' not in fm:
+    sys.stderr.write("SKILL.md: argument-hint missing\n"); sys.exit(1)
+tools = fm.get('allowed-tools')
+if not (isinstance(tools, list) and tools):
+    sys.stderr.write("SKILL.md: allowed-tools must be a non-empty list\n"); sys.exit(1)
 PY
             ok "customer-profile/SKILL.md frontmatter valid"
         else
@@ -181,21 +190,44 @@ PY
         render-whoami.sh
         init-profile.sh
     )
+    # Script validation: executable + bash shebang + safety flags. state-io.sh
+    # and profile-schema.sh are sourceable libraries that must NOT self-enable
+    # `set -euo pipefail` at file scope (would corrupt callers' shell options).
+    local -a safety_exempt=(state-io.sh profile-schema.sh)
     for s in "${skill_scripts[@]}"; do
         local p="${skill_root}/scripts/${s}"
-        if [ -x "$p" ] && head -1 "$p" | grep -q '^#!/usr/bin/env bash'; then
-            ok "script ${s} present, executable, correct shebang"
+        if ! [ -x "$p" ]; then
+            fail "script ${s}: not executable or missing"
+            continue
+        fi
+        if ! head -1 "$p" | grep -q '^#!/usr/bin/env bash'; then
+            fail "script ${s}: wrong shebang (expected #!/usr/bin/env bash)"
+            continue
+        fi
+        # Safety flags required only on runnable scripts; sourceable libraries
+        # must not self-enable strict mode because it leaks into the caller.
+        local exempt=0
+        for ex in "${safety_exempt[@]}"; do [ "$s" = "$ex" ] && exempt=1; done
+        if [ "$exempt" -eq 1 ]; then
+            ok "script ${s} present, executable, correct shebang (sourceable library)"
+        elif head -20 "$p" | grep -qE '^[[:space:]]*set[[:space:]]+-euo[[:space:]]+pipefail[[:space:]]*$'; then
+            ok "script ${s} present, executable, correct shebang, has set -euo pipefail"
         else
-            fail "script ${s}: missing, not executable, or wrong shebang"
+            fail "script ${s}: missing 'set -euo pipefail' in first 20 lines"
         fi
     done
 
-    # shared data-root resolver
+    # shared data-root resolver — runnable AND sourceable; require safety flags
+    # since it's invoked as a CLI by resolve-customer.sh and init-profile.sh.
     local rdr="${shared_scripts}/resolve-data-root.sh"
-    if [ -x "$rdr" ] && head -1 "$rdr" | grep -q '^#!/usr/bin/env bash'; then
-        ok "shared resolve-data-root.sh present, executable, correct shebang"
+    if ! [ -x "$rdr" ]; then
+        fail "shared resolve-data-root.sh: missing or not executable"
+    elif ! head -1 "$rdr" | grep -q '^#!/usr/bin/env bash'; then
+        fail "shared resolve-data-root.sh: wrong shebang"
+    elif head -20 "$rdr" | grep -qE '^[[:space:]]*set[[:space:]]+-euo[[:space:]]+pipefail[[:space:]]*$'; then
+        ok "shared resolve-data-root.sh present, executable, correct shebang, has set -euo pipefail"
     else
-        fail "shared resolve-data-root.sh: missing, not executable, or wrong shebang"
+        fail "shared resolve-data-root.sh: missing 'set -euo pipefail' in first 20 lines"
     fi
 
     # --- slash-command wrappers ---
@@ -203,12 +235,17 @@ PY
         local md="${commands_dir}/${cmd}.md"
         if [ -f "$md" ]; then
             if python3 - "$md" <<'PY'; then
-import yaml, sys
+import sys
+import yaml
 src = open(sys.argv[1]).read()
 parts = src.split('---', 2)
-if len(parts) < 3: sys.exit(1)
+if len(parts) < 3:
+    sys.stderr.write("command.md: missing YAML frontmatter\n"); sys.exit(1)
 fm = yaml.safe_load(parts[1])
-assert fm.get('description'), 'description missing'
+if not isinstance(fm, dict):
+    sys.stderr.write("command.md: frontmatter is not a mapping\n"); sys.exit(1)
+if not fm.get('description'):
+    sys.stderr.write("command.md: description missing or empty\n"); sys.exit(1)
 PY
                 ok "command ${cmd}.md frontmatter valid"
             else

--- a/yci/commands/init.md
+++ b/yci/commands/init.md
@@ -25,6 +25,7 @@ Scaffold a new yci customer profile. Copies `yci/skills/customer-profile/referen
 - Refuses if `<data-root>/profiles/<customer>.yaml` already exists, unless `--force`.
 - Copies the template with mode `0600`.
 - Prints confirmation:
+
   ```
   yci: scaffolded profile at <path>
     edit the <TODO: ...> placeholders, then run: /yci:switch <customer>

--- a/yci/commands/init.md
+++ b/yci/commands/init.md
@@ -1,0 +1,46 @@
+---
+description: Scaffold a new yci customer profile from _template.yaml.
+argument-hint: '<customer> [--data-root <path>] [--force] [--allow-reserved]'
+allowed-tools:
+  - Read
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/customer-profile/scripts/*.sh:*)
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/*.sh:*)
+  - Bash(cat:*)
+  - Bash(ls:*)
+  - Bash(test:*)
+  - Bash(cp:*)
+  - Bash(chmod:*)
+  - Bash(mkdir:*)
+---
+
+# /yci:init
+
+Scaffold a new yci customer profile. Copies `yci/skills/customer-profile/references/_template.yaml` into `<data-root>/profiles/<customer>.yaml` with `<TODO: ...>` placeholders you fill in before switching.
+
+## What it does
+
+- Validates `<customer>` against `[a-z0-9][a-z0-9-]*` (lowercase start, no leading hyphen).
+- Rejects reserved ids (`_internal`, `_template`, any id starting with `_`) unless `--allow-reserved`.
+- Creates `<data-root>/profiles/` with mode `0700` if absent.
+- Refuses if `<data-root>/profiles/<customer>.yaml` already exists, unless `--force`.
+- Copies the template with mode `0600`.
+- Prints confirmation:
+  ```
+  yci: scaffolded profile at <path>
+    edit the <TODO: ...> placeholders, then run: /yci:switch <customer>
+  ```
+
+## Arguments
+
+- `<customer>` — required. Profile id (e.g., `acme-corp`).
+- `--data-root <path>` — optional. Overrides `$YCI_DATA_ROOT` and the default `~/.config/yci/`.
+- `--force` — overwrite an existing profile.
+- `--allow-reserved` — permit `_template`, `_internal`, or other underscore-prefixed ids. Use when importing fixture profiles; not recommended for day-to-day operation.
+
+## Security
+
+Profiles NEVER contain secrets (see PRD §11.9). The scaffold uses `credential_ref` placeholders pointing at your vault. Never paste an inline secret.
+
+## Instructions
+
+Load and follow the `yci:customer-profile` skill with mode `init` and $ARGUMENTS.

--- a/yci/commands/switch.md
+++ b/yci/commands/switch.md
@@ -1,0 +1,41 @@
+---
+description: Load a yci customer profile and mark it active.
+argument-hint: '<customer> [--data-root <path>]'
+allowed-tools:
+  - Read
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/customer-profile/scripts/*.sh:*)
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/*.sh:*)
+  - Bash(cat:*)
+  - Bash(test:*)
+---
+
+# /yci:switch
+
+Load a yci customer profile from `<data-root>/profiles/<customer>.yaml` and mark it active.
+
+## What it does
+
+- Validates `<customer>` against the id format `[a-z0-9][a-z0-9-]*`.
+- Loads and schema-validates the YAML profile (see `yci:customer-profile` → `references/schema.md`).
+- Writes the resolved id to `<data-root>/state.json` and updates the MRU list.
+- Prints a one-line confirmation: `yci: switched to <customer> (<engagement.id>, <compliance.regime>, <safety.default_posture>)`.
+
+## Arguments
+
+- `<customer>` — required. The profile id (e.g., `acme-corp`).
+- `--data-root <path>` — optional. Overrides `$YCI_DATA_ROOT` and the `~/.config/yci/` default.
+
+## Precedence for the active customer
+
+This command SETS the active customer. Subsequent `/yci:whoami` calls without args read it back via the four-tier chain:
+
+1. `$YCI_CUSTOMER` env var
+2. `.yci-customer` dotfile (walk-up)
+3. `<data-root>/state.json` `.active` field (what `/yci:switch` writes)
+4. refuse
+
+See `yci:customer-profile/references/precedence.md` for the full spec.
+
+## Instructions
+
+Load and follow the `yci:customer-profile` skill with mode `switch` and $ARGUMENTS.

--- a/yci/commands/whoami.md
+++ b/yci/commands/whoami.md
@@ -1,0 +1,47 @@
+---
+description: Print the active yci customer (id, display name, engagement, compliance regime, safety posture).
+argument-hint: '[--data-root <path>]'
+allowed-tools:
+  - Read
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/customer-profile/scripts/*.sh:*)
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/*.sh:*)
+  - Bash(cat:*)
+  - Bash(test:*)
+---
+
+# /yci:whoami
+
+Print the active yci customer context — a human-readable summary of who `yci` currently thinks you are operating for.
+
+## What it does
+
+- Resolves the active customer via the four-tier precedence chain:
+  1. `$YCI_CUSTOMER` env var
+  2. `.yci-customer` dotfile (walk-up from CWD, stopping at `$HOME`)
+  3. `<data-root>/state.json` `.active` field
+  4. refuse — no active customer
+- Loads and schema-validates the resolved profile.
+- Renders a concise summary:
+
+```
+yci: active customer = <customer.id>
+  display name   : <customer.display_name>
+  engagement     : <engagement.id> (<engagement.type>, SOW <engagement.sow_ref>)
+  dates          : <engagement.start_date> → <engagement.end_date>
+  compliance     : <compliance.regime> (evidence schema v<compliance.evidence_schema_version>)
+  safety posture : <safety.default_posture>  (scope: <safety.scope_enforcement>, change-window-required: <safety.change_window_required>)
+  scope tags     : <engagement.scope_tags joined by ", ">
+```
+
+## Arguments
+
+- `--data-root <path>` — optional. Overrides `$YCI_DATA_ROOT` and the default `~/.config/yci/`.
+
+## Failure modes
+
+- No active customer → exit 1 with the canonical refusal message pointing at `/yci:init` or `/yci:switch`.
+- Stored active customer's profile is missing or malformed → propagate the loader error.
+
+## Instructions
+
+Load and follow the `yci:customer-profile` skill with mode `whoami` and $ARGUMENTS.

--- a/yci/skills/_shared/scripts/resolve-data-root.sh
+++ b/yci/skills/_shared/scripts/resolve-data-root.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# yci — resolve the runtime data root.
+#
+# Precedence (highest to lowest):
+#   1. --data-root <path>  CLI flag passed to this script or the sourced function
+#   2. $YCI_DATA_ROOT      environment variable
+#   3. ${HOME}/.config/yci default fallback
+#
+# On first use the resolved directory is created with mode 0700 (idempotent).
+# Prints the resolved absolute path (no trailing slash) to stdout.
+#
+# Source into another script to expose yci_resolve_data_root(), or run directly.
+#
+# Exit codes:
+#   0  success — resolved path printed to stdout
+#   3  runtime error — unwritable or invalid path (message on stderr)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# yci_resolve_data_root [--data-root <path>] [--data-root=<path>]
+# ---------------------------------------------------------------------------
+
+yci_resolve_data_root() {
+    local data_root=""
+
+    # Parse optional --data-root flag; stop at first non-flag or --.
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --data-root)
+                if [ -z "${2:-}" ]; then
+                    printf 'yci: --data-root requires a value\n' >&2
+                    return 3
+                fi
+                data_root="$2"
+                shift 2
+                ;;
+            --data-root=*)
+                data_root="${1#*=}"
+                shift
+                ;;
+            --) shift; break ;;
+            *)  break ;;
+        esac
+    done
+
+    # Fall back to env var, then default.
+    if [ -z "$data_root" ]; then
+        data_root="${YCI_DATA_ROOT:-${HOME}/.config/yci}"
+    fi
+
+    # Reject empty string (e.g. YCI_DATA_ROOT="" with no flag).
+    if [ -z "$data_root" ]; then
+        printf "yci: cannot resolve data root path: ''\n" >&2
+        printf '  ensure the path is a valid absolute or expandable path\n' >&2
+        return 3
+    fi
+
+    # Expand a leading ~ if the caller passed it as a literal character.
+    # Use $tilde in comparisons to keep shellcheck (SC2088) quiet about the
+    # intentional literal tilde match.
+    local tilde='~'
+    if [ "$data_root" = "$tilde" ]; then
+        data_root="${HOME}"
+    elif [ "${data_root:0:2}" = "${tilde}/" ]; then
+        data_root="${HOME}/${data_root:2}"
+    fi
+
+    # If the directory already exists, canonicalize via cd + pwd.
+    if [ -d "$data_root" ]; then
+        data_root="$(cd "$data_root" && pwd -P)"
+    else
+        # Make the path absolute before mkdir.
+        case "$data_root" in
+            /*) ;;
+            *)  data_root="$(pwd -P)/${data_root}" ;;
+        esac
+        # Strip any trailing slashes.
+        data_root="${data_root%/}"
+
+        # Attempt to create the directory (mkdir -p is idempotent).
+        if ! mkdir -p "$data_root" 2>/dev/null; then
+            printf 'yci: data root is not writable: %s\n' "$data_root" >&2
+            printf "  check directory permissions or set a writable path via --data-root or \$YCI_DATA_ROOT\n" >&2
+            return 3
+        fi
+        chmod 0700 "$data_root" 2>/dev/null || true
+        # Re-canonicalize now that the directory exists.
+        data_root="$(cd "$data_root" && pwd -P)"
+    fi
+
+    # Final sanity checks: must be a directory and must be writable.
+    if [ ! -d "$data_root" ]; then
+        printf "yci: cannot resolve data root path: '%s'\n" "$data_root" >&2
+        printf '  ensure the path is a valid absolute or expandable path\n' >&2
+        return 3
+    fi
+
+    if [ ! -w "$data_root" ]; then
+        printf 'yci: data root is not writable: %s\n' "$data_root" >&2
+        printf "  check directory permissions or set a writable path via --data-root or \$YCI_DATA_ROOT\n" >&2
+        return 3
+    fi
+
+    printf '%s\n' "$data_root"
+}
+
+# ---------------------------------------------------------------------------
+# Standalone entry point — only runs when the script is executed directly,
+# not when it is sourced.
+# ---------------------------------------------------------------------------
+
+if [ "${BASH_SOURCE[0]:-}" = "$0" ]; then
+    yci_resolve_data_root "$@"
+fi

--- a/yci/skills/customer-profile/SKILL.md
+++ b/yci/skills/customer-profile/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: customer-profile
+description: Load, switch, and scaffold yci customer profiles. Use when the user runs /yci:switch, /yci:whoami, or /yci:init — or asks to see/change/create the active customer context. Resolves the active customer via the 4-tier precedence chain ($YCI_CUSTOMER > .yci-customer dotfile > MRU > refuse) and persists state to <data-root>/state.json. All downstream yci skills depend on this one — it is the load-bearing primitive for customer isolation.
+argument-hint: '{switch|whoami|init} [<customer>] [--data-root <path>] [--force] [--allow-reserved]'
+allowed-tools:
+  - Read
+  - Write
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/customer-profile/scripts/*.sh:*)
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/*.sh:*)
+  - Bash(cat:*)
+  - Bash(ls:*)
+  - Bash(test:*)
+  - Bash(python3:*)
+  - Bash(mkdir:*)
+  - Bash(cp:*)
+  - Bash(chmod:*)
+---
+
+# yci:customer-profile Skill
+
+This skill manages the active customer context for all yci workflows. It is the
+load-bearing primitive for customer isolation — PRD §11.1 defines the authoritative
+4-tier precedence chain (`$YCI_CUSTOMER` > `.yci-customer` dotfile > MRU state >
+refuse) and PRD §5.2 defines the profile schema. Every downstream yci skill calls
+`resolve-customer.sh` before touching any customer-scoped resource; a refusal from
+that resolver propagates upward and aborts the workflow.
+
+## Subcommands
+
+The skill takes a MODE as its first positional argument. If MODE is missing or
+unrecognised, print a one-line usage hint and exit 1.
+
+- `switch <customer>` — resolve, load, and activate the named customer profile
+- `whoami` — print the active customer context (who is currently active?)
+- `init <customer>` — scaffold a new profile from `references/_template.yaml`
+
+## Data Root
+
+`<data-root>` resolves via `yci/skills/_shared/scripts/resolve-data-root.sh`:
+
+1. `--data-root <path>` flag (highest precedence)
+2. `$YCI_DATA_ROOT` env var
+3. `~/.config/yci/` (default)
+
+Do NOT hardcode the path anywhere — always call the helper. See the shared helper
+for permission and canonicalization details.
+
+## Precedence (switch and whoami)
+
+Full spec: `references/precedence.md` (mirrors PRD §11.1).
+
+Resolution stops at the first tier that yields a non-empty, valid value:
+
+- **Tier 1** — `$YCI_CUSTOMER` env var (trimmed; set, non-empty, and valid wins)
+- **Tier 2** — `.yci-customer` dotfile walk-up from `$PWD`; stops at `$HOME` or
+  `/`, whichever comes first; never ascends past `$HOME`
+- **Tier 3** — `state.json .active` field at `<data-root>/state.json` (MRU)
+- **Tier 4** — REFUSE: emit `resolver-no-active-customer` to stderr, exit 1
+
+Valid customer ID format: `[a-z0-9][a-z0-9-]*` (lowercase, hyphens only, no
+leading hyphen, no underscore, no uppercase).
+
+## Workflows
+
+### Mode: switch
+
+1. Validate the customer ID against `[a-z0-9][a-z0-9-]*`. On failure: emit
+   `init-invalid-customer-id` (from `references/error-messages.md`) and exit 1.
+2. Resolve data-root via `resolve-data-root.sh`.
+3. Call `load-profile.sh <data-root> <customer>` to load and validate the YAML.
+   - Profile not found → exit 1 with `loader-missing-file`.
+   - Malformed YAML → exit 2 with `loader-malformed-yaml`.
+   - Missing required key → exit 2 with `loader-missing-required-key`.
+   - Unknown enum value → exit 2 with `loader-invalid-enum-value`.
+4. On successful load, call `state_write_active <data-root> <customer>`
+   (from `state-io.sh`) to persist the active customer.
+   - Permission denied → exit 3 with `state-write-permission-denied`.
+5. Print a one-line confirmation:
+   `yci: switched to <customer> (<engagement.id>, <compliance.regime>, <safety.default_posture>)`
+6. Exit 0.
+
+### Mode: whoami
+
+1. Resolve data-root via `resolve-data-root.sh`.
+2. Call `resolve-customer.sh --data-root <data-root>` to determine the active
+   customer via the 4-tier chain.
+3. If the resolver exits 1 (refusal), surface the shorter command-oriented message
+   `whoami-no-active-customer` from `references/error-messages.md` and exit 1.
+4. Load the resolved profile via `load-profile.sh`.
+5. Call `render-whoami.sh` to print the human-readable context summary.
+6. Exit 0.
+
+### Mode: init
+
+1. Validate the customer ID against `[a-z0-9][a-z0-9-]*`. On failure: emit
+   `init-invalid-customer-id` and exit 1.
+2. Reject IDs starting with `_` (e.g., `_internal`, `_template`) unless
+   `--allow-reserved` was passed. On rejection: emit `init-reserved-id` and exit 1.
+3. Resolve data-root via `resolve-data-root.sh`.
+4. Check whether `<data-root>/profiles/<customer>.yaml` already exists. If it does
+   and `--force` was not passed: emit `init-profile-exists` and exit 1.
+5. Call `init-profile.sh <data-root> <customer> [--force]` to copy the template.
+6. Print a confirmation with:
+   - The full path to the created file.
+   - A pointer to `references/schema.md` for required fields.
+   - A reminder to replace every `<TODO: ...>` placeholder before running
+     `/yci:switch <customer>`.
+7. Exit 0.
+
+## Error Messages
+
+All user-visible errors come from `references/error-messages.md`. When a script
+exits non-zero, surface its stderr verbatim — do NOT reformat or add extra context.
+The user must see the same text catalogued in the reference doc.
+
+Exit-code convention (from `error-messages.md`):
+
+| Exit | Meaning                                                         |
+| ---- | --------------------------------------------------------------- |
+| 0    | success                                                         |
+| 1    | resolver refusal or user-input error (invalid id, overwrite)    |
+| 2    | schema violation (malformed YAML, missing key, bad enum value)  |
+| 3    | runtime / environment error (pyyaml missing, permission denied) |
+
+## Prerequisites
+
+The following scripts are **not yet installed** (land in B5):
+
+- `scripts/load-profile.sh`
+- `scripts/render-whoami.sh`
+- `scripts/init-profile.sh`
+
+Until B5 merges, the `switch`, `whoami`, and `init` workflows cannot complete.
+If invoked before B5 lands, inform the user:
+
+> "yci:customer-profile requires load-profile.sh, render-whoami.sh, and
+> init-profile.sh (shipping in B5). Run `./scripts/validate.sh --only yci`
+> to check installation status."
+
+Then exit 1 without touching any data. The scripts already present
+(`resolve-customer.sh`, `state-io.sh`, `profile-schema.sh`) are functional.
+
+## Cross-References
+
+- `references/schema.md` — profile schema (PRD §5.2 mirror)
+- `references/precedence.md` — resolver precedence spec (PRD §11.1 mirror)
+- `references/error-messages.md` — canonical error copy
+- `references/_template.yaml` — init scaffold
+- `scripts/resolve-customer.sh` — tier resolver
+- `scripts/state-io.sh` — state.json atomic I/O
+- `scripts/profile-schema.sh` — schema constants
+- `../_shared/scripts/resolve-data-root.sh` — data-root helper
+
+## When NOT to Use This Skill
+
+- **Editing a profile** — users edit `<data-root>/profiles/<customer>.yaml` with
+  their text editor. This skill does not provide an edit mode.
+- **Listing all profiles** — no `/yci:list` yet; use `ls <data-root>/profiles/`.
+- **Deleting a profile** — no `/yci:remove` yet; users delete the YAML file
+  manually and prune `state.json` by switching to another customer (which rewrites
+  `.active` and dedupes MRU).
+
+## Security Reminders (PRD §11.9)
+
+- Profiles **MUST NOT contain secrets**. Only `credential_ref` pointers into the
+  active vaults subtree.
+- The resolver's refusal path is load-bearing: every downstream yci hook calls
+  `resolve-customer.sh` first and aborts on non-zero exit.
+- The `.yci-customer` dotfile walk-up **never ascends past `$HOME`**, preventing
+  ambient configuration from a shared or multi-user environment from leaking into
+  the session.

--- a/yci/skills/customer-profile/references/_template.yaml
+++ b/yci/skills/customer-profile/references/_template.yaml
@@ -1,0 +1,86 @@
+# yci customer profile — TEMPLATE
+#
+# This file is the scaffold copied by `/yci:init <customer>` into
+# <data-root>/profiles/<customer>.yaml. Never commit an operational profile;
+# operational profiles contain customer-sensitive data and live only in the
+# operator's runtime data root (default: ~/.config/yci/profiles/).
+#
+# See:
+#   - yci/skills/customer-profile/references/schema.md  (field reference)
+#   - yci/CONTRIBUTING.md                               (scope guardrails)
+#   - docs/prps/prds/yci.prd.md §5.2                    (authoritative schema)
+#   - docs/prps/prds/yci.prd.md §11.9                   (no-secrets rule)
+#
+# Rules:
+#   - Replace every <TODO: ...> placeholder before switching to this profile.
+#   - Uncomment and populate optional blocks as needed.
+#   - NO SECRETS. Use credential_ref: <vault-path> pointers, never inline values.
+
+customer:
+  id: '<TODO: lowercase-kebab-case-id>'
+  display_name: '<TODO: human-readable name>'
+  # code: "<TODO: optional internal billing / project code>"
+  # branding:
+  #   logo_path: "<TODO: path to customer logo file>"
+  #   color: "<TODO: hex color e.g. #003366>"
+
+engagement:
+  id: '<TODO: engagement-id e.g. acme-2026-network-refresh>'
+  type: '<TODO: discovery|design|implementation|ongoing>'
+  sow_ref: '<TODO: SOW document reference e.g. SOW-2026-0117>'
+  scope_tags:
+    - '<TODO: e.g. network-automation>'
+  start_date: '<TODO: YYYY-MM-DD>'
+  end_date: '<TODO: YYYY-MM-DD>'
+
+compliance:
+  regime: '<TODO: hipaa|pci|sox|soc2|iso27001|nist|commercial|none>'
+  # baa_reference: "<TODO: BAA document reference — HIPAA engagements only>"
+  evidence_schema_version: '<TODO: integer e.g. 1>'
+
+# change_window:
+#   adapter: "<TODO: ical|servicenow-cab|json-schedule|always-open|none>"
+#   source: "<TODO: path or URL to calendar source>"
+#   timezone: "<TODO: IANA timezone e.g. America/New_York>"
+
+inventory:
+  adapter: '<TODO: file|netbox|nautobot|servicenow-cmdb|infoblox>'
+  # endpoint: "<TODO: API base URL — adapter-dependent>"
+  # credential_ref: "<TODO: vault path — NEVER an inline secret>"
+  # path: "<TODO: optional path override e.g. ~/Dropbox-Acme/inventories/>"
+
+approval:
+  adapter: '<TODO: github-pr|email-signoff|jira|servicenow-request|none>'
+  # endpoint: "<TODO: API base URL — adapter-dependent>"
+  # credential_ref: "<TODO: vault path — NEVER an inline secret>"
+
+# vaults:
+#   path: "<TODO: vault URI or path — NEVER an inline secret>"
+#   # Common path patterns:
+#   #   op://vault-name                    (1Password — use op:// scheme)
+#   #   hcv://secret/acme                  (HashiCorp Vault — use hcv:// scheme)
+#   #   asm://prefix                       (AWS Secrets Manager — use asm:// scheme)
+#   #   ~/.config/yci/vaults/<customer>    (default on-disk, encrypted with age/sops)
+
+deliverable:
+  format:
+    - '<TODO: markdown|pdf|word|confluence>'
+  header_template: '<TODO: path to dual-branded header template e.g. ~/.config/yci/branding/acme-header.md>'
+  handoff_format: '<TODO: git-repo|zip|confluence|pdf-bundle>'
+  # path: "<TODO: optional output path override>"
+  # Common consulting patterns for path:
+  #   ~/Dropbox-Acme/deliverables/        (Dropbox desktop-synced)
+  #   ~/OneDrive-Acme/deliverables/       (OneDrive desktop-synced)
+  #   ~/gdrive/Acme/deliverables/         (rclone or Google Drive for Desktop)
+  #   /Volumes/Acme-NAS/deliverables/     (shared network drive)
+  #   ~/Encrypted-Customers/acme/         (separate encrypted volume)
+
+# vendor_tooling:
+#   - vendor: "<TODO: e.g. cisco>"
+#     product: "<TODO: e.g. ios-xe>"
+#     version: "<TODO: e.g. 17.9>"
+
+safety:
+  default_posture: '<TODO: dry-run|review|apply>'
+  change_window_required: '<TODO: true|false>'
+  scope_enforcement: '<TODO: warn|block|off>'

--- a/yci/skills/customer-profile/references/error-messages.md
+++ b/yci/skills/customer-profile/references/error-messages.md
@@ -1,0 +1,354 @@
+# yci Customer-Profile Error Messages
+
+This file is the canonical source of user-visible error strings for the
+`customer-profile` skill. Scripts emit these strings verbatim; tests assert
+against them verbatim. **Change here first, then update scripts and tests.**
+Enumerated errors derive from PRD §11.1 (resolver refusal), §5.2 (schema errors),
+and §11.9 (secrets / data-root location). Adding a new error requires updating
+this catalog, the emitting script, and the corresponding test in the same change.
+
+---
+
+## Exit-Code Convention
+
+| Exit | Meaning                                                                               |
+| ---- | ------------------------------------------------------------------------------------- |
+| 0    | success                                                                               |
+| 1    | resolver refusal or user-input error (invalid id, overwrite refused, etc.)            |
+| 2    | schema violation (malformed YAML, missing required keys, unknown enum value)          |
+| 3    | runtime / environment error (pyyaml missing, unwritable data root, permission denied) |
+
+---
+
+## Error Catalog
+
+### Resolver (`resolve-customer.sh` — task 3.2)
+
+---
+
+### `resolver-no-active-customer`
+
+- **ID**: `resolver-no-active-customer`
+- **Producer**: `resolve-customer.sh`
+- **Exit code**: 1
+- **Trigger**: all three resolution tiers exhausted — `$YCI_CUSTOMER` unset/empty,
+  no `.yci-customer` dotfile found from `$PWD` up to `$HOME`, and `state.json`
+  either absent or has no non-empty `.active` field.
+- **Message**:
+  ```
+  yci: no active customer.
+    $YCI_CUSTOMER: unset
+    .yci-customer: not found (searched from <cwd> up to <stop>)
+    state.json: no active customer at <path>
+  Run `/yci:init <customer>` to create a profile, or `/yci:switch <customer>` to activate one.
+  ```
+  When `$YCI_CUSTOMER` was set but rejected because it was whitespace-only,
+  replace `unset` with `empty (whitespace-only)`.
+- **Test coverage**: `test_resolve_customer.sh::test_no_active_customer`,
+  `test_resolve_customer.sh::test_whitespace_env_shows_empty_hint`
+
+---
+
+### `resolver-invalid-id-format`
+
+- **ID**: `resolver-invalid-id-format`
+- **Producer**: `resolve-customer.sh`
+- **Exit code**: 1
+- **Trigger**: a customer ID was resolved from one of the tiers but fails the
+  format constraint — allowed pattern is `[a-z0-9][a-z0-9-]*` (lowercase
+  alphanumeric, interior hyphens only, no leading hyphen, no underscore, no
+  uppercase). Example: `ACME`, `acme_corp`, `-acme`.
+- **Message**:
+  ```
+  yci: invalid customer id: '<customer>'
+    allowed pattern: [a-z0-9][a-z0-9-]*  (lowercase, hyphens only)
+  Check $YCI_CUSTOMER, your .yci-customer dotfile, or state.json .active field.
+  ```
+- **Test coverage**: `test_resolve_customer.sh::test_invalid_id_format`
+
+---
+
+### `resolver-walkup-escaped-home`
+
+> **Decision**: `precedence.md` specifies that the dotfile walk-up **stops** when
+> the current directory equals `$HOME` (or `/`, whichever is first) and does NOT
+> ascend past `$HOME`. When a dotfile exists only above `$HOME`, the walk reaches
+> `$HOME` without finding one, treating the result as "not found" — a **silent
+> fall-through** to Tier 3 (MRU), not an explicit error. This error ID is
+> therefore **not emitted**. The case is covered by `resolver-no-active-customer`
+> (when MRU also fails) or by a clean resolution from Tier 3.
+>
+> Test coverage: `test_resolve_customer.sh::test_walk_stops_at_home` confirms
+> the walk-stops-at-HOME behavior without expecting an explicit error message.
+
+---
+
+### Data-Root Resolver (`resolve-data-root.sh` — task 3.1)
+
+---
+
+### `dataroot-unwritable`
+
+- **ID**: `dataroot-unwritable`
+- **Producer**: `resolve-data-root.sh`
+- **Exit code**: 3
+- **Trigger**: the resolved data-root path exists but is not writable by the
+  current process (permission check fails).
+- **Message**:
+  ```
+  yci: data root is not writable: <path>
+    check directory permissions or set a writable path via --data-root or $YCI_DATA_ROOT
+  ```
+- **Test coverage**: `test_resolve_data_root.sh::test_dataroot_unwritable`
+
+---
+
+### `dataroot-invalid-path`
+
+- **ID**: `dataroot-invalid-path`
+- **Producer**: `resolve-data-root.sh`
+- **Exit code**: 3
+- **Trigger**: the `--data-root` argument (or `$YCI_DATA_ROOT` value) cannot be
+  canonicalized — the path is syntactically invalid, contains null bytes, or
+  `realpath` / equivalent normalization fails.
+- **Message**:
+  ```
+  yci: cannot resolve data root path: '<path>'
+    ensure the path is a valid absolute or expandable path
+  ```
+- **Test coverage**: `test_resolve_data_root.sh::test_dataroot_invalid_path`
+
+---
+
+### Loader (`load-profile.sh` — task 5.1)
+
+---
+
+### `loader-missing-file`
+
+- **ID**: `loader-missing-file`
+- **Producer**: `load-profile.sh`
+- **Exit code**: 1
+- **Trigger**: the expected profile YAML file does not exist at the resolved path
+  `<data-root>/profiles/<customer-id>.yaml`.
+- **Message**:
+  ```
+  yci: profile not found: <path>
+    create a new profile with `/yci:init <customer>` or copy _template.yaml
+  ```
+- **Test coverage**: `test_load_profile.sh::test_missing_file`
+
+---
+
+### `loader-malformed-yaml`
+
+- **ID**: `loader-malformed-yaml`
+- **Producer**: `load-profile.sh`
+- **Exit code**: 2
+- **Trigger**: `python3 -c "import yaml; yaml.safe_load(...)"` raises a
+  `yaml.YAMLError` — the file is not valid YAML.
+- **Message**:
+  ```
+  yci: malformed YAML in profile: <path>
+    <parse-error>
+  Fix the YAML syntax and retry.
+  ```
+  `<parse-error>` is the verbatim first line of the pyyaml exception message.
+- **Test coverage**: `test_load_profile.sh::test_malformed_yaml`
+
+---
+
+### `loader-missing-required-key`
+
+- **ID**: `loader-missing-required-key`
+- **Producer**: `load-profile.sh`
+- **Exit code**: 2
+- **Trigger**: a required top-level key (see `schema.md` — `customer`,
+  `engagement`, `compliance`, `inventory`, `approval`, `deliverable`, `safety`)
+  or a required nested key within those subtrees is absent from the loaded YAML.
+- **Message**:
+  ```
+  yci: missing required field '<field>' in profile: <path>
+    see yci/skills/customer-profile/references/schema.md for required fields
+  ```
+- **Test coverage**: `test_load_profile.sh::test_missing_required_key`
+
+---
+
+### `loader-invalid-enum-value`
+
+- **ID**: `loader-invalid-enum-value`
+- **Producer**: `load-profile.sh`
+- **Exit code**: 2
+- **Trigger**: a field that accepts a fixed enum set receives a value not in that
+  set. Enum fields and their canonical allowed values (from `schema.md`):
+  - `compliance.regime`: `hipaa`, `pci`, `sox`, `soc2`, `iso27001`, `nist`,
+    `commercial`, `none`
+  - `engagement.type`: `discovery`, `design`, `implementation`, `ongoing`
+  - `safety.default_posture`: `dry-run`, `review`, `apply`
+  - `safety.scope_enforcement`: `warn`, `block`, `off`
+  - `change_window.adapter`: `ical`, `servicenow-cab`, `json-schedule`,
+    `always-open`, `none`
+  - `deliverable.handoff_format`: `git-repo`, `zip`, `confluence`, `pdf-bundle`
+- **Message**:
+  ```
+  yci: invalid value for '<field>': '<value>'
+    allowed values: <allowed-list>
+    see yci/skills/customer-profile/references/schema.md for the canonical enum lists
+  ```
+- **Test coverage**: `test_load_profile.sh::test_invalid_enum_value`
+
+---
+
+### `loader-pyyaml-missing`
+
+- **ID**: `loader-pyyaml-missing`
+- **Producer**: `load-profile.sh`
+- **Exit code**: 3
+- **Trigger**: `python3 -c "import yaml"` exits non-zero — the `pyyaml` library
+  is not installed in the active Python environment.
+- **Message**:
+  ```
+  yci: pyyaml not found — cannot parse YAML profiles
+    pyyaml required — install via 'pip install pyyaml' or your distro's python3-yaml package
+  ```
+- **Test coverage**: `test_load_profile.sh::test_pyyaml_missing`
+
+---
+
+### State I/O (`state-io.sh` — task 3.3)
+
+---
+
+### `state-corrupt-json`
+
+- **ID**: `state-corrupt-json`
+- **Producer**: `state-io.sh`
+- **Exit code**: 2
+- **Trigger**: `state.json` exists but fails to parse as valid JSON (e.g.,
+  truncated file, hand-edited corruption, encoding issue).
+- **Message**:
+  ```
+  yci: corrupt state file: <path>
+    state.json failed JSON parse — delete or repair the file to continue
+  ```
+- **Test coverage**: `test_state_io.sh::test_corrupt_json`
+
+---
+
+### `state-write-permission-denied`
+
+- **ID**: `state-write-permission-denied`
+- **Producer**: `state-io.sh`
+- **Exit code**: 3
+- **Trigger**: an attempt to write `state.json` fails with a filesystem
+  permission error (EACCES / EPERM).
+- **Message**:
+  ```
+  yci: cannot write state file: <path>
+    permission denied — check directory ownership and mode (expected 0700)
+  ```
+- **Test coverage**: `test_state_io.sh::test_write_permission_denied`
+
+---
+
+### Initializer (`init-profile.sh` — task 5.1)
+
+---
+
+### `init-profile-exists`
+
+- **ID**: `init-profile-exists`
+- **Producer**: `init-profile.sh`
+- **Exit code**: 1
+- **Trigger**: the target profile YAML file `<data-root>/profiles/<customer-id>.yaml`
+  already exists and `--force` was not passed.
+- **Message**:
+  ```
+  yci: profile already exists: <path>
+    pass --force to overwrite, or choose a different customer id
+  ```
+- **Test coverage**: `test_init_profile.sh::test_profile_exists`
+
+---
+
+### `init-invalid-customer-id`
+
+- **ID**: `init-invalid-customer-id`
+- **Producer**: `init-profile.sh`
+- **Exit code**: 1
+- **Trigger**: the customer ID argument passed to `init-profile.sh` fails the
+  format constraint `[a-z0-9][a-z0-9-]*`.
+- **Message**:
+  ```
+  yci: invalid customer id: '<customer>'
+    allowed pattern: [a-z0-9][a-z0-9-]*  (lowercase, hyphens only)
+  ```
+- **Test coverage**: `test_init_profile.sh::test_invalid_customer_id`
+
+---
+
+### `init-reserved-id`
+
+- **ID**: `init-reserved-id`
+- **Producer**: `init-profile.sh`
+- **Exit code**: 1
+- **Trigger**: the customer ID starts with an underscore (e.g., `_internal`,
+  `_template`), indicating a reserved namespace, and `--allow-reserved` was not
+  passed.
+- **Message**:
+  ```
+  yci: reserved customer id: '<customer>'
+    ids starting with '_' are reserved for internal use
+    pass --allow-reserved to create a reserved-namespace profile
+  ```
+- **Test coverage**: `test_init_profile.sh::test_reserved_id`
+
+---
+
+### Renderer (`render-whoami.sh` — task 5.1)
+
+---
+
+### `whoami-no-active-customer`
+
+- **ID**: `whoami-no-active-customer`
+- **Producer**: `render-whoami.sh`
+- **Exit code**: 1
+- **Trigger**: same root cause as `resolver-no-active-customer` — the resolver
+  returns exit 1 before the renderer can display any profile. The renderer
+  surfaces a shorter, command-oriented message appropriate for interactive use.
+- **Message**:
+  ```
+  yci: no active customer — run /yci:init <customer> or /yci:switch <customer>
+  ```
+- **Test coverage**: `test_render_whoami.sh::test_no_active_customer`
+
+---
+
+## Style Guide
+
+- **`yci:` prefix**: every message begins with `yci: ` so users immediately
+  identify which tool produced the error, regardless of shell noise around it.
+- **Angle-bracket placeholders**: dynamic parts appear as `<placeholder>` in this
+  catalog (e.g., `<path>`, `<field>`, `<customer>`, `<value>`). Scripts substitute
+  the actual value at emit time; tests match on the static prefix/suffix to avoid
+  brittle string copies.
+- **No trailing period on the final line**: shell error convention; the terminal
+  newline is sufficient sentence termination.
+- **Multi-line continuation indent**: additional lines in a message use a 2-space
+  indent so the error block is visually grouped when printed to a terminal.
+- **Remediation hint required for every exit-1 error**: every user-input or
+  resolver-refusal error must tell the user what to do next. Exit-2 (schema) and
+  exit-3 (runtime) errors should include a hint where a concrete action exists.
+
+---
+
+## Test-Assertion Helpers
+
+The test harness at `tests/helpers.sh` (task 5.2) will expose an
+`assert_error_id <id>` function that reads the `Message` block for the given
+error ID from this file and matches the actual command output against it.
+Tests reference errors by their catalog ID — never by copy-pasting the message
+string — so that a single wording change here propagates to all assertions
+automatically on the next test run.

--- a/yci/skills/customer-profile/references/precedence.md
+++ b/yci/skills/customer-profile/references/precedence.md
@@ -1,0 +1,270 @@
+# Customer-Scope Precedence Specification
+
+> **Canonical reference**: PRD §11.1 — "Authoritative customer-scope source".
+> This document translates that section into an implementable spec for
+> `resolve-customer.sh` (task 3.2), its unit tests, and every `yci` hook that
+> must determine "which customer are we in?"
+
+## Introduction
+
+`resolve-customer.sh` is the single entry point for determining the active
+customer ID in any `yci` skill, hook, or command. It must be called before
+touching any customer-scoped resource. The resolver returns exactly one
+customer ID string (via stdout) or exits with code 1.
+
+**Why this matters**: cross-customer context leakage is the #1 security
+concern for `yci` (PRD §2, threat model item 1 — "career-ending if it
+happens"). A deterministic, auditable precedence chain ensures that any
+given invocation can only be associated with one customer, that explicit
+signals always override ambient ones, and that a silent fallback to the
+wrong customer is structurally impossible. If no tier resolves, the resolver
+refuses rather than guessing.
+
+---
+
+## Precedence Chain
+
+Resolution stops at the first tier that yields a non-empty, valid value.
+
+```
+Tier 1 — $YCI_CUSTOMER env var             (explicit, session-scoped)
+    │
+    ▼ (only if unset or empty)
+Tier 2 — .yci-customer dotfile walk-up     (project-scoped)
+    │
+    ▼ (only if not found or all blank/comments)
+Tier 3 — MRU: state.json .active field     (session-state, last switched)
+    │
+    ▼ (only if absent or empty)
+Tier 4 — REFUSE (exit 1)
+```
+
+---
+
+## Per-Tier Specification
+
+### Tier 1 — `$YCI_CUSTOMER` Environment Variable
+
+**Signal**: set by the operator for session-scoped or pipeline-scoped overrides
+(e.g., tmux per-customer windows, CI pipelines).
+
+**Accept condition**: the variable is set AND its value after trimming leading
+and trailing whitespace is non-empty.
+
+**Rejection cases** (fall through to Tier 2):
+
+- `$YCI_CUSTOMER` is unset.
+- `$YCI_CUSTOMER` is the empty string (`YCI_CUSTOMER=""`).
+- `$YCI_CUSTOMER` contains only whitespace (`YCI_CUSTOMER="   "`).
+
+**Case sensitivity**: the value is case-sensitive. `ACME` and `acme` are
+different strings.
+
+**Format validation** (performed AFTER tier selection, not during resolution):
+the resolver returns the raw trimmed string. The _loader_ (not the resolver)
+validates that the ID matches the required format and that a profile file
+exists. Format reference (for documentation and test purposes):
+
+```
+[a-z0-9][a-z0-9-]*
+```
+
+Examples of valid IDs: `acme`, `acme-healthcare`, `bigbank-cdc`, `_internal`.
+Examples of invalid IDs: `ACME` (uppercase), `acme_corp` (underscore),
+`-acme` (leading hyphen).
+
+> The resolver does NOT validate format or profile existence. It returns the
+> trimmed string. Format validation and profile loading are the caller's
+> responsibility.
+
+---
+
+### Tier 2 — `.yci-customer` Dotfile Walk-Up
+
+**Signal**: a plain-text file in the project directory (or any ancestor)
+declaring the customer for that directory tree.
+
+**Algorithm**:
+
+1. Start at `$PWD`. Resolve to an absolute path.
+2. Look for `.yci-customer` in the current directory.
+3. If not present, ascend one level (`dirname`). Repeat.
+4. Stop (not found) when the current directory equals `$HOME` OR equals `/` —
+   whichever is reached first.
+5. **Never ascend past `$HOME`.** If the dotfile exists only in a parent of
+   `$HOME`, it is ignored. This prevents picking up someone else's home
+   directory configuration.
+
+**When the file is found**:
+
+- Read the file.
+- Skip lines that are empty or start with `#` (comment lines).
+- Take the first non-skipped line.
+- Trim leading and trailing whitespace.
+- If the trimmed value is non-empty, use it as the customer ID.
+- If the file has no non-empty, non-comment lines, treat it as "not found"
+  and continue the walk-up (the walk does NOT stop — ascend and look again).
+
+**File format example**:
+
+```
+# This project is scoped to Acme Healthcare
+# Last updated 2026-03-01
+acme-healthcare
+```
+
+**Edge cases**:
+
+- Empty file → treat as not found; continue walk.
+- Whitespace-only file → treat as not found; continue walk.
+- All-comment file → treat as not found; continue walk.
+- Multiple non-comment lines → only the first non-empty, non-comment line
+  is used; the rest are ignored.
+
+---
+
+### Tier 3 — MRU from `state.json`
+
+**Signal**: the last customer activated via `/yci:switch <id>` or equivalent.
+Stored in `<data-root>/state.json`.
+
+**`<data-root>` resolution**: delegated to `resolve-data-root.sh` (task 3.1).
+The resolver accepts `--data-root <path>` as a pass-through to that helper.
+The path is NOT hardcoded.
+
+**State file structure** (relevant fields):
+
+```json
+{
+  "active": "acme-healthcare",
+  "mru": ["acme-healthcare", "bigbank-cdc", "widgetco"]
+}
+```
+
+**Accept condition**:
+
+- `state.json` exists and is valid JSON.
+- `.active` field is present, non-null, and non-empty after trim.
+
+**Rejection cases** (fall through to Tier 4):
+
+- `state.json` does not exist.
+- `state.json` exists but is not valid JSON (parse error → treat as "no MRU";
+  emit a warning to stderr).
+- `.active` field is absent.
+- `.active` is `null` or an empty string.
+
+**Important**: the `.mru` array is history only. It is consumed by
+`/yci:whoami --history` (future skill) and MUST NOT be used as a fallback
+here. The MRU tier means "the most recently switched customer" — that is
+`.active`, exclusively.
+
+---
+
+### Tier 4 — Refusal
+
+When all three tiers fail to yield a customer ID, the resolver emits the
+canonical error message to **stderr** and exits with code **1**.
+
+Exit code 1 is reserved for "no customer resolved." Schema/format errors
+exit with code 2.
+
+---
+
+## Error Copy
+
+The exact text emitted on refusal (to stderr):
+
+```
+yci: no active customer.
+  $YCI_CUSTOMER: unset
+  .yci-customer: not found (searched from <cwd> up to <stop>)
+  state.json: no active customer at <path>
+Run `/yci:init <customer>` to create a profile, or `/yci:switch <customer>` to activate one.
+```
+
+**Placeholder substitution**:
+
+| Placeholder | Substituted with                                            |
+| ----------- | ----------------------------------------------------------- |
+| `<cwd>`     | Absolute path of `$PWD` at invocation time                  |
+| `<stop>`    | The directory where the walk stopped: either `$HOME` or `/` |
+| `<path>`    | Absolute path of the `state.json` file that was checked     |
+
+If `$YCI_CUSTOMER` was set but rejected (whitespace-only), replace
+`unset` with `empty (whitespace-only)` to aid debugging.
+
+This error text is the canonical form. `error-messages.md` (task 2.1) will
+register it formally; this file is the source of truth for the shape.
+
+---
+
+## Data-Root Interaction
+
+`<data-root>` is resolved at runtime by
+`yci/skills/_shared/scripts/resolve-data-root.sh` (task 3.1). Resolution
+order for that helper (not this resolver's concern, documented for
+cross-reference):
+
+1. `--data-root <path>` CLI flag.
+2. `$YCI_DATA_ROOT` env var.
+3. Default: `~/.config/yci/`.
+
+`resolve-customer.sh` accepts `--data-root <path>` and forwards it to
+`resolve-data-root.sh` when constructing the `state.json` path. The data
+root is never hardcoded in this resolver.
+
+---
+
+## Security Invariants
+
+The following properties MUST hold at all times:
+
+- **No ascent past `$HOME`**: the dotfile walk never reads files in parent
+  directories of `$HOME`. Prevents ambient configuration from a shared or
+  multi-user environment from leaking into the session.
+
+- **Explicit beats ambient**: Tier 1 (env) always wins over Tier 2 (dotfile)
+  always wins over Tier 3 (MRU). A dotfile can never override an explicit
+  env var. MRU can never override a dotfile.
+
+- **Empty/whitespace is unset**: in all three tiers, a value that is empty
+  or whitespace-only after trim is treated as "not provided" and the resolver
+  falls through to the next tier. There is no "empty string customer."
+
+- **Resolver returns ID only**: `resolve-customer.sh` outputs the customer ID
+  string and nothing else. It does NOT load the profile YAML, validate that the
+  profile file exists, or set any side-effect state. Those are the loader's
+  and hook's responsibilities.
+
+- **Refusal exits 1**: a resolver that cannot find a customer MUST exit 1.
+  Exit code 0 means "a customer ID was printed to stdout." Callers MUST
+  treat a non-zero exit as a hard failure and propagate it.
+
+- **Schema errors exit 2**: format validation failures (invalid ID characters,
+  malformed state.json after the file was found) exit 2 to distinguish them
+  from "no customer found" (exit 1). Callers can branch on these separately.
+
+---
+
+## Test-Case Matrix
+
+Every case below MUST have a corresponding unit test in `test_resolve_customer.sh`.
+
+| Case                      | `$YCI_CUSTOMER`    | Dotfile at `$CWD`             | Dotfile at ancestor    | `state.json.active` | Expected result                   |
+| ------------------------- | ------------------ | ----------------------------- | ---------------------- | ------------------- | --------------------------------- |
+| env wins                  | `acme`             | `beta`                        | —                      | `gamma`             | `acme`                            |
+| dotfile at cwd            | —                  | `beta`                        | —                      | `gamma`             | `beta`                            |
+| dotfile at ancestor       | —                  | —                             | `beta` (in `$PWD/..`)  | `gamma`             | `beta`                            |
+| mru only                  | —                  | —                             | —                      | `gamma`             | `gamma`                           |
+| all empty                 | —                  | —                             | —                      | —                   | refuse (exit 1)                   |
+| walk stops at `$HOME`     | —                  | —                             | `beta` (above `$HOME`) | —                   | refuse (exit 1)                   |
+| empty env is ignored      | `""`               | `beta`                        | —                      | —                   | `beta`                            |
+| whitespace-only dotfile   | —                  | `"   \n"`                     | `beta` (ancestor)      | —                   | `beta`                            |
+| comment-only dotfile      | —                  | `"# comment\n"`               | `beta` (ancestor)      | —                   | `beta`                            |
+| invalid id format         | `ACME` (uppercase) | —                             | —                      | —                   | refuse with "invalid id" (exit 2) |
+| missing state.json        | —                  | —                             | —                      | (file absent)       | refuse (exit 1)                   |
+| state.json no `.active`   | —                  | —                             | —                      | `{}`                | refuse (exit 1)                   |
+| state.json `.active` null | —                  | —                             | —                      | `{"active":null}`   | refuse (exit 1)                   |
+| whitespace-only env       | `"   "`            | `beta`                        | —                      | —                   | `beta`                            |
+| multi-line dotfile        | —                  | `"# comment\nreal-id\nother"` | —                      | —                   | `real-id`                         |

--- a/yci/skills/customer-profile/references/precedence.md
+++ b/yci/skills/customer-profile/references/precedence.md
@@ -69,9 +69,14 @@ exists. Format reference (for documentation and test purposes):
 [a-z0-9][a-z0-9-]*
 ```
 
-Examples of valid IDs: `acme`, `acme-healthcare`, `bigbank-cdc`, `_internal`.
+Examples of valid IDs: `acme`, `acme-healthcare`, `bigbank-cdc`.
 Examples of invalid IDs: `ACME` (uppercase), `acme_corp` (underscore),
-`-acme` (leading hyphen).
+`-acme` (leading hyphen), `_internal` (leading underscore).
+
+> **Reserved IDs** — IDs starting with `_` (e.g. `_internal`, `_template`) are
+> reserved for template/example use and rejected by the regex above. See
+> `init-profile.sh` `--allow-reserved` and the `init-reserved-id` entry in
+> `error-messages.md` for the init-side policy.
 
 > The resolver does NOT validate format or profile existence. It returns the
 > trimmed string. Format validation and profile loading are the caller's
@@ -241,9 +246,15 @@ The following properties MUST hold at all times:
   Exit code 0 means "a customer ID was printed to stdout." Callers MUST
   treat a non-zero exit as a hard failure and propagate it.
 
-- **Schema errors exit 2**: format validation failures (invalid ID characters,
-  malformed state.json after the file was found) exit 2 to distinguish them
-  from "no customer found" (exit 1). Callers can branch on these separately.
+- **User-input errors exit 1**: invalid ID characters in `$YCI_CUSTOMER`, the
+  dotfile, or `state.json`'s `.active` field exit 1 (same code as refusal) —
+  this is a user-provided-data error, indistinguishable at the shell level
+  from "no customer found." Canonical message: `resolver-invalid-id-format` in
+  `error-messages.md`.
+
+- **Data corruption exits 2**: `state.json` that exists but fails JSON parse
+  exits 2 (canonical: `state-corrupt-json`). This is distinct from "no
+  state.json found" (treated as no-MRU, falls through to refusal = exit 1).
 
 ---
 

--- a/yci/skills/customer-profile/references/schema.md
+++ b/yci/skills/customer-profile/references/schema.md
@@ -87,22 +87,31 @@ Required when `safety.change_window_required: true`. If omitted and that flag is
 
 ### `inventory`
 
-| Field            | Type   | Required | Allowed values                                              | Notes                                             |
-| ---------------- | ------ | -------- | ----------------------------------------------------------- | ------------------------------------------------- |
-| `adapter`        | string | yes      | `file`, `netbox`, `nautobot`, `servicenow-cmdb`, `infoblox` | CMDB adapter to load                              |
-| `endpoint`       | string | cond.    | URL                                                         | Required for API-backed adapters                  |
-| `credential_ref` | string | cond.    | `<customer-id>/<key-name>`                                  | Reference into the vaults subtree; no raw secrets |
-| `path`           | string | no       | any path                                                    | Override for inventory storage location           |
+| Field            | Type   | Required | Example values                                                        | Notes                                             |
+| ---------------- | ------ | -------- | --------------------------------------------------------------------- | ------------------------------------------------- |
+| `adapter`        | string | yes      | `file`, `manual`, `netbox`, `nautobot`, `servicenow-cmdb`, `infoblox` | CMDB adapter to load — see adapter note below     |
+| `endpoint`       | string | cond.    | URL                                                                   | Required for API-backed adapters                  |
+| `credential_ref` | string | cond.    | `<customer-id>/<key-name>`                                            | Reference into the vaults subtree; no raw secrets |
+| `path`           | string | no       | any path                                                              | Override for inventory storage location           |
+
+> **Adapter note** — `inventory.adapter` is validated as a non-empty string, not
+> a closed enum. The values above are illustrative common adapters; new
+> adapters can be added to a profile without a schema change, provided the
+> consuming hook knows how to read them. `profile-schema.sh` reflects this
+> (no `YCI_INVENTORY_ADAPTERS` enum array is declared).
 
 ---
 
 ### `approval`
 
-| Field            | Type   | Required | Allowed values                                                     | Notes                                             |
-| ---------------- | ------ | -------- | ------------------------------------------------------------------ | ------------------------------------------------- |
-| `adapter`        | string | yes      | `github-pr`, `email-signoff`, `jira`, `servicenow-request`, `none` | Approval-workflow adapter                         |
-| `endpoint`       | string | cond.    | URL                                                                | Required for API-backed adapters                  |
-| `credential_ref` | string | cond.    | `<customer-id>/<key-name>`                                         | Reference into the vaults subtree; no raw secrets |
+| Field            | Type   | Required | Example values                                                               | Notes                                              |
+| ---------------- | ------ | -------- | ---------------------------------------------------------------------------- | -------------------------------------------------- |
+| `adapter`        | string | yes      | `github-pr`, `email-signoff`, `jira`, `servicenow-request`, `manual`, `none` | Approval-workflow adapter — see adapter note below |
+| `endpoint`       | string | cond.    | URL                                                                          | Required for API-backed adapters                   |
+| `credential_ref` | string | cond.    | `<customer-id>/<key-name>`                                                   | Reference into the vaults subtree; no raw secrets  |
+
+> **Adapter note** — like `inventory.adapter`, `approval.adapter` is validated
+> as a non-empty string, not a closed enum. The list above is illustrative.
 
 ---
 

--- a/yci/skills/customer-profile/references/schema.md
+++ b/yci/skills/customer-profile/references/schema.md
@@ -1,0 +1,231 @@
+# yci Customer Profile Schema
+
+> **Source of truth**: PRD §5.2. This document mirrors that section verbatim and
+> is the canonical reference for `load-profile.sh`, `init-profile.sh`, unit tests,
+> and humans authoring profiles by hand.
+
+A **customer profile** is a YAML document that describes one customer engagement.
+It lives at `<data-root>/profiles/<customer-id>.yaml`, where `<data-root>` resolves
+via the precedence chain: `--data-root <path>` > `$YCI_DATA_ROOT` > `~/.config/yci/`
+(see PRD §5.1). Start a new profile from `_template.yaml` in the same directory.
+
+---
+
+## Top-level keys
+
+| Key              | Required | Notes                                                           |
+| ---------------- | -------- | --------------------------------------------------------------- |
+| `customer`       | yes      | Stable identity of the customer; used as scope label everywhere |
+| `engagement`     | yes      | Current SOW / engagement context                                |
+| `compliance`     | yes      | Regime + evidence schema                                        |
+| `inventory`      | yes      | CMDB / device-inventory adapter                                 |
+| `approval`       | yes      | Approval-workflow adapter                                       |
+| `deliverable`    | yes      | Output format and destination path                              |
+| `safety`         | yes      | Default posture, change-window policy, scope enforcement        |
+| `change_window`  | no       | Required only when `safety.change_window_required: true`        |
+| `vaults`         | no       | Override for secrets-store path; defaults to data-root subtree  |
+| `vendor_tooling` | no       | List of vendor/product/version entries for the engagement       |
+
+---
+
+## Per-subtree field tables
+
+### `customer`
+
+| Field          | Type   | Required | Allowed values | Notes                                         |
+| -------------- | ------ | -------- | -------------- | --------------------------------------------- |
+| `id`           | string | yes      | `[a-z0-9-]+`   | Stable slug; used as scope label in artifacts |
+| `display_name` | string | yes      | any string     | Human-readable name for deliverable headers   |
+| `branding`     | object | no       | —              | See nested fields below                       |
+
+#### `customer.branding`
+
+| Field       | Type   | Required | Notes                                                      |
+| ----------- | ------ | -------- | ---------------------------------------------------------- |
+| `logo_path` | string | no       | Absolute or `~/`-prefixed path to a PNG/SVG logo           |
+| `color`     | string | no       | Hex color code (e.g., `'#003366'`) for deliverable styling |
+
+> Consultant brand is always composited alongside customer brand (PRD §0 Q3).
+
+---
+
+### `engagement`
+
+| Field        | Type   | Required | Allowed values                                     | Notes                                    |
+| ------------ | ------ | -------- | -------------------------------------------------- | ---------------------------------------- |
+| `id`         | string | yes      | `[a-z0-9-]+`                                       | Stable engagement slug                   |
+| `type`       | string | yes      | `discovery`, `design`, `implementation`, `ongoing` | Engagement phase; see Enum section below |
+| `sow_ref`    | string | yes      | any string                                         | SOW / contract reference number          |
+| `scope_tags` | list   | yes      | any strings                                        | Tags used by scope-gate hook; match SOW  |
+| `start_date` | string | yes      | `YYYY-MM-DD`                                       | Engagement start                         |
+| `end_date`   | string | yes      | `YYYY-MM-DD`                                       | Engagement end                           |
+
+---
+
+### `compliance`
+
+| Field                     | Type    | Required | Allowed values                        | Notes                                   |
+| ------------------------- | ------- | -------- | ------------------------------------- | --------------------------------------- |
+| `regime`                  | string  | yes      | see **Compliance regimes** enum below | Selects the compliance adapter          |
+| `baa_reference`           | string  | no       | any string                            | BAA / DPA reference (HIPAA customers)   |
+| `evidence_schema_version` | integer | yes      | `1` (current)                         | Adapter evidence-schema version to load |
+
+---
+
+### `change_window`
+
+Required when `safety.change_window_required: true`. If omitted and that flag is
+`true`, the loader emits an error.
+
+| Field      | Type   | Required | Allowed values                                                   | Notes                                                  |
+| ---------- | ------ | -------- | ---------------------------------------------------------------- | ------------------------------------------------------ |
+| `adapter`  | string | yes      | `ical`, `servicenow-cab`, `json-schedule`, `always-open`, `none` | Selects the changewindow adapter                       |
+| `source`   | string | cond.    | file path or URL                                                 | Required for `ical`, `json-schedule`, `servicenow-cab` |
+| `timezone` | string | no       | IANA tz string (e.g., `America/Chicago`)                         | Defaults to system timezone                            |
+
+---
+
+### `inventory`
+
+| Field            | Type   | Required | Allowed values                                              | Notes                                             |
+| ---------------- | ------ | -------- | ----------------------------------------------------------- | ------------------------------------------------- |
+| `adapter`        | string | yes      | `file`, `netbox`, `nautobot`, `servicenow-cmdb`, `infoblox` | CMDB adapter to load                              |
+| `endpoint`       | string | cond.    | URL                                                         | Required for API-backed adapters                  |
+| `credential_ref` | string | cond.    | `<customer-id>/<key-name>`                                  | Reference into the vaults subtree; no raw secrets |
+| `path`           | string | no       | any path                                                    | Override for inventory storage location           |
+
+---
+
+### `approval`
+
+| Field            | Type   | Required | Allowed values                                                     | Notes                                             |
+| ---------------- | ------ | -------- | ------------------------------------------------------------------ | ------------------------------------------------- |
+| `adapter`        | string | yes      | `github-pr`, `email-signoff`, `jira`, `servicenow-request`, `none` | Approval-workflow adapter                         |
+| `endpoint`       | string | cond.    | URL                                                                | Required for API-backed adapters                  |
+| `credential_ref` | string | cond.    | `<customer-id>/<key-name>`                                         | Reference into the vaults subtree; no raw secrets |
+
+---
+
+### `vaults`
+
+Optional top-level override. Defaults to `$YCI_DATA_ROOT/vaults/<customer-id>/`.
+
+| Field  | Type   | Required | Notes                                                                  |
+| ------ | ------ | -------- | ---------------------------------------------------------------------- |
+| `path` | string | no       | Any path or URI (e.g., `onepassword://acme-vault`, `~/Dropbox/vault/`) |
+
+---
+
+### `deliverable`
+
+| Field             | Type         | Required | Allowed values                                | Notes                                                        |
+| ----------------- | ------------ | -------- | --------------------------------------------- | ------------------------------------------------------------ |
+| `format`          | list[string] | yes      | `markdown`, `pdf`, `word`, `confluence`       | Output formats for this customer                             |
+| `header_template` | string       | yes      | file path                                     | Dual-branded header template (PRD §0 Q3)                     |
+| `handoff_format`  | string       | yes      | `git-repo`, `zip`, `confluence`, `pdf-bundle` | Delivery packaging for end-of-engagement handoff             |
+| `path`            | string       | no       | any path                                      | Override for artifact storage; defaults to data-root subtree |
+
+Common `path` patterns: `~/Dropbox-<Customer>/deliverables/`,
+`~/OneDrive-<Customer>/deliverables/`, `/Volumes/<NAS>/deliverables/`,
+`~/Encrypted-Customers/<id>/` (see PRD §11.10).
+
+---
+
+### `vendor_tooling`
+
+A list of objects. Each entry has:
+
+| Field     | Type   | Required | Notes                                              |
+| --------- | ------ | -------- | -------------------------------------------------- |
+| `vendor`  | string | yes      | Vendor slug (e.g., `cisco`, `palo-alto`, `vmware`) |
+| `product` | string | yes      | Product slug (e.g., `ios-xe`, `pan-os`)            |
+| `version` | string | yes      | Semver or version string (e.g., `'17.9'`)          |
+
+---
+
+### `safety`
+
+| Field                    | Type    | Required | Allowed values                         | Notes                                              |
+| ------------------------ | ------- | -------- | -------------------------------------- | -------------------------------------------------- |
+| `default_posture`        | string  | yes      | see **Safety postures** enum below     | Default for all yci workflows in this engagement   |
+| `change_window_required` | boolean | yes      | `true`, `false`                        | If `true`, `change_window` key must be present     |
+| `scope_enforcement`      | string  | yes      | see **Scope enforcement values** below | Behavior when scope-gate detects out-of-scope work |
+
+---
+
+## Enum sections
+
+### Compliance regimes
+
+Values for `compliance.regime` (PRD §11.2):
+
+| Value        | Meaning                                           |
+| ------------ | ------------------------------------------------- |
+| `hipaa`      | HIPAA/HITECH — healthcare customers               |
+| `pci`        | PCI-DSS — customers handling card data            |
+| `sox`        | SOX — publicly-traded financial customers         |
+| `soc2`       | SOC 2 — cloud-native commercial customers         |
+| `iso27001`   | ISO 27001 — international / EU customers          |
+| `nist`       | NIST 800-53 — federal customers                   |
+| `commercial` | Generic best-practice, no specific named regime   |
+| `none`       | No compliance framing (internal / lab / non-prod) |
+
+---
+
+### Safety postures
+
+Values for `safety.default_posture` (PRD §11.7):
+
+| Value     | Meaning                                                                |
+| --------- | ---------------------------------------------------------------------- |
+| `dry-run` | Produce plan/diff/review artifact only; never write or apply (default) |
+| `review`  | Surface changes for human review before applying                       |
+| `apply`   | Allow changes to proceed (requires explicit `--apply` flag at runtime) |
+
+Default for all profiles is `dry-run`. The stock `_internal` profile uses `review`
+(PRD §0 Q5).
+
+---
+
+### Engagement types
+
+Values for `engagement.type` (PRD §5.2):
+
+| Value            | Meaning                                           |
+| ---------------- | ------------------------------------------------- |
+| `discovery`      | Read-only assessment; no write operations allowed |
+| `design`         | Architecture / design phase                       |
+| `implementation` | Active build / configuration phase                |
+| `ongoing`        | Ongoing managed service or support engagement     |
+
+---
+
+### Scope enforcement values
+
+Values for `safety.scope_enforcement` (PRD §5.2, §6.1 P0.9):
+
+| Value   | Meaning                                                         |
+| ------- | --------------------------------------------------------------- |
+| `warn`  | Log a warning when work appears outside SOW scope tags; proceed |
+| `block` | Refuse to proceed until scope is confirmed or overridden        |
+| `off`   | No scope checking (use only for `_internal` or lab profiles)    |
+
+---
+
+## Unknown-keys policy
+
+The profile loader emits a **warning** on any unrecognised top-level key and
+continues loading. This allows forward-compatible profiles (e.g., a profile
+authored for a future `yci` version with a new optional key will still load on
+an older version). Missing **required** keys cause an immediate **error** and
+abort loading.
+
+---
+
+## Credentials note
+
+Profiles **MUST NOT contain secrets**, credentials, tokens, passwords, or any
+sensitive value. Use `credential_ref` fields as opaque pointers into the active
+vaults subtree (e.g., `acme-healthcare/netbox-token`). The vault itself is
+encrypted at rest (`age` or `sops` recommended) and lives outside any git
+repository. See PRD §11.9.

--- a/yci/skills/customer-profile/scripts/init-profile.sh
+++ b/yci/skills/customer-profile/scripts/init-profile.sh
@@ -23,7 +23,11 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --force)           force=1 ;;
         --allow-reserved)  allow_reserved=1 ;;
-        *) ;;
+        *)
+            printf "yci: unknown flag: '%s'\n" "$1" >&2
+            printf '  valid flags: --force, --allow-reserved\n' >&2
+            exit 1
+            ;;
     esac
     shift
 done

--- a/yci/skills/customer-profile/scripts/init-profile.sh
+++ b/yci/skills/customer-profile/scripts/init-profile.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# yci — scaffold a new customer profile from _template.yaml.
+#
+# Usage: init-profile.sh <data-root> <customer> [--force] [--allow-reserved]
+# Stdout: confirmation message on success.
+# Stderr: error messages only.
+# Exit 0: success.
+# Exit 1: invalid id, reserved id, or profile already exists without --force.
+# Exit 3: runtime error (mkdir failure, cp failure).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+TEMPLATE="${SCRIPT_DIR}/../references/_template.yaml"
+
+data_root="${1:?usage: init-profile.sh <data-root> <customer> [--force] [--allow-reserved]}"
+customer="${2:?usage: init-profile.sh <data-root> <customer> [--force] [--allow-reserved]}"
+shift 2
+
+force=0
+allow_reserved=0
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --force)           force=1 ;;
+        --allow-reserved)  allow_reserved=1 ;;
+        *) ;;
+    esac
+    shift
+done
+
+# --- validate customer id format (init-invalid-customer-id, exit 1) ---------
+# Reserved ids start with '_'; they fail this regex (requires [a-z0-9] first).
+# We check reserved separately below, so regex only tests format here.
+if ! [[ "$customer" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    # Could be a reserved id (starts with _) — check that first for a better message.
+    if [[ "$customer" == _* ]]; then
+        if [ "$allow_reserved" -eq 0 ]; then
+            printf "yci: reserved customer id: '%s'\n" "$customer" >&2
+            printf "  ids starting with '_' are reserved for internal use\n" >&2
+            printf '  pass --allow-reserved to create a reserved-namespace profile\n' >&2
+            exit 1
+        fi
+        # --allow-reserved passed; still validate the rest of the id.
+        # Reserved ids don't need to match [a-z0-9][a-z0-9-]* but must at
+        # minimum be non-empty after the underscore and contain no spaces.
+        if [[ "$customer" =~ [[:space:]] ]]; then
+            printf "yci: invalid customer id: '%s'\n" "$customer" >&2
+            printf '  allowed pattern: [a-z0-9][a-z0-9-]*  (lowercase, hyphens only)\n' >&2
+            exit 1
+        fi
+    else
+        printf "yci: invalid customer id: '%s'\n" "$customer" >&2
+        printf '  allowed pattern: [a-z0-9][a-z0-9-]*  (lowercase, hyphens only)\n' >&2
+        exit 1
+    fi
+else
+    # Passes main regex — check reserved regardless (reserved start with _ which fails regex,
+    # so this branch means the id does NOT start with _ and is fully valid).
+    :
+fi
+
+# Separate reserved check for ids that pass the format regex (none currently,
+# since _ prefix fails [a-z0-9] first char; kept for defensive correctness).
+if [[ "$customer" == _* ]] && [ "$allow_reserved" -eq 0 ]; then
+    printf "yci: reserved customer id: '%s'\n" "$customer" >&2
+    printf "  ids starting with '_' are reserved for internal use\n" >&2
+    printf '  pass --allow-reserved to create a reserved-namespace profile\n' >&2
+    exit 1
+fi
+
+profiles_dir="${data_root}/profiles"
+target="${profiles_dir}/${customer}.yaml"
+
+# --- create profiles directory (mode 0700) if absent -----------------------
+if [ ! -d "$profiles_dir" ]; then
+    if ! mkdir -p "$profiles_dir"; then
+        printf 'yci: cannot create profiles directory: %s\n' "$profiles_dir" >&2
+        exit 3
+    fi
+    chmod 0700 "$profiles_dir"
+fi
+
+# --- refuse overwrite without --force (init-profile-exists, exit 1) --------
+if [ -f "$target" ] && [ "$force" -eq 0 ]; then
+    printf 'yci: profile already exists: %s\n' "$target" >&2
+    printf '  pass --force to overwrite, or choose a different customer id\n' >&2
+    exit 1
+fi
+
+# --- copy template ----------------------------------------------------------
+if ! cp "$TEMPLATE" "$target"; then
+    printf 'yci: failed to copy template to: %s\n' "$target" >&2
+    exit 3
+fi
+chmod 0600 "$target"
+
+# --- confirmation -----------------------------------------------------------
+printf 'yci: scaffolded profile at %s\n' "$target"
+printf '  edit the <TODO: ...> placeholders, then run: /yci:switch %s\n' "$customer"

--- a/yci/skills/customer-profile/scripts/load-profile.sh
+++ b/yci/skills/customer-profile/scripts/load-profile.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# yci — load and validate a customer profile YAML, emitting normalized JSON.
+#
+# Usage: load-profile.sh <data-root> <customer>
+# Stdout: indented JSON of the parsed profile on success.
+# Stderr: error messages only.
+# Exit 0: success.
+# Exit 1: profile file not found (loader-missing-file).
+# Exit 2: schema violation — malformed YAML, missing required key, invalid enum.
+# Exit 3: runtime error — pyyaml not installed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/profile-schema.sh"
+
+data_root="${1:?usage: load-profile.sh <data-root> <customer>}"
+customer="${2:?usage: load-profile.sh <data-root> <customer>}"
+profile_path="${data_root}/profiles/${customer}.yaml"
+
+# --- loader-missing-file (exit 1) -------------------------------------------
+if [ ! -f "$profile_path" ]; then
+    printf 'yci: profile not found: %s\n' "$profile_path" >&2
+    printf '  create a new profile with `/yci:init %s` or copy _template.yaml\n' "$customer" >&2
+    exit 1
+fi
+
+# --- Export schema arrays as space-separated env vars for Python -------------
+export YCI_REQUIRED_TOP_LEVEL="${YCI_PROFILE_REQUIRED_TOP_LEVEL[*]}"
+export YCI_OPTIONAL_TOP_LEVEL="${YCI_PROFILE_OPTIONAL_TOP_LEVEL[*]}"
+export YCI_CUSTOMER_REQ="${YCI_CUSTOMER_REQUIRED[*]}"
+export YCI_ENGAGEMENT_REQ="${YCI_ENGAGEMENT_REQUIRED[*]}"
+export YCI_COMPLIANCE_REQ="${YCI_COMPLIANCE_REQUIRED[*]}"
+export YCI_INVENTORY_REQ="${YCI_INVENTORY_REQUIRED[*]}"
+export YCI_APPROVAL_REQ="${YCI_APPROVAL_REQUIRED[*]}"
+export YCI_DELIVERABLE_REQ="${YCI_DELIVERABLE_REQUIRED[*]}"
+export YCI_SAFETY_REQ="${YCI_SAFETY_REQUIRED[*]}"
+export YCI_COMPLIANCE_REGIMES_ENV="${YCI_COMPLIANCE_REGIMES[*]}"
+export YCI_SAFETY_POSTURES_ENV="${YCI_SAFETY_POSTURES[*]}"
+export YCI_ENGAGEMENT_TYPES_ENV="${YCI_ENGAGEMENT_TYPES[*]}"
+export YCI_SCOPE_ENFORCEMENT_ENV="${YCI_SCOPE_ENFORCEMENT[*]}"
+
+python3 - "$profile_path" <<'PY'
+import json, os, sys
+
+# --- pyyaml check (loader-pyyaml-missing, exit 3) ---------------------------
+try:
+    import yaml
+except ModuleNotFoundError:
+    sys.stderr.write(
+        "yci: pyyaml not found — cannot parse YAML profiles\n"
+        "  pyyaml required — install via 'pip install pyyaml' or your distro's python3-yaml package\n"
+    )
+    sys.exit(3)
+
+path = sys.argv[1]
+
+# --- parse (loader-malformed-yaml, exit 2) ----------------------------------
+try:
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+except yaml.YAMLError as exc:
+    first_line = str(exc).splitlines()[0] if str(exc) else str(exc)
+    sys.stderr.write(f"yci: malformed YAML in profile: {path}\n  {first_line}\nFix the YAML syntax and retry.\n")
+    sys.exit(2)
+
+if not isinstance(data, dict):
+    sys.stderr.write(
+        f"yci: malformed YAML in profile: {path}\n"
+        f"  profile must be a YAML mapping at top level\n"
+        "Fix the YAML syntax and retry.\n"
+    )
+    sys.exit(2)
+
+# --- required top-level keys (loader-missing-required-key, exit 2) ----------
+req_top = os.environ["YCI_REQUIRED_TOP_LEVEL"].split()
+opt_top = os.environ["YCI_OPTIONAL_TOP_LEVEL"].split()
+
+for key in req_top:
+    if key not in data:
+        sys.stderr.write(
+            f"yci: missing required field '{key}' in profile: {path}\n"
+            "  see yci/skills/customer-profile/references/schema.md for required fields\n"
+        )
+        sys.exit(2)
+
+# --- nested required fields (loader-missing-required-key, exit 2) -----------
+nested_req = {
+    "customer":    os.environ["YCI_CUSTOMER_REQ"].split(),
+    "engagement":  os.environ["YCI_ENGAGEMENT_REQ"].split(),
+    "compliance":  os.environ["YCI_COMPLIANCE_REQ"].split(),
+    "inventory":   os.environ["YCI_INVENTORY_REQ"].split(),
+    "approval":    os.environ["YCI_APPROVAL_REQ"].split(),
+    "deliverable": os.environ["YCI_DELIVERABLE_REQ"].split(),
+    "safety":      os.environ["YCI_SAFETY_REQ"].split(),
+}
+for section, fields in nested_req.items():
+    section_data = data.get(section)
+    if not isinstance(section_data, dict):
+        sys.stderr.write(
+            f"yci: missing required field '{section}' in profile: {path}\n"
+            "  see yci/skills/customer-profile/references/schema.md for required fields\n"
+        )
+        sys.exit(2)
+    for field in fields:
+        if field not in section_data:
+            sys.stderr.write(
+                f"yci: missing required field '{section}.{field}' in profile: {path}\n"
+                "  see yci/skills/customer-profile/references/schema.md for required fields\n"
+            )
+            sys.exit(2)
+
+# --- enum validation (loader-invalid-enum-value, exit 2) --------------------
+enums = {
+    ("compliance", "regime"):           set(os.environ["YCI_COMPLIANCE_REGIMES_ENV"].split()),
+    ("safety",     "default_posture"):  set(os.environ["YCI_SAFETY_POSTURES_ENV"].split()),
+    ("engagement", "type"):             set(os.environ["YCI_ENGAGEMENT_TYPES_ENV"].split()),
+    ("safety",     "scope_enforcement"): set(os.environ["YCI_SCOPE_ENFORCEMENT_ENV"].split()),
+}
+for (sec, field), allowed in enums.items():
+    val = data.get(sec, {}).get(field)
+    if val is None:
+        continue  # nested-required check already caught absent field above
+    if str(val) not in allowed:
+        sys.stderr.write(
+            f"yci: invalid value for '{sec}.{field}': '{val}'\n"
+            f"  allowed values: {sorted(allowed)}\n"
+            "  see yci/skills/customer-profile/references/schema.md for the canonical enum lists\n"
+        )
+        sys.exit(2)
+
+# --- unknown top-level key warning (stderr, not error) ----------------------
+allowed_top = set(req_top) | set(opt_top)
+for key in data:
+    if key not in allowed_top:
+        sys.stderr.write(f"yci: warning — unknown top-level key: {key}\n")
+
+# --- success: emit JSON ------------------------------------------------------
+print(json.dumps(data, indent=2, sort_keys=False, default=str))
+PY

--- a/yci/skills/customer-profile/scripts/load-profile.sh
+++ b/yci/skills/customer-profile/scripts/load-profile.sh
@@ -42,6 +42,7 @@ export YCI_SAFETY_POSTURES_ENV="${YCI_SAFETY_POSTURES[*]}"
 export YCI_ENGAGEMENT_TYPES_ENV="${YCI_ENGAGEMENT_TYPES[*]}"
 export YCI_SCOPE_ENFORCEMENT_ENV="${YCI_SCOPE_ENFORCEMENT[*]}"
 export YCI_HANDOFF_FORMATS_ENV="${YCI_DELIVERABLE_HANDOFF_FORMATS[*]}"
+export YCI_CHANGE_WINDOW_ADAPTERS_ENV="${YCI_CHANGE_WINDOW_ADAPTERS[*]}"
 
 python3 - "$profile_path" <<'PY'
 import json, os, sys
@@ -129,6 +130,21 @@ for (sec, field), allowed in enums.items():
         sys.stderr.write(
             f"yci: invalid value for '{sec}.{field}': '{val}'\n"
             f"  allowed values: {sorted(allowed)}\n"
+            "  see yci/skills/customer-profile/references/schema.md for the canonical enum lists\n"
+        )
+        sys.exit(2)
+
+# --- optional-section enum validation ---------------------------------------
+# change_window is optional at the top level; only validate its adapter when
+# the block is present.
+cw = data.get("change_window")
+if isinstance(cw, dict):
+    cw_allowed = set(os.environ["YCI_CHANGE_WINDOW_ADAPTERS_ENV"].split())
+    cw_adapter = cw.get("adapter")
+    if cw_adapter is not None and str(cw_adapter) not in cw_allowed:
+        sys.stderr.write(
+            f"yci: invalid value for 'change_window.adapter': '{cw_adapter}'\n"
+            f"  allowed values: {sorted(cw_allowed)}\n"
             "  see yci/skills/customer-profile/references/schema.md for the canonical enum lists\n"
         )
         sys.exit(2)

--- a/yci/skills/customer-profile/scripts/load-profile.sh
+++ b/yci/skills/customer-profile/scripts/load-profile.sh
@@ -41,6 +41,7 @@ export YCI_COMPLIANCE_REGIMES_ENV="${YCI_COMPLIANCE_REGIMES[*]}"
 export YCI_SAFETY_POSTURES_ENV="${YCI_SAFETY_POSTURES[*]}"
 export YCI_ENGAGEMENT_TYPES_ENV="${YCI_ENGAGEMENT_TYPES[*]}"
 export YCI_SCOPE_ENFORCEMENT_ENV="${YCI_SCOPE_ENFORCEMENT[*]}"
+export YCI_HANDOFF_FORMATS_ENV="${YCI_DELIVERABLE_HANDOFF_FORMATS[*]}"
 
 python3 - "$profile_path" <<'PY'
 import json, os, sys
@@ -118,6 +119,7 @@ enums = {
     ("safety",     "default_posture"):  set(os.environ["YCI_SAFETY_POSTURES_ENV"].split()),
     ("engagement", "type"):             set(os.environ["YCI_ENGAGEMENT_TYPES_ENV"].split()),
     ("safety",     "scope_enforcement"): set(os.environ["YCI_SCOPE_ENFORCEMENT_ENV"].split()),
+    ("deliverable", "handoff_format"):   set(os.environ["YCI_HANDOFF_FORMATS_ENV"].split()),
 }
 for (sec, field), allowed in enums.items():
     val = data.get(sec, {}).get(field)

--- a/yci/skills/customer-profile/scripts/profile-schema.sh
+++ b/yci/skills/customer-profile/scripts/profile-schema.sh
@@ -8,6 +8,12 @@
 #   - yci/skills/customer-profile/references/schema.md
 #   - docs/prps/prds/yci.prd.md §5.2
 
+# shellcheck disable=SC2034
+# All YCI_* arrays below are sourced by downstream scripts (load-profile.sh,
+# init-profile.sh, tests/) which read them via `${YCI_*[@]}` or export them
+# to the environment. shellcheck can't see cross-file usage, so suppress
+# SC2034 for the whole file.
+
 # Top-level keys --------------------------------------------------------------
 
 # Must appear in every valid profile.

--- a/yci/skills/customer-profile/scripts/profile-schema.sh
+++ b/yci/skills/customer-profile/scripts/profile-schema.sh
@@ -46,6 +46,9 @@ YCI_ENGAGEMENT_TYPES=(discovery design implementation ongoing)
 # Values for safety.scope_enforcement (schema.md "Scope enforcement values").
 YCI_SCOPE_ENFORCEMENT=(warn block off)
 
+# Values for deliverable.handoff_format (schema.md "deliverable" table).
+YCI_DELIVERABLE_HANDOFF_FORMATS=(git-repo zip confluence pdf-bundle)
+
 # Inventory/approval adapter types: schema.md enumerates these but the loader
 # validates adapter presence (non-empty string), not a closed enum, because
 # new adapters are added without schema changes. Uncomment if stricter

--- a/yci/skills/customer-profile/scripts/profile-schema.sh
+++ b/yci/skills/customer-profile/scripts/profile-schema.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# yci — profile schema declaration (source this file; do not execute directly).
+#
+# Single source of truth for required/optional keys and enum allowed values.
+# Consumed by load-profile.sh, init-profile.sh, and the test harness.
+#
+# Keep in sync with:
+#   - yci/skills/customer-profile/references/schema.md
+#   - docs/prps/prds/yci.prd.md §5.2
+
+# Top-level keys --------------------------------------------------------------
+
+# Must appear in every valid profile.
+YCI_PROFILE_REQUIRED_TOP_LEVEL=(customer engagement compliance inventory approval deliverable safety)
+
+# May appear; loader warns if absent and does NOT error.
+YCI_PROFILE_OPTIONAL_TOP_LEVEL=(change_window vaults vendor_tooling)
+
+# Nested required fields ------------------------------------------------------
+#
+# Convention: YCI_<UPPERCASE_SECTION>_REQUIRED=(...) for each top-level section
+# with nested requirements. Loader iterates these arrays.
+
+YCI_CUSTOMER_REQUIRED=(id display_name)
+YCI_ENGAGEMENT_REQUIRED=(id type sow_ref scope_tags start_date end_date)
+YCI_COMPLIANCE_REQUIRED=(regime evidence_schema_version)
+YCI_INVENTORY_REQUIRED=(adapter)
+YCI_APPROVAL_REQUIRED=(adapter)
+YCI_DELIVERABLE_REQUIRED=(format header_template handoff_format)
+YCI_SAFETY_REQUIRED=(default_posture change_window_required scope_enforcement)
+
+# Enum allowed values ---------------------------------------------------------
+#
+# IMPORTANT: these MUST match schema.md's enum sections verbatim. The loader
+# rejects any value not in the array for the corresponding field.
+
+# Values for compliance.regime (schema.md "Compliance regimes" / PRD §11.2).
+YCI_COMPLIANCE_REGIMES=(hipaa pci sox soc2 iso27001 nist commercial none)
+
+# Values for safety.default_posture (schema.md "Safety postures" / PRD §11.7).
+YCI_SAFETY_POSTURES=(dry-run review apply)
+
+# Values for engagement.type (schema.md "Engagement types" / PRD §5.2).
+YCI_ENGAGEMENT_TYPES=(discovery design implementation ongoing)
+
+# Values for safety.scope_enforcement (schema.md "Scope enforcement values").
+YCI_SCOPE_ENFORCEMENT=(warn block off)
+
+# Inventory/approval adapter types: schema.md enumerates these but the loader
+# validates adapter presence (non-empty string), not a closed enum, because
+# new adapters are added without schema changes. Uncomment if stricter
+# validation is desired in a future iteration.
+# YCI_INVENTORY_ADAPTERS=(file netbox nautobot servicenow-cmdb infoblox)
+# YCI_APPROVAL_ADAPTERS=(github-pr email-signoff jira servicenow-request none)
+
+# Helpers ---------------------------------------------------------------------
+
+# yci_enum_contains <array-name> <value>
+#   Returns 0 if <value> is in the named array, 1 otherwise.
+yci_enum_contains() {
+    local -n _yci_arr="$1"
+    local needle="$2"
+    local item
+    for item in "${_yci_arr[@]}"; do
+        [ "$item" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+# yci_required_for <section>
+#   Echoes the space-separated required field list for <section>,
+#   or nothing if no required fields are declared for that section.
+yci_required_for() {
+    local section
+    section="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
+    local varname="YCI_${section}_REQUIRED"
+    if [ -n "${!varname+set}" ]; then
+        local -n _yci_req_arr="$varname"
+        printf '%s ' "${_yci_req_arr[@]}"
+    fi
+}

--- a/yci/skills/customer-profile/scripts/profile-schema.sh
+++ b/yci/skills/customer-profile/scripts/profile-schema.sh
@@ -55,36 +55,11 @@ YCI_SCOPE_ENFORCEMENT=(warn block off)
 # Values for deliverable.handoff_format (schema.md "deliverable" table).
 YCI_DELIVERABLE_HANDOFF_FORMATS=(git-repo zip confluence pdf-bundle)
 
-# Inventory/approval adapter types: schema.md enumerates these but the loader
-# validates adapter presence (non-empty string), not a closed enum, because
-# new adapters are added without schema changes. Uncomment if stricter
-# validation is desired in a future iteration.
-# YCI_INVENTORY_ADAPTERS=(file netbox nautobot servicenow-cmdb infoblox)
-# YCI_APPROVAL_ADAPTERS=(github-pr email-signoff jira servicenow-request none)
+# Values for change_window.adapter (schema.md "change_window" table).
+# Only validated when change_window is present (the whole block is optional).
+YCI_CHANGE_WINDOW_ADAPTERS=(ical servicenow-cab json-schedule always-open none)
 
-# Helpers ---------------------------------------------------------------------
-
-# yci_enum_contains <array-name> <value>
-#   Returns 0 if <value> is in the named array, 1 otherwise.
-yci_enum_contains() {
-    local -n _yci_arr="$1"
-    local needle="$2"
-    local item
-    for item in "${_yci_arr[@]}"; do
-        [ "$item" = "$needle" ] && return 0
-    done
-    return 1
-}
-
-# yci_required_for <section>
-#   Echoes the space-separated required field list for <section>,
-#   or nothing if no required fields are declared for that section.
-yci_required_for() {
-    local section
-    section="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
-    local varname="YCI_${section}_REQUIRED"
-    if [ -n "${!varname+set}" ]; then
-        local -n _yci_req_arr="$varname"
-        printf '%s ' "${_yci_req_arr[@]}"
-    fi
-}
+# Inventory/approval adapter types: schema.md lists common adapters but the
+# loader validates the field as a non-empty string, not a closed enum — new
+# adapters are added without schema changes. See schema.md "Adapter note"
+# under inventory and approval.

--- a/yci/skills/customer-profile/scripts/render-whoami.sh
+++ b/yci/skills/customer-profile/scripts/render-whoami.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# yci — render the human-readable whoami view for an active customer profile.
+#
+# Usage: render-whoami.sh <data-root> <customer>
+# Stdout: multi-line context summary on success.
+# Stderr: error messages only.
+# Exit 0: success.
+# Exit 1: profile not found or invalid customer id.
+# Exit 2: schema violation from loader.
+# Exit 3: runtime error from loader.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+data_root="${1:?usage: render-whoami.sh <data-root> <customer>}"
+customer="${2:?usage: render-whoami.sh <data-root> <customer>}"
+
+# --- load and validate profile (propagates loader exit codes) ---------------
+profile_json="$("${SCRIPT_DIR}/load-profile.sh" "$data_root" "$customer")"
+
+# --- render human-readable summary ------------------------------------------
+# Pass profile_json as argv[2] to avoid the pipe-vs-heredoc conflict (SC2259).
+python3 - "$customer" "$profile_json" <<'PY'
+import json, sys
+
+customer_arg = sys.argv[1]
+data = json.loads(sys.argv[2])
+
+def get(obj, *keys, default="-"):
+    """Safely traverse nested dicts; return default on any missing key."""
+    for key in keys:
+        if not isinstance(obj, dict):
+            return default
+        obj = obj.get(key)
+        if obj is None:
+            return default
+    return str(obj) if obj is not None else default
+
+cust       = data.get("customer", {})
+eng        = data.get("engagement", {})
+comp       = data.get("compliance", {})
+safety     = data.get("safety", {})
+
+cust_id       = get(cust,  "id",           default=customer_arg)
+display_name  = get(cust,  "display_name")
+eng_id        = get(eng,   "id")
+eng_type      = get(eng,   "type")
+sow_ref       = get(eng,   "sow_ref")
+start_date    = get(eng,   "start_date")
+end_date      = get(eng,   "end_date")
+regime        = get(comp,  "regime")
+ev_schema_ver = get(comp,  "evidence_schema_version")
+posture       = get(safety, "default_posture")
+scope_enf     = get(safety, "scope_enforcement")
+cw_required   = get(safety, "change_window_required")
+
+# scope_tags is a list; join with ", "
+raw_tags = eng.get("scope_tags")
+if isinstance(raw_tags, list) and raw_tags:
+    scope_tags = ", ".join(str(t) for t in raw_tags)
+elif isinstance(raw_tags, str) and raw_tags:
+    scope_tags = raw_tags
+else:
+    scope_tags = "-"
+
+print(f"yci: active customer = {cust_id}")
+print(f"  display name   : {display_name}")
+print(f"  engagement     : {eng_id} ({eng_type}, SOW {sow_ref})")
+print(f"  dates          : {start_date} → {end_date}")
+print(f"  compliance     : {regime} (evidence schema v{ev_schema_ver})")
+print(f"  safety posture : {posture}  (scope: {scope_enf}, change-window-required: {cw_required})")
+print(f"  scope tags     : {scope_tags}")
+PY

--- a/yci/skills/customer-profile/scripts/resolve-customer.sh
+++ b/yci/skills/customer-profile/scripts/resolve-customer.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# yci — resolve active customer id via 4-tier precedence chain.
+#
+# Tiers (first non-empty, valid id wins):
+#   1. $YCI_CUSTOMER           (env var; trimmed; must match [a-z0-9][a-z0-9-]*)
+#   2. .yci-customer dotfile   (walk up from $PWD, stop at $HOME or /)
+#   3. state.json .active      (<data-root>/state.json)
+#   4. refuse with error       (exit 1)
+#
+# Usage: resolve-customer.sh [--data-root <path>]
+# Stdout: customer id string (no trailing whitespace) on success.
+# Stderr: diagnostic messages on error.
+# Exit 0: success — customer id printed to stdout.
+# Exit 1: no customer resolved, or invalid id format.
+#
+# See yci/skills/customer-profile/references/precedence.md for the authoritative spec.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+SHARED_DIR="${SCRIPT_DIR}/../../_shared/scripts"
+
+# shellcheck source=/dev/null
+source "${SHARED_DIR}/resolve-data-root.sh"
+
+readonly YCI_ID_RE='^[a-z0-9][a-z0-9-]*$'
+
+# NOTE on reserved ids (_internal, _template):
+# These ids start with '_', which already fails YCI_ID_RE (requires [a-z0-9] first char).
+# If the regex is ever relaxed, reserved ids MUST remain blocked — see init-reserved-id
+# in error-messages.md for the init-side policy. Resolver behavior: skip (fall through),
+# not an error — a stale env var or dotfile should not abort the session.
+
+yci_trim() {
+    # Strip leading and trailing whitespace.
+    local s="$1"
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+yci_validate_id() {
+    # Return 0 if id matches [a-z0-9][a-z0-9-]*; 1 otherwise.
+    [[ "$1" =~ $YCI_ID_RE ]]
+}
+
+yci_read_dotfile_line() {
+    # Read the first non-empty, non-comment, trimmed line from a dotfile.
+    # Returns 0 and prints the line on success; returns 1 if no usable line found.
+    local file="$1" line trimmed
+    [ -r "$file" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in \#*) continue ;; esac
+        trimmed="$(yci_trim "$line")"
+        [ -z "$trimmed" ] && continue
+        printf '%s' "$trimmed"
+        return 0
+    done < "$file"
+    return 1
+}
+
+yci_walkup_dotfile() {
+    # Walk from $PWD upward looking for .yci-customer dotfiles.
+    # $HOME is checked (inclusive); the walk never ascends past $HOME.
+    # Prints the customer id and returns 0 on success; returns 1 if not found.
+    local dir home_abs candidate
+    dir="$(pwd -P)"
+    home_abs="${HOME:-/}"
+    home_abs="$(cd "$home_abs" 2>/dev/null && pwd -P || printf '%s' "$home_abs")"
+
+    while :; do
+        if [ -f "$dir/.yci-customer" ]; then
+            if candidate="$(yci_read_dotfile_line "$dir/.yci-customer")"; then
+                printf '%s' "$candidate"
+                return 0
+            fi
+            # File has no usable lines — continue walking up
+        fi
+        # Stop AFTER checking $HOME; never ascend past it
+        [ "$dir" = "$home_abs" ] && break
+        [ "$dir" = "/" ] && break
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+yci_read_state_active() {
+    # Read .active from <data-root>/state.json via embedded Python.
+    # Prints the trimmed value and returns 0 on success; returns 1 otherwise.
+    local state_path="${1}/state.json"
+    [ -f "$state_path" ] || return 1
+    python3 - "$state_path" 2>/dev/null <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(1)
+active = data.get("active")
+if isinstance(active, str) and active.strip():
+    print(active.strip(), end="")
+else:
+    sys.exit(1)
+PY
+}
+
+yci_emit_invalid_id() {
+    # Emit resolver-invalid-id-format (exit 1) — error-messages.md verbatim.
+    local id="$1"
+    printf "yci: invalid customer id: '%s'\n" "$id" >&2
+    printf '  allowed pattern: [a-z0-9][a-z0-9-]*  (lowercase, hyphens only)\n' >&2
+    printf 'Check $YCI_CUSTOMER, your .yci-customer dotfile, or state.json .active field.\n' >&2
+}
+
+yci_emit_refusal() {
+    # Emit resolver-no-active-customer (exit 1) — error-messages.md verbatim.
+    # Args: <data_root> <env_status>
+    # env_status is "unset" or "empty (whitespace-only)"
+    local data_root="$1" env_status="$2"
+    local cwd stop_at
+    cwd="$(pwd -P)"
+    stop_at="$(cd "${HOME:-/}" 2>/dev/null && pwd -P || printf '/')"
+    printf 'yci: no active customer.\n' >&2
+    printf '  $YCI_CUSTOMER: %s\n' "$env_status" >&2
+    printf '  .yci-customer: not found (searched from %s up to %s)\n' "$cwd" "$stop_at" >&2
+    printf '  state.json: no active customer at %s/state.json\n' "$data_root" >&2
+    printf 'Run `/yci:init <customer>` to create a profile, or `/yci:switch <customer>` to activate one.\n' >&2
+}
+
+main() {
+    local data_root env_status="unset"
+    data_root="$(yci_resolve_data_root "$@")"
+
+    # Tier 1 — $YCI_CUSTOMER env var
+    if [ -n "${YCI_CUSTOMER+x}" ]; then
+        # Variable is set (possibly empty or whitespace-only)
+        local env_id
+        env_id="$(yci_trim "${YCI_CUSTOMER}")"
+        if [ -n "$env_id" ]; then
+            if yci_validate_id "$env_id"; then
+                printf '%s\n' "$env_id"
+                return 0
+            else
+                # Set, non-empty after trim, but invalid format — hard error (exit 1).
+                yci_emit_invalid_id "$env_id"
+                return 1
+            fi
+        fi
+        # Variable is set but empty or whitespace-only — fall through
+        env_status="empty (whitespace-only)"
+    fi
+
+    # Tier 2 — .yci-customer dotfile walk-up
+    local dotfile_id
+    if dotfile_id="$(yci_walkup_dotfile)"; then
+        if yci_validate_id "$dotfile_id"; then
+            printf '%s\n' "$dotfile_id"
+            return 0
+        else
+            # Dotfile contains an invalid id — surface the format error (exit 1).
+            yci_emit_invalid_id "$dotfile_id"
+            return 1
+        fi
+    fi
+
+    # Tier 3 — state.json .active (MRU)
+    local mru_id
+    if mru_id="$(yci_read_state_active "$data_root")"; then
+        if yci_validate_id "$mru_id"; then
+            printf '%s\n' "$mru_id"
+            return 0
+        else
+            yci_emit_invalid_id "$mru_id"
+            return 1
+        fi
+    fi
+
+    # Tier 4 — refuse
+    yci_emit_refusal "$data_root" "$env_status"
+    return 1
+}
+
+main "$@"

--- a/yci/skills/customer-profile/scripts/state-io.sh
+++ b/yci/skills/customer-profile/scripts/state-io.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# yci — state.json I/O library (source this file; do not execute directly).
+#
+# Provides atomic read/write of <data-root>/state.json. Uses python3 for JSON
+# parsing/serialization to avoid jq dependency.
+#
+# Public functions:
+#   state_read            <data-root>
+#   state_get_active      <data-root>
+#   state_write_active    <data-root> <customer-id>
+#   state_push_mru        <data-root> <customer-id> [--cap N]
+
+# Do NOT set -euo pipefail at file scope — that breaks sourcing scripts that
+# don't expect strict mode. Callers enable strict mode themselves.
+
+readonly YCI_STATE_MRU_DEFAULT_CAP=20
+
+_yci_state_path() {
+    printf '%s' "$1/state.json"
+}
+
+_yci_state_iso_now() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+_yci_state_ensure_dir() {
+    local data_root="$1"
+    if [ ! -d "$data_root" ]; then
+        printf 'yci: data root directory missing: %s\n' "$data_root" >&2
+        return 3
+    fi
+    if [ ! -w "$data_root" ]; then
+        local path; path="$(_yci_state_path "$data_root")"
+        printf 'yci: cannot write state file: %s\n  permission denied — check directory ownership and mode (expected 0700)\n' "$path" >&2
+        return 3
+    fi
+    return 0
+}
+
+# state_read <data-root>
+# Prints the full state.json to stdout as JSON. Exits 0 if present & valid,
+# returns 1 if missing (prints empty {"active":null,"mru":[]}), exits 2 on corrupt JSON.
+state_read() {
+    local data_root="${1:?state_read requires <data-root>}"
+    local path; path="$(_yci_state_path "$data_root")"
+    if [ ! -f "$path" ]; then
+        printf '%s\n' '{"active":null,"mru":[]}'
+        return 1
+    fi
+    python3 - "$path" <<'PY'
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        data = json.load(f)
+except Exception as e:
+    sys.stderr.write(f"yci: corrupt state file: {path}\n  state.json failed JSON parse — delete or repair the file to continue\n")
+    sys.exit(2)
+if not isinstance(data, dict):
+    sys.stderr.write(f"yci: corrupt state file: {path}\n  state.json failed JSON parse — delete or repair the file to continue\n")
+    sys.exit(2)
+data.setdefault("active", None)
+data.setdefault("mru", [])
+if not isinstance(data["mru"], list):
+    data["mru"] = []
+print(json.dumps(data))
+PY
+}
+
+# state_get_active <data-root>
+# Prints .active value to stdout (empty line if absent). Exit 0 if file missing (treats as "no active"),
+# exit 2 if file is corrupt JSON.
+state_get_active() {
+    local data_root="${1:?state_get_active requires <data-root>}"
+    local path; path="$(_yci_state_path "$data_root")"
+    if [ ! -f "$path" ]; then
+        printf '\n'
+        return 0
+    fi
+    python3 - "$path" <<'PY'
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        data = json.load(f)
+except Exception as e:
+    sys.stderr.write(f"yci: corrupt state file: {path}\n  state.json failed JSON parse — delete or repair the file to continue\n")
+    sys.exit(2)
+active = data.get("active") if isinstance(data, dict) else None
+print(active if isinstance(active, str) else "")
+PY
+}
+
+_yci_state_write_atomic() {
+    # _yci_state_write_atomic <data-root> <json-body>
+    local data_root="$1" body="$2"
+    _yci_state_ensure_dir "$data_root" || return 3
+    local path; path="$(_yci_state_path "$data_root")"
+    local tmp
+    tmp="$(mktemp "${data_root}/.state.json.XXXXXX")" || {
+        printf 'yci: cannot write state file: %s\n  permission denied — check directory ownership and mode (expected 0700)\n' "$path" >&2
+        return 3
+    }
+    # ensure cleanup on interrupt
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmp'" EXIT INT TERM
+    if ! printf '%s\n' "$body" > "$tmp"; then
+        rm -f "$tmp"
+        trap - EXIT INT TERM
+        printf 'yci: cannot write state file: %s\n  permission denied — check directory ownership and mode (expected 0700)\n' "$path" >&2
+        return 3
+    fi
+    chmod 0600 "$tmp" 2>/dev/null || true
+    if ! mv -f "$tmp" "$path"; then
+        rm -f "$tmp"
+        trap - EXIT INT TERM
+        printf 'yci: cannot write state file: %s\n  permission denied — check directory ownership and mode (expected 0700)\n' "$path" >&2
+        return 3
+    fi
+    trap - EXIT INT TERM
+    return 0
+}
+
+# state_write_active <data-root> <customer-id>
+# Sets .active=<customer-id> and pushes to MRU (dedupe + cap 20). Writes atomically.
+# Updates .updated_at to current ISO-8601 UTC. Exit 3 on permission-denied.
+state_write_active() {
+    local data_root="${1:?state_write_active requires <data-root>}"
+    local customer_id="${2:?state_write_active requires <customer-id>}"
+    local cap="${YCI_STATE_MRU_CAP:-$YCI_STATE_MRU_DEFAULT_CAP}"
+    local now; now="$(_yci_state_iso_now)"
+    local current; current="$(state_read "$data_root" 2>/dev/null)" || current='{"active":null,"mru":[]}'
+    local body
+    # Pass current JSON as argv[4] to avoid stdin conflict with the heredoc.
+    body="$(python3 - "$customer_id" "$now" "$cap" "$current" <<'PY'
+import json, sys
+customer, now, cap, current_json = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
+try:
+    data = json.loads(current_json)
+except Exception:
+    data = {"active": None, "mru": []}
+mru = [m for m in data.get("mru", []) if isinstance(m, str) and m != customer]
+mru.insert(0, customer)
+mru = mru[:cap]
+out = {"active": customer, "mru": mru, "updated_at": now}
+print(json.dumps(out, indent=2, sort_keys=True))
+PY
+)"
+    _yci_state_write_atomic "$data_root" "$body"
+}
+
+# state_push_mru <data-root> <customer-id> [--cap N]
+# Pushes <customer-id> to front of .mru (dedupe, cap N; default 20). Does NOT change .active.
+# Atomic write. Exit 3 on permission-denied.
+state_push_mru() {
+    local data_root="${1:?state_push_mru requires <data-root>}"
+    local customer_id="${2:?state_push_mru requires <customer-id>}"
+    shift 2
+    local cap="$YCI_STATE_MRU_DEFAULT_CAP"
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --cap) cap="${2:-$YCI_STATE_MRU_DEFAULT_CAP}"; shift 2 ;;
+            --cap=*) cap="${1#*=}"; shift ;;
+            *) shift ;;
+        esac
+    done
+    local now; now="$(_yci_state_iso_now)"
+    local current; current="$(state_read "$data_root" 2>/dev/null)" || current='{"active":null,"mru":[]}'
+    local body
+    # Pass current JSON as argv[4] to avoid stdin conflict with the heredoc.
+    body="$(python3 - "$customer_id" "$now" "$cap" "$current" <<'PY'
+import json, sys
+customer, now, cap, current_json = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
+try:
+    data = json.loads(current_json)
+except Exception:
+    data = {"active": None, "mru": []}
+mru = [m for m in data.get("mru", []) if isinstance(m, str) and m != customer]
+mru.insert(0, customer)
+mru = mru[:cap]
+out = dict(data)
+out["mru"] = mru
+out["updated_at"] = now
+print(json.dumps(out, indent=2, sort_keys=True))
+PY
+)"
+    _yci_state_write_atomic "$data_root" "$body"
+}

--- a/yci/skills/customer-profile/scripts/state-io.sh
+++ b/yci/skills/customer-profile/scripts/state-io.sh
@@ -13,7 +13,11 @@
 # Do NOT set -euo pipefail at file scope — that breaks sourcing scripts that
 # don't expect strict mode. Callers enable strict mode themselves.
 
-readonly YCI_STATE_MRU_DEFAULT_CAP=20
+# Guard the readonly decl so repeated sourcing (tests, nested callers) doesn't
+# trip "YCI_STATE_MRU_DEFAULT_CAP: readonly variable" on the second source.
+if [ -z "${YCI_STATE_MRU_DEFAULT_CAP:-}" ]; then
+    readonly YCI_STATE_MRU_DEFAULT_CAP=20
+fi
 
 _yci_state_path() {
     printf '%s' "$1/state.json"
@@ -161,7 +165,10 @@ state_push_mru() {
         case "$1" in
             --cap) cap="${2:-$YCI_STATE_MRU_DEFAULT_CAP}"; shift 2 ;;
             --cap=*) cap="${1#*=}"; shift ;;
-            *) shift ;;
+            *)
+                printf "yci: state_push_mru: unknown argument: '%s'\n" "$1" >&2
+                return 1
+                ;;
         esac
     done
     local now; now="$(_yci_state_iso_now)"

--- a/yci/skills/customer-profile/scripts/switch-profile.sh
+++ b/yci/skills/customer-profile/scripts/switch-profile.sh
@@ -29,13 +29,19 @@ fi
 # --- load and validate profile (propagates loader exit codes) ---------------
 profile_json="$("${SCRIPT_DIR}/load-profile.sh" "$data_root" "$customer")"
 
-# --- extract summary fields for confirmation line ---------------------------
-engagement_id="$(printf '%s' "$profile_json" | python3 -c \
-    "import json,sys; d=json.load(sys.stdin); print(d.get('engagement',{}).get('id',''))")"
-compliance_regime="$(printf '%s' "$profile_json" | python3 -c \
-    "import json,sys; d=json.load(sys.stdin); print(d.get('compliance',{}).get('regime',''))")"
-default_posture="$(printf '%s' "$profile_json" | python3 -c \
-    "import json,sys; d=json.load(sys.stdin); print(d.get('safety',{}).get('default_posture',''))")"
+# --- extract summary fields for confirmation line (single python3 invocation) ---
+IFS=$'\t' read -r engagement_id compliance_regime default_posture < <(
+    printf '%s' "$profile_json" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+print(
+    d.get("engagement", {}).get("id", ""),
+    d.get("compliance", {}).get("regime", ""),
+    d.get("safety", {}).get("default_posture", ""),
+    sep="\t",
+)
+'
+)
 
 # --- persist active state (propagates state-io exit codes) ------------------
 state_write_active "$data_root" "$customer"

--- a/yci/skills/customer-profile/scripts/switch-profile.sh
+++ b/yci/skills/customer-profile/scripts/switch-profile.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# yci — validate customer id, load profile, persist active state.
+#
+# Usage: switch-profile.sh <data-root> <customer>
+# Stdout: one-line confirmation on success.
+# Stderr: error messages only.
+# Exit 0: success.
+# Exit 1: invalid customer id, or loader reports missing file.
+# Exit 2: schema violation from loader.
+# Exit 3: runtime error from loader or state-io.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/state-io.sh"
+
+data_root="${1:?usage: switch-profile.sh <data-root> <customer>}"
+customer="${2:?usage: switch-profile.sh <data-root> <customer>}"
+
+# --- validate customer id format (init-invalid-customer-id, exit 1) ---------
+if ! [[ "$customer" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    printf "yci: invalid customer id: '%s'\n" "$customer" >&2
+    printf '  allowed pattern: [a-z0-9][a-z0-9-]*  (lowercase, hyphens only)\n' >&2
+    exit 1
+fi
+
+# --- load and validate profile (propagates loader exit codes) ---------------
+profile_json="$("${SCRIPT_DIR}/load-profile.sh" "$data_root" "$customer")"
+
+# --- extract summary fields for confirmation line ---------------------------
+engagement_id="$(printf '%s' "$profile_json" | python3 -c \
+    "import json,sys; d=json.load(sys.stdin); print(d.get('engagement',{}).get('id',''))")"
+compliance_regime="$(printf '%s' "$profile_json" | python3 -c \
+    "import json,sys; d=json.load(sys.stdin); print(d.get('compliance',{}).get('regime',''))")"
+default_posture="$(printf '%s' "$profile_json" | python3 -c \
+    "import json,sys; d=json.load(sys.stdin); print(d.get('safety',{}).get('default_posture',''))")"
+
+# --- persist active state (propagates state-io exit codes) ------------------
+state_write_active "$data_root" "$customer"
+
+# --- confirmation -----------------------------------------------------------
+printf 'yci: switched to %s (%s, %s, %s)\n' \
+    "$customer" "$engagement_id" "$compliance_regime" "$default_posture"

--- a/yci/skills/customer-profile/tests/fixtures/acme-example.yaml
+++ b/yci/skills/customer-profile/tests/fixtures/acme-example.yaml
@@ -1,0 +1,65 @@
+# Golden fixture — fully-populated profile exercising every schema.md field.
+# All enum values are drawn verbatim from profile-schema.sh.
+# Used by: test_render_whoami.sh::test_whoami_full_profile
+
+customer:
+  id: acme
+  display_name: ACME Corporation
+  code: ACM
+  branding:
+    color: '#0055AA'
+    logo_path: '~/customers/acme/logo.png'
+
+engagement:
+  id: eng-acme-2026-q1
+  type: implementation
+  sow_ref: SOW-ACM-2026-001
+  scope_tags:
+    - network-automation
+    - compliance-audit
+  start_date: '2026-01-15'
+  end_date: '2026-06-30'
+
+compliance:
+  regime: hipaa
+  evidence_schema_version: 1
+  baa_reference: BAA-ACM-2026-001
+
+change_window:
+  adapter: json-schedule
+  source: '~/.config/yci/change-windows/acme.json'
+  timezone: America/New_York
+
+inventory:
+  adapter: netbox
+  endpoint: https://netbox.acme.internal
+  credential_ref: vault://ops/acme/netbox
+  path: /api/dcim/devices
+
+approval:
+  adapter: jira
+  endpoint: https://jira.acme.internal
+  credential_ref: vault://ops/acme/jira
+
+vaults:
+  path: op://ACME-Ops/main
+
+deliverable:
+  format:
+    - markdown
+  header_template: 'Deliverable for ACME Corporation — {engagement.id}'
+  handoff_format: git-repo
+  path: /mnt/deliverables/acme
+
+vendor_tooling:
+  - vendor: hashicorp
+    product: terraform
+    version: '1.7'
+  - vendor: redhat
+    product: ansible
+    version: '2.16'
+
+safety:
+  default_posture: review
+  change_window_required: true
+  scope_enforcement: warn

--- a/yci/skills/customer-profile/tests/fixtures/minimal.yaml
+++ b/yci/skills/customer-profile/tests/fixtures/minimal.yaml
@@ -1,0 +1,37 @@
+# Minimal fixture — required fields only, no optional blocks.
+# Tests that render-whoami and load-profile handle absent optional sections.
+# Used by: test_render_whoami.sh::test_whoami_minimal_profile
+
+customer:
+  id: min
+  display_name: Minimal Co
+
+engagement:
+  id: eng-min-01
+  type: discovery
+  sow_ref: SOW-MIN-01
+  scope_tags:
+    - audit
+  start_date: '2026-03-01'
+  end_date: '2026-03-31'
+
+compliance:
+  regime: none
+  evidence_schema_version: 1
+
+inventory:
+  adapter: manual
+
+approval:
+  adapter: none
+
+deliverable:
+  format:
+    - markdown
+  header_template: 'Minimal deliverable'
+  handoff_format: zip
+
+safety:
+  default_posture: review
+  change_window_required: false
+  scope_enforcement: 'off'

--- a/yci/skills/customer-profile/tests/helpers.sh
+++ b/yci/skills/customer-profile/tests/helpers.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Shared test helpers. Source this file from every test_*.sh.
+# Do NOT set -euo here — tests need fine-grained control over exit behavior.
+
+YCI_TEST_PASS=0
+YCI_TEST_FAIL=0
+YCI_TEST_FILE="${BASH_SOURCE[1]##*/}"  # caller's basename
+
+# Resolve key directory paths (tolerates missing dirs — scripts may not yet exist)
+_HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+if cd "${_HELPERS_DIR}/../scripts" 2>/dev/null; then
+    YCI_SCRIPTS_DIR="$(pwd -P)"
+    cd "${_HELPERS_DIR}" || true
+else
+    YCI_SCRIPTS_DIR="${_HELPERS_DIR}/../scripts"
+fi
+export YCI_SCRIPTS_DIR
+
+if cd "${_HELPERS_DIR}/../../_shared/scripts" 2>/dev/null; then
+    YCI_SHARED_DIR="$(pwd -P)"
+    cd "${_HELPERS_DIR}" || true
+else
+    YCI_SHARED_DIR="${_HELPERS_DIR}/../../_shared/scripts"
+fi
+export YCI_SHARED_DIR
+
+if cd "${_HELPERS_DIR}/../references" 2>/dev/null; then
+    YCI_REFS_DIR="$(pwd -P)"
+    cd "${_HELPERS_DIR}" || true
+else
+    YCI_REFS_DIR="${_HELPERS_DIR}/../references"
+fi
+export YCI_REFS_DIR
+
+# ---------------------------------------------------------------------------
+# Internal reporter
+# ---------------------------------------------------------------------------
+
+_yci_test_report() {
+    local status="$1" name="$2" detail="${3:-}"
+    if [ "$status" = "PASS" ]; then
+        YCI_TEST_PASS=$((YCI_TEST_PASS + 1))
+        [ "${YCI_TEST_VERBOSE:-0}" = "1" ] && printf '  \033[32m+\033[0m %s\n' "$name"
+    else
+        YCI_TEST_FAIL=$((YCI_TEST_FAIL + 1))
+        printf '  \033[31mFAIL\033[0m %s\n' "$name" >&2
+        [ -n "$detail" ] && printf '    %s\n' "$detail" >&2
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+assert_eq() {
+    local got="$1" expected="$2" name="${3:-assert_eq}"
+    if [ "$got" = "$expected" ]; then
+        _yci_test_report PASS "$name"
+    else
+        _yci_test_report FAIL "$name" "got='$got' expected='$expected'"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" name="${3:-assert_contains}"
+    case "$haystack" in
+        *"$needle"*) _yci_test_report PASS "$name" ;;
+        *)           _yci_test_report FAIL "$name" "'$needle' not in output" ;;
+    esac
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" name="${3:-assert_not_contains}"
+    case "$haystack" in
+        *"$needle"*) _yci_test_report FAIL "$name" "unexpected '$needle' found in output" ;;
+        *)           _yci_test_report PASS "$name" ;;
+    esac
+}
+
+assert_exit() {
+    local expected="$1" got="$2" name="${3:-assert_exit}"
+    if [ "$got" = "$expected" ]; then
+        _yci_test_report PASS "$name"
+    else
+        _yci_test_report FAIL "$name" "exit got=$got expected=$expected"
+    fi
+}
+
+assert_file_exists() {
+    local path="$1" name="${2:-assert_file_exists}"
+    if [ -f "$path" ]; then
+        _yci_test_report PASS "$name"
+    else
+        _yci_test_report FAIL "$name" "file not found: $path"
+    fi
+}
+
+assert_json_valid() {
+    # Assert that the given file (or string piped to python) is valid JSON.
+    local path="$1" name="${2:-assert_json_valid}"
+    if python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$path" 2>/dev/null; then
+        _yci_test_report PASS "$name"
+    else
+        _yci_test_report FAIL "$name" "invalid JSON in: $path"
+    fi
+}
+
+assert_error_id() {
+    # Match emitted stderr against the canonical message for <id> in error-messages.md.
+    # Matching is lenient: we check that a distinctive phrase from the catalog appears.
+    local id="$1" stderr_content="$2" name="${3:-assert_error_id}"
+    local refs_md="${YCI_REFS_DIR}/error-messages.md"
+    if [ ! -f "$refs_md" ]; then
+        _yci_test_report FAIL "$name" "error-messages.md not found at $refs_md"
+        return
+    fi
+    # Extract the first code-block line inside the entry for this id.
+    local phrase
+    phrase="$(awk -v id="$id" '
+        /^### `/ { in_id = ($0 ~ id) ? 1 : 0 }
+        in_id && /^- \*\*ID\*\*:/ { found_id=1 }
+        found_id && /^```$/ { in_block=!in_block; next }
+        found_id && in_block { print; exit }
+    ' "$refs_md" | sed 's/[<>].*//' | head -1 | tr -d '\n')"
+    if [ -z "$phrase" ]; then
+        _yci_test_report FAIL "$name" "error catalog has no extractable phrase for id '$id'"
+        return
+    fi
+    case "$stderr_content" in
+        *"$phrase"*) _yci_test_report PASS "$name" ;;
+        *)           _yci_test_report FAIL "$name" "expected phrase '$phrase' not in stderr for id '$id'" ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Sandbox helper
+# ---------------------------------------------------------------------------
+
+with_sandbox() {
+    # Usage: with_sandbox <fn-name>
+    # Calls <fn-name> with the sandbox path as its first argument, inside
+    # a subshell cd-ed to $sandbox/cwd. Cleans up on exit.
+    local fn="$1"
+    local sb
+    sb="$(mktemp -d -t yci-test-XXXXXX)"
+    export YCI_TEST_SANDBOX="$sb"
+    mkdir -p "$sb/real" "$sb/home" "$sb/cwd"
+    local saved_home="$HOME"
+    export HOME="$sb/home"
+    export YCI_DATA_ROOT=""
+    export YCI_CUSTOMER=""
+    (
+        cd "$sb/cwd" || exit 1
+        "$fn" "$sb"
+    )
+    local rc=$?
+    export HOME="$saved_home"
+    rm -rf "$sb"
+    unset YCI_TEST_SANDBOX
+    return $rc
+}
+
+# ---------------------------------------------------------------------------
+# Summary — call at the end of every test_*.sh
+# ---------------------------------------------------------------------------
+
+yci_test_summary() {
+    if [ "$YCI_TEST_FAIL" -eq 0 ]; then
+        printf '  %s: %d passed\n' "$YCI_TEST_FILE" "$YCI_TEST_PASS"
+        return 0
+    else
+        printf '  %s: %d passed, %d FAILED\n' "$YCI_TEST_FILE" "$YCI_TEST_PASS" "$YCI_TEST_FAIL" >&2
+        return 1
+    fi
+}

--- a/yci/skills/customer-profile/tests/helpers.sh
+++ b/yci/skills/customer-profile/tests/helpers.sh
@@ -138,26 +138,45 @@ assert_error_id() {
 
 with_sandbox() {
     # Usage: with_sandbox <fn-name>
-    # Calls <fn-name> with the sandbox path as its first argument, inside
-    # a subshell cd-ed to $sandbox/cwd. Cleans up on exit.
+    # Calls <fn-name> with the sandbox path as its first argument. Runs in the
+    # CURRENT shell (not a subshell) so that assertion counters
+    # YCI_TEST_PASS / YCI_TEST_FAIL propagate to yci_test_summary. Save/restore
+    # HOME, YCI_DATA_ROOT, YCI_CUSTOMER, and the working directory around the
+    # call so cross-test state never leaks.
     local fn="$1"
     local sb
     sb="$(mktemp -d -t yci-test-XXXXXX)"
-    export YCI_TEST_SANDBOX="$sb"
     mkdir -p "$sb/real" "$sb/home" "$sb/cwd"
-    local saved_home="$HOME"
+
+    # Save previous env + cwd (use +x for "was the var set at all" vs. empty).
+    local saved_home="${HOME:-}"
+    local saved_dr_set=${YCI_DATA_ROOT+x} saved_dr="${YCI_DATA_ROOT:-}"
+    local saved_cu_set=${YCI_CUSTOMER+x}  saved_cu="${YCI_CUSTOMER:-}"
+    local saved_cwd; saved_cwd="$(pwd -P)"
+
+    export YCI_TEST_SANDBOX="$sb"
     export HOME="$sb/home"
     export YCI_DATA_ROOT=""
     export YCI_CUSTOMER=""
-    (
-        cd "$sb/cwd" || exit 1
-        "$fn" "$sb"
-    )
-    local rc=$?
+
+    local rc=0
+    if cd "$sb/cwd"; then
+        "$fn" "$sb" || rc=$?
+    else
+        rc=1
+    fi
+
+    # Restore cwd first (so cleanup doesn't delete the CWD out from under us).
+    cd "$saved_cwd" || true
+
+    # Restore env vars to their prior state (set vs. unset vs. value).
     export HOME="$saved_home"
+    if [ -n "$saved_dr_set" ]; then export YCI_DATA_ROOT="$saved_dr"; else unset YCI_DATA_ROOT; fi
+    if [ -n "$saved_cu_set" ]; then export YCI_CUSTOMER="$saved_cu";  else unset YCI_CUSTOMER; fi
+
     rm -rf "$sb"
     unset YCI_TEST_SANDBOX
-    return $rc
+    return "$rc"
 }
 
 # ---------------------------------------------------------------------------

--- a/yci/skills/customer-profile/tests/run-all.sh
+++ b/yci/skills/customer-profile/tests/run-all.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# yci customer-profile test runner.
+# Discovers test_*.sh in this directory, runs each in a fresh tmp sandbox,
+# aggregates pass/fail counts, exits non-zero on any failure.
+#
+# Usage:
+#   run-all.sh               # run every test
+#   run-all.sh --verbose     # show per-assertion output
+#   run-all.sh test_foo.sh   # run a specific test file
+
+set -u  # intentional: no -e here; tests handle their own failures
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=/dev/null
+source "${TESTS_DIR}/helpers.sh"
+
+VERBOSE=0
+FILTER=()
+for arg in "$@"; do
+    case "$arg" in
+        --verbose|-v) VERBOSE=1 ;;
+        test_*.sh)    FILTER+=("$arg") ;;
+        *)            printf 'unknown arg: %s\n' "$arg" >&2; exit 2 ;;
+    esac
+done
+export YCI_TEST_VERBOSE=$VERBOSE
+
+if [ "${#FILTER[@]}" -eq 0 ]; then
+    mapfile -t test_files < <(cd "$TESTS_DIR" && ls test_*.sh 2>/dev/null | sort)
+else
+    test_files=("${FILTER[@]}")
+fi
+
+pass=0; fail=0; files_run=0
+for tf in "${test_files[@]}"; do
+    files_run=$((files_run + 1))
+    printf '=== %s ===\n' "$tf"
+    if bash "${TESTS_DIR}/${tf}"; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+    fi
+done
+
+printf '\n'
+printf 'tests: %d files  pass=%d  fail=%d\n' "$files_run" "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/yci/skills/customer-profile/tests/run-all.sh
+++ b/yci/skills/customer-profile/tests/run-all.sh
@@ -8,7 +8,7 @@
 #   run-all.sh --verbose     # show per-assertion output
 #   run-all.sh test_foo.sh   # run a specific test file
 
-set -u  # intentional: no -e here; tests handle their own failures
+set -uo pipefail  # intentional: no -e here; tests handle their own failures
 
 TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=/dev/null
@@ -26,7 +26,10 @@ done
 export YCI_TEST_VERBOSE=$VERBOSE
 
 if [ "${#FILTER[@]}" -eq 0 ]; then
-    mapfile -t test_files < <(cd "$TESTS_DIR" && ls test_*.sh 2>/dev/null | sort)
+    mapfile -t test_files < <(
+        find "$TESTS_DIR" -maxdepth 1 -type f -name 'test_*.sh' -printf '%f\n' 2>/dev/null \
+            | sort
+    )
 else
     test_files=("${FILTER[@]}")
 fi

--- a/yci/skills/customer-profile/tests/test_init_profile.sh
+++ b/yci/skills/customer-profile/tests/test_init_profile.sh
@@ -105,11 +105,7 @@ test_init_respects_data_root_flag() {
     "${YCI_SCRIPTS_DIR}/init-profile.sh" "$alt" flag-test
     rc=$?
     assert_exit 0 "$rc" "init alternate-root: exit 0"
-    if [ -f "$alt/profiles/flag-test.yaml" ]; then
-        assert_eq "yes" "yes" "init alternate-root: file in alt root"
-    else
-        assert_eq "yes" "no" "init alternate-root: file in alt root"
-    fi
+    assert_file_exists "$alt/profiles/flag-test.yaml" "init alternate-root: file in alt root"
 }
 
 # ---------------------------------------------------------------------------

--- a/yci/skills/customer-profile/tests/test_init_profile.sh
+++ b/yci/skills/customer-profile/tests/test_init_profile.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Tests for init-profile.sh
+# Covers: file creation, overwrite guard, --force, id validation, reserved-id
+#         guard, --data-root, file mode (0600), profiles-dir mode (0700).
+#
+# Runtime dependencies:
+#   - helpers.sh  (task 5.2) — provides with_sandbox, assert_*, yci_test_summary
+#   - ${YCI_SCRIPTS_DIR}/init-profile.sh  (task 5.1)
+#
+# shellcheck disable=SC1091
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
+
+# ---------------------------------------------------------------------------
+# test_init_creates_from_template
+#   init-profile.sh should create <data-root>/profiles/<id>.yaml and exit 0.
+# ---------------------------------------------------------------------------
+test_init_creates_from_template() {
+    local sb="$1"
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test
+    rc=$?
+    assert_exit 0 "$rc" "init: exit 0"
+    assert_contains "$(ls "$sb/real/profiles/" 2>/dev/null || true)" \
+        "acme-test.yaml" "init: file created"
+    # file must be 0600
+    local mode
+    mode="$(stat -c %a "$sb/real/profiles/acme-test.yaml" 2>/dev/null \
+        || stat -f %A "$sb/real/profiles/acme-test.yaml")"
+    assert_eq "$mode" "600" "init: file mode 0600"
+}
+
+# ---------------------------------------------------------------------------
+# test_init_refuses_overwrite
+#   A second init without --force must exit 1 and mention "already exists".
+# ---------------------------------------------------------------------------
+test_init_refuses_overwrite() {
+    local sb="$1"
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test >/dev/null
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "init overwrite: exit 1"
+    assert_contains "$(cat "$sb/err")" "already exists" "init overwrite: phrase"
+}
+
+# ---------------------------------------------------------------------------
+# test_init_force_overwrites
+#   --force should allow overwriting an existing profile (exit 0).
+# ---------------------------------------------------------------------------
+test_init_force_overwrites() {
+    local sb="$1"
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test >/dev/null
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test --force || true
+    rc=$?
+    assert_exit 0 "$rc" "init --force: exit 0"
+}
+
+# ---------------------------------------------------------------------------
+# test_init_rejects_uppercase
+#   Uppercase IDs must be rejected with exit 1 and contain "invalid".
+# ---------------------------------------------------------------------------
+test_init_rejects_uppercase() {
+    local sb="$1"
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" ACME 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "init uppercase: exit 1"
+    assert_contains "$(cat "$sb/err")" "invalid" "init uppercase: phrase"
+}
+
+# ---------------------------------------------------------------------------
+# test_init_rejects_leading_hyphen
+#   IDs beginning with '-' must be rejected with exit 1.
+# ---------------------------------------------------------------------------
+test_init_rejects_leading_hyphen() {
+    local sb="$1"
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" -acme 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "init leading-hyphen: exit 1"
+    assert_contains "$(cat "$sb/err")" "invalid" "init leading-hyphen: phrase"
+}
+
+# ---------------------------------------------------------------------------
+# test_init_rejects_reserved
+#   IDs starting with '_' must be rejected unless --allow-reserved is passed.
+# ---------------------------------------------------------------------------
+test_init_rejects_reserved() {
+    local sb="$1"
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" _internal 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "init reserved: exit 1 without --allow-reserved"
+    assert_contains "$(cat "$sb/err")" "reserved" "init reserved: phrase"
+    # with --allow-reserved it should succeed
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" _internal --allow-reserved || true
+    rc=$?
+    assert_exit 0 "$rc" "init reserved: exit 0 with --allow-reserved"
+}
+
+# ---------------------------------------------------------------------------
+# test_init_respects_data_root_flag
+#   Files should land under the provided data-root, not the default.
+# ---------------------------------------------------------------------------
+test_init_respects_data_root_flag() {
+    local sb="$1"
+    local alt="$sb/alternate-root"
+    mkdir -p "$alt"
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$alt" flag-test || true
+    rc=$?
+    assert_exit 0 "$rc" "init alternate-root: exit 0"
+    if [ -f "$alt/profiles/flag-test.yaml" ]; then
+        assert_eq "yes" "yes" "init alternate-root: file in alt root"
+    else
+        assert_eq "yes" "no" "init alternate-root: file in alt root"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# test_init_profiles_dir_mode
+#   The profiles/ directory must be created with mode 0700.
+# ---------------------------------------------------------------------------
+test_init_profiles_dir_mode() {
+    local sb="$1"
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" dirmode-test >/dev/null
+    local mode
+    mode="$(stat -c %a "$sb/real/profiles" 2>/dev/null \
+        || stat -f %A "$sb/real/profiles")"
+    assert_eq "$mode" "700" "init: profiles/ dir mode 0700"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+    with_sandbox test_init_creates_from_template
+    with_sandbox test_init_refuses_overwrite
+    with_sandbox test_init_force_overwrites
+    with_sandbox test_init_rejects_uppercase
+    with_sandbox test_init_rejects_leading_hyphen
+    with_sandbox test_init_rejects_reserved
+    with_sandbox test_init_respects_data_root_flag
+    with_sandbox test_init_profiles_dir_mode
+    yci_test_summary
+}
+
+main

--- a/yci/skills/customer-profile/tests/test_init_profile.sh
+++ b/yci/skills/customer-profile/tests/test_init_profile.sh
@@ -8,7 +8,7 @@
 #   - ${YCI_SCRIPTS_DIR}/init-profile.sh  (task 5.1)
 #
 # shellcheck disable=SC1091
-set -euo pipefail
+# set -euo pipefail (removed: tests need explicit exit-code capture)
 source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
 
 # ---------------------------------------------------------------------------
@@ -36,7 +36,7 @@ test_init_creates_from_template() {
 test_init_refuses_overwrite() {
     local sb="$1"
     "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test >/dev/null
-    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test 2>"$sb/err" || true
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "init overwrite: exit 1"
     assert_contains "$(cat "$sb/err")" "already exists" "init overwrite: phrase"
@@ -49,7 +49,7 @@ test_init_refuses_overwrite() {
 test_init_force_overwrites() {
     local sb="$1"
     "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test >/dev/null
-    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test --force || true
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" acme-test --force
     rc=$?
     assert_exit 0 "$rc" "init --force: exit 0"
 }
@@ -60,7 +60,7 @@ test_init_force_overwrites() {
 # ---------------------------------------------------------------------------
 test_init_rejects_uppercase() {
     local sb="$1"
-    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" ACME 2>"$sb/err" || true
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" ACME 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "init uppercase: exit 1"
     assert_contains "$(cat "$sb/err")" "invalid" "init uppercase: phrase"
@@ -72,7 +72,7 @@ test_init_rejects_uppercase() {
 # ---------------------------------------------------------------------------
 test_init_rejects_leading_hyphen() {
     local sb="$1"
-    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" -acme 2>"$sb/err" || true
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" -acme 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "init leading-hyphen: exit 1"
     assert_contains "$(cat "$sb/err")" "invalid" "init leading-hyphen: phrase"
@@ -84,12 +84,12 @@ test_init_rejects_leading_hyphen() {
 # ---------------------------------------------------------------------------
 test_init_rejects_reserved() {
     local sb="$1"
-    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" _internal 2>"$sb/err" || true
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" _internal 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "init reserved: exit 1 without --allow-reserved"
     assert_contains "$(cat "$sb/err")" "reserved" "init reserved: phrase"
     # with --allow-reserved it should succeed
-    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" _internal --allow-reserved || true
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$sb/real" _internal --allow-reserved
     rc=$?
     assert_exit 0 "$rc" "init reserved: exit 0 with --allow-reserved"
 }
@@ -102,7 +102,7 @@ test_init_respects_data_root_flag() {
     local sb="$1"
     local alt="$sb/alternate-root"
     mkdir -p "$alt"
-    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$alt" flag-test || true
+    "${YCI_SCRIPTS_DIR}/init-profile.sh" "$alt" flag-test
     rc=$?
     assert_exit 0 "$rc" "init alternate-root: exit 0"
     if [ -f "$alt/profiles/flag-test.yaml" ]; then

--- a/yci/skills/customer-profile/tests/test_load_profile.sh
+++ b/yci/skills/customer-profile/tests/test_load_profile.sh
@@ -1,0 +1,595 @@
+#!/usr/bin/env bash
+# Tests for load-profile.sh.
+# Covers: happy path, missing file, malformed YAML, missing required keys,
+# invalid enum values, unknown key warning, pyyaml-missing guard.
+#
+# load-profile.sh lives in the B5.1 worktree; tests reference it by path via
+# SCRIPTS_DIR and tolerate its absence with a diagnostic.
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
+
+LOADER="${YCI_SCRIPTS_DIR}/load-profile.sh"
+
+_loader_missing_diagnostic() {
+    if [ ! -f "$LOADER" ]; then
+        printf 'DIAGNOSTIC: load-profile.sh not found at %s\n' "$LOADER" >&2
+        printf '  (expected after B5.1 merges)\n' >&2
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Happy path — well-formed full profile, all required fields present
+# ---------------------------------------------------------------------------
+test_load_happy_path() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "load_happy: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/acme.yaml" <<'EOF'
+customer:
+  id: acme
+  display_name: "ACME Co"
+engagement:
+  id: eng-001
+  type: implementation
+  sow_ref: SOW-1
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: hipaa
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: manual
+deliverable:
+  format: [markdown]
+  header_template: "Deliv {c}"
+  handoff_format: git-repo
+safety:
+  default_posture: review
+  change_window_required: false
+  scope_enforcement: warn
+EOF
+    local out rc
+    out="$("$LOADER" "$sb/real" acme 2>"$sb/err")"; rc=$?
+    assert_exit 0 "$rc" "load_happy: exit 0"
+    assert_contains "$out" "\"customer\"" "load_happy: JSON has customer key"
+    assert_contains "$out" "\"acme\"" "load_happy: JSON has id value"
+    assert_contains "$out" "\"engagement\"" "load_happy: JSON has engagement"
+}
+
+# ---------------------------------------------------------------------------
+# Happy path with change_window (change_window_required: true)
+# ---------------------------------------------------------------------------
+test_load_happy_with_change_window() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "load_cw: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/bigbank.yaml" <<'EOF'
+customer:
+  id: bigbank
+  display_name: "Big Bank"
+engagement:
+  id: eng-002
+  type: ongoing
+  sow_ref: SOW-2
+  scope_tags: [core, net]
+  start_date: "2026-02-01"
+  end_date: "2027-01-31"
+compliance:
+  regime: sox
+  evidence_schema_version: 1
+inventory:
+  adapter: netbox
+  endpoint: https://netbox.bigbank.internal
+approval:
+  adapter: github-pr
+deliverable:
+  format: [markdown, pdf]
+  header_template: "Report {c}"
+  handoff_format: zip
+safety:
+  default_posture: dry-run
+  change_window_required: true
+  scope_enforcement: block
+change_window:
+  adapter: ical
+  source: https://calendar.bigbank.internal/change-windows.ics
+  timezone: America/Chicago
+EOF
+    local out rc
+    out="$("$LOADER" "$sb/real" bigbank 2>"$sb/err")"; rc=$?
+    assert_exit 0 "$rc" "load_cw: exit 0"
+    assert_contains "$out" "change_window" "load_cw: JSON has change_window"
+}
+
+# ---------------------------------------------------------------------------
+# Missing file → exit 1 with loader-missing-file error
+# ---------------------------------------------------------------------------
+test_missing_file() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "missing_file: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    local rc
+    "$LOADER" "$sb/real" nonexistent >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "missing_file: exit 1"
+    assert_contains "$(cat "$sb/err")" "profile not found" "missing_file: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Malformed YAML → exit 2 with loader-malformed-yaml error
+# ---------------------------------------------------------------------------
+test_malformed_yaml() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "malformed_yaml: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    printf 'customer:\n  id: broken\n  bad: [unclosed\n' > "$sb/real/profiles/broken.yaml"
+    local rc
+    "$LOADER" "$sb/real" broken >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "malformed_yaml: exit 2"
+    assert_contains "$(cat "$sb/err")" "malformed YAML" "malformed_yaml: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Missing required top-level key (customer section absent) → exit 2
+# ---------------------------------------------------------------------------
+test_missing_required_key_customer() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "missing_customer: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/no-customer.yaml" <<'EOF'
+engagement:
+  id: eng-001
+  type: discovery
+  sow_ref: SOW-0
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: commercial
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: manual
+deliverable:
+  format: [markdown]
+  header_template: "Deliv"
+  handoff_format: zip
+safety:
+  default_posture: dry-run
+  change_window_required: false
+  scope_enforcement: off
+EOF
+    local rc
+    "$LOADER" "$sb/real" no-customer >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "missing_customer: exit 2"
+    assert_contains "$(cat "$sb/err")" "missing required field" "missing_customer: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Missing nested required key (engagement.sow_ref absent) → exit 2
+# ---------------------------------------------------------------------------
+test_missing_required_key_engagement() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "missing_sow: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/no-sow.yaml" <<'EOF'
+customer:
+  id: no-sow
+  display_name: "No SOW Co"
+engagement:
+  id: eng-001
+  type: design
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: none
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: none
+deliverable:
+  format: [markdown]
+  header_template: "Deliv"
+  handoff_format: zip
+safety:
+  default_posture: dry-run
+  change_window_required: false
+  scope_enforcement: warn
+EOF
+    local rc
+    "$LOADER" "$sb/real" no-sow >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "missing_sow: exit 2"
+    assert_contains "$(cat "$sb/err")" "missing required field" "missing_sow: error phrase"
+    assert_contains "$(cat "$sb/err")" "sow_ref" "missing_sow: field name in error"
+}
+
+# ---------------------------------------------------------------------------
+# Missing nested required key (safety.scope_enforcement absent) → exit 2
+# ---------------------------------------------------------------------------
+test_missing_required_key_safety() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "missing_scope_enforcement: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/no-scope.yaml" <<'EOF'
+customer:
+  id: no-scope
+  display_name: "No Scope Co"
+engagement:
+  id: eng-001
+  type: design
+  sow_ref: SOW-X
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: none
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: none
+deliverable:
+  format: [markdown]
+  header_template: "Deliv"
+  handoff_format: zip
+safety:
+  default_posture: dry-run
+  change_window_required: false
+EOF
+    local rc
+    "$LOADER" "$sb/real" no-scope >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "missing_scope_enforcement: exit 2"
+    assert_contains "$(cat "$sb/err")" "missing required field" "missing_scope_enforcement: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Invalid enum: compliance.regime → exit 2
+# ---------------------------------------------------------------------------
+test_invalid_enum_regime() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "invalid_regime: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/bad-regime.yaml" <<'EOF'
+customer:
+  id: bad-regime
+  display_name: "Bad Regime Co"
+engagement:
+  id: eng-001
+  type: implementation
+  sow_ref: SOW-1
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: fips-140
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: manual
+deliverable:
+  format: [markdown]
+  header_template: "Deliv"
+  handoff_format: zip
+safety:
+  default_posture: dry-run
+  change_window_required: false
+  scope_enforcement: warn
+EOF
+    local rc
+    "$LOADER" "$sb/real" bad-regime >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "invalid_regime: exit 2"
+    assert_contains "$(cat "$sb/err")" "invalid value" "invalid_regime: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Invalid enum: engagement.type → exit 2
+# ---------------------------------------------------------------------------
+test_invalid_enum_engagement_type() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "invalid_eng_type: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/bad-type.yaml" <<'EOF'
+customer:
+  id: bad-type
+  display_name: "Bad Type Co"
+engagement:
+  id: eng-001
+  type: consulting
+  sow_ref: SOW-1
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: commercial
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: manual
+deliverable:
+  format: [markdown]
+  header_template: "Deliv"
+  handoff_format: zip
+safety:
+  default_posture: dry-run
+  change_window_required: false
+  scope_enforcement: warn
+EOF
+    local rc
+    "$LOADER" "$sb/real" bad-type >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "invalid_eng_type: exit 2"
+    assert_contains "$(cat "$sb/err")" "invalid value" "invalid_eng_type: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Invalid enum: safety.default_posture → exit 2
+# ---------------------------------------------------------------------------
+test_invalid_enum_posture() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "invalid_posture: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/bad-posture.yaml" <<'EOF'
+customer:
+  id: bad-posture
+  display_name: "Bad Posture Co"
+engagement:
+  id: eng-001
+  type: implementation
+  sow_ref: SOW-1
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: commercial
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: manual
+deliverable:
+  format: [markdown]
+  header_template: "Deliv"
+  handoff_format: zip
+safety:
+  default_posture: yolo
+  change_window_required: false
+  scope_enforcement: warn
+EOF
+    local rc
+    "$LOADER" "$sb/real" bad-posture >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "invalid_posture: exit 2"
+    assert_contains "$(cat "$sb/err")" "invalid value" "invalid_posture: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Invalid enum: safety.scope_enforcement → exit 2
+# ---------------------------------------------------------------------------
+test_invalid_enum_scope_enforcement() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "invalid_enforcement: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/bad-enforcement.yaml" <<'EOF'
+customer:
+  id: bad-enforcement
+  display_name: "Bad Enforcement Co"
+engagement:
+  id: eng-001
+  type: implementation
+  sow_ref: SOW-1
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: commercial
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: manual
+deliverable:
+  format: [markdown]
+  header_template: "Deliv"
+  handoff_format: zip
+safety:
+  default_posture: dry-run
+  change_window_required: false
+  scope_enforcement: maybe
+EOF
+    local rc
+    "$LOADER" "$sb/real" bad-enforcement >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "invalid_enforcement: exit 2"
+    assert_contains "$(cat "$sb/err")" "invalid value" "invalid_enforcement: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Invalid enum: deliverable.handoff_format → exit 2
+# ---------------------------------------------------------------------------
+test_invalid_enum_handoff_format() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "invalid_handoff: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/bad-handoff.yaml" <<'EOF'
+customer:
+  id: bad-handoff
+  display_name: "Bad Handoff Co"
+engagement:
+  id: eng-001
+  type: implementation
+  sow_ref: SOW-1
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: commercial
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: manual
+deliverable:
+  format: [markdown]
+  header_template: "Deliv"
+  handoff_format: usb-drive
+safety:
+  default_posture: dry-run
+  change_window_required: false
+  scope_enforcement: warn
+EOF
+    local rc
+    "$LOADER" "$sb/real" bad-handoff >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "invalid_handoff: exit 2"
+    assert_contains "$(cat "$sb/err")" "invalid value" "invalid_handoff: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Unknown top-level key → exit 0 but warning on stderr
+# ---------------------------------------------------------------------------
+test_unknown_key_warning() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "unknown_key: skipped (loader absent)"; return 0; }
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/extra-key.yaml" <<'EOF'
+customer:
+  id: extra-key
+  display_name: "Extra Key Co"
+engagement:
+  id: eng-001
+  type: implementation
+  sow_ref: SOW-1
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: soc2
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: manual
+deliverable:
+  format: [markdown]
+  header_template: "Deliv"
+  handoff_format: git-repo
+safety:
+  default_posture: review
+  change_window_required: false
+  scope_enforcement: warn
+future_field_unknown: some_value
+EOF
+    local out rc
+    out="$("$LOADER" "$sb/real" extra-key 2>"$sb/err")"; rc=$?
+    assert_exit 0 "$rc" "unknown_key: exit 0 (loaded successfully)"
+    assert_contains "$out" "extra-key" "unknown_key: profile loaded"
+    assert_contains "$(cat "$sb/err")" "unknown" "unknown_key: warning on stderr"
+}
+
+# ---------------------------------------------------------------------------
+# All valid enum round-trips: compliance.regime values
+# ---------------------------------------------------------------------------
+_mk_profile() {
+    local sb="$1" id="$2" regime="$3" posture="$4" eng_type="$5" enforcement="$6" handoff="$7"
+    mkdir -p "$sb/real/profiles"
+    cat > "$sb/real/profiles/${id}.yaml" <<EOF
+customer:
+  id: ${id}
+  display_name: "${id} Co"
+engagement:
+  id: eng-001
+  type: ${eng_type}
+  sow_ref: SOW-1
+  scope_tags: [net]
+  start_date: "2026-01-01"
+  end_date: "2026-12-31"
+compliance:
+  regime: ${regime}
+  evidence_schema_version: 1
+inventory:
+  adapter: manual
+approval:
+  adapter: manual
+deliverable:
+  format: [markdown]
+  header_template: "Deliv"
+  handoff_format: ${handoff}
+safety:
+  default_posture: ${posture}
+  change_window_required: false
+  scope_enforcement: ${enforcement}
+EOF
+}
+
+test_enum_roundtrip_hipaa() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "enum_hipaa: skipped (loader absent)"; return 0; }
+    _mk_profile "$sb" hipaa-co hipaa review implementation git-repo warn
+    local rc
+    "$LOADER" "$sb/real" hipaa-co >"$sb/out" 2>"$sb/err"; rc=$?
+    assert_exit 0 "$rc" "enum_hipaa: exit 0"
+}
+
+test_enum_roundtrip_pci() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "enum_pci: skipped (loader absent)"; return 0; }
+    _mk_profile "$sb" pci-co pci dry-run discovery zip block
+    local rc
+    "$LOADER" "$sb/real" pci-co >"$sb/out" 2>"$sb/err"; rc=$?
+    assert_exit 0 "$rc" "enum_pci: exit 0"
+}
+
+test_enum_roundtrip_iso27001() {
+    local sb="$1"
+    _loader_missing_diagnostic || { _yci_test_report PASS "enum_iso: skipped (loader absent)"; return 0; }
+    _mk_profile "$sb" iso-co iso27001 apply ongoing confluence off
+    local rc
+    "$LOADER" "$sb/real" iso-co >"$sb/out" 2>"$sb/err"; rc=$?
+    assert_exit 0 "$rc" "enum_iso: exit 0"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    if [ ! -f "$LOADER" ]; then
+        printf 'DIAGNOSTIC: load-profile.sh not found at %s\n' "$LOADER" >&2
+        printf '  (expected after B5.1 merges)\n' >&2
+    fi
+
+    with_sandbox test_load_happy_path
+    with_sandbox test_load_happy_with_change_window
+    with_sandbox test_missing_file
+    with_sandbox test_malformed_yaml
+    with_sandbox test_missing_required_key_customer
+    with_sandbox test_missing_required_key_engagement
+    with_sandbox test_missing_required_key_safety
+    with_sandbox test_invalid_enum_regime
+    with_sandbox test_invalid_enum_engagement_type
+    with_sandbox test_invalid_enum_posture
+    with_sandbox test_invalid_enum_scope_enforcement
+    with_sandbox test_invalid_enum_handoff_format
+    with_sandbox test_unknown_key_warning
+    with_sandbox test_enum_roundtrip_hipaa
+    with_sandbox test_enum_roundtrip_pci
+    with_sandbox test_enum_roundtrip_iso27001
+    yci_test_summary
+}
+
+main

--- a/yci/skills/customer-profile/tests/test_load_profile.sh
+++ b/yci/skills/customer-profile/tests/test_load_profile.sh
@@ -114,7 +114,7 @@ test_missing_file() {
     _loader_missing_diagnostic || { _yci_test_report PASS "missing_file: skipped (loader absent)"; return 0; }
     mkdir -p "$sb/real/profiles"
     local rc
-    "$LOADER" "$sb/real" nonexistent >"$sb/out" 2>"$sb/err" || true
+    "$LOADER" "$sb/real" nonexistent >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "missing_file: exit 1"
     assert_contains "$(cat "$sb/err")" "profile not found" "missing_file: error phrase"
@@ -129,7 +129,7 @@ test_malformed_yaml() {
     mkdir -p "$sb/real/profiles"
     printf 'customer:\n  id: broken\n  bad: [unclosed\n' > "$sb/real/profiles/broken.yaml"
     local rc
-    "$LOADER" "$sb/real" broken >"$sb/out" 2>"$sb/err" || true
+    "$LOADER" "$sb/real" broken >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "malformed_yaml: exit 2"
     assert_contains "$(cat "$sb/err")" "malformed YAML" "malformed_yaml: error phrase"
@@ -167,7 +167,7 @@ safety:
   scope_enforcement: off
 EOF
     local rc
-    "$LOADER" "$sb/real" no-customer >"$sb/out" 2>"$sb/err" || true
+    "$LOADER" "$sb/real" no-customer >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "missing_customer: exit 2"
     assert_contains "$(cat "$sb/err")" "missing required field" "missing_customer: error phrase"
@@ -207,7 +207,7 @@ safety:
   scope_enforcement: warn
 EOF
     local rc
-    "$LOADER" "$sb/real" no-sow >"$sb/out" 2>"$sb/err" || true
+    "$LOADER" "$sb/real" no-sow >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "missing_sow: exit 2"
     assert_contains "$(cat "$sb/err")" "missing required field" "missing_sow: error phrase"
@@ -248,7 +248,7 @@ safety:
   change_window_required: false
 EOF
     local rc
-    "$LOADER" "$sb/real" no-scope >"$sb/out" 2>"$sb/err" || true
+    "$LOADER" "$sb/real" no-scope >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "missing_scope_enforcement: exit 2"
     assert_contains "$(cat "$sb/err")" "missing required field" "missing_scope_enforcement: error phrase"
@@ -289,7 +289,7 @@ safety:
   scope_enforcement: warn
 EOF
     local rc
-    "$LOADER" "$sb/real" bad-regime >"$sb/out" 2>"$sb/err" || true
+    "$LOADER" "$sb/real" bad-regime >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "invalid_regime: exit 2"
     assert_contains "$(cat "$sb/err")" "invalid value" "invalid_regime: error phrase"
@@ -330,7 +330,7 @@ safety:
   scope_enforcement: warn
 EOF
     local rc
-    "$LOADER" "$sb/real" bad-type >"$sb/out" 2>"$sb/err" || true
+    "$LOADER" "$sb/real" bad-type >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "invalid_eng_type: exit 2"
     assert_contains "$(cat "$sb/err")" "invalid value" "invalid_eng_type: error phrase"
@@ -371,7 +371,7 @@ safety:
   scope_enforcement: warn
 EOF
     local rc
-    "$LOADER" "$sb/real" bad-posture >"$sb/out" 2>"$sb/err" || true
+    "$LOADER" "$sb/real" bad-posture >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "invalid_posture: exit 2"
     assert_contains "$(cat "$sb/err")" "invalid value" "invalid_posture: error phrase"
@@ -412,7 +412,7 @@ safety:
   scope_enforcement: maybe
 EOF
     local rc
-    "$LOADER" "$sb/real" bad-enforcement >"$sb/out" 2>"$sb/err" || true
+    "$LOADER" "$sb/real" bad-enforcement >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "invalid_enforcement: exit 2"
     assert_contains "$(cat "$sb/err")" "invalid value" "invalid_enforcement: error phrase"
@@ -453,7 +453,7 @@ safety:
   scope_enforcement: warn
 EOF
     local rc
-    "$LOADER" "$sb/real" bad-handoff >"$sb/out" 2>"$sb/err" || true
+    "$LOADER" "$sb/real" bad-handoff >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "invalid_handoff: exit 2"
     assert_contains "$(cat "$sb/err")" "invalid value" "invalid_handoff: error phrase"
@@ -505,7 +505,7 @@ EOF
 # All valid enum round-trips: compliance.regime values
 # ---------------------------------------------------------------------------
 _mk_profile() {
-    local sb="$1" id="$2" regime="$3" posture="$4" eng_type="$5" enforcement="$6" handoff="$7"
+    local sb="$1" id="$2" regime="$3" posture="$4" eng_type="$5" handoff="$6" enforcement="$7"
     mkdir -p "$sb/real/profiles"
     cat > "$sb/real/profiles/${id}.yaml" <<EOF
 customer:
@@ -528,11 +528,11 @@ approval:
 deliverable:
   format: [markdown]
   header_template: "Deliv"
-  handoff_format: ${handoff}
+  handoff_format: "${handoff}"
 safety:
-  default_posture: ${posture}
+  default_posture: "${posture}"
   change_window_required: false
-  scope_enforcement: ${enforcement}
+  scope_enforcement: "${enforcement}"
 EOF
 }
 

--- a/yci/skills/customer-profile/tests/test_render_whoami.sh
+++ b/yci/skills/customer-profile/tests/test_render_whoami.sh
@@ -7,7 +7,7 @@
 #   - ${YCI_SCRIPTS_DIR}/render-whoami.sh  (task 5.1)
 #
 # shellcheck disable=SC1091
-set -euo pipefail
+# set -euo pipefail (removed: tests need explicit exit-code capture)
 source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
 
 FIXTURES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/fixtures" && pwd -P 2>/dev/null \
@@ -60,7 +60,7 @@ test_whoami_minimal_profile() {
 test_whoami_missing_profile() {
     local sb="$1"
     "${YCI_SCRIPTS_DIR}/render-whoami.sh" "$sb/real" nonexistent \
-        >/dev/null 2>"$sb/err" || true
+        >/dev/null 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "whoami missing: exit 1"
     assert_contains "$(cat "$sb/err")" "not found" "whoami missing: phrase"

--- a/yci/skills/customer-profile/tests/test_render_whoami.sh
+++ b/yci/skills/customer-profile/tests/test_render_whoami.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Tests for render-whoami.sh
+# Covers: full profile render, minimal profile render, missing profile error.
+#
+# Runtime dependencies:
+#   - helpers.sh  (task 5.2) — provides with_sandbox, assert_*, yci_test_summary
+#   - ${YCI_SCRIPTS_DIR}/render-whoami.sh  (task 5.1)
+#
+# shellcheck disable=SC1091
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
+
+FIXTURES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/fixtures" && pwd -P 2>/dev/null \
+    || printf '%s' "$(dirname "${BASH_SOURCE[0]}")/fixtures")"
+
+# ---------------------------------------------------------------------------
+# _install_fixture <sandbox> <customer-id> <fixture-filename>
+#   Copies a fixture YAML into the sandbox's profiles/ directory.
+# ---------------------------------------------------------------------------
+_install_fixture() {
+    local sb="$1" name="$2" src_file="$3"
+    mkdir -p "$sb/real/profiles"
+    cp "$FIXTURES_DIR/$src_file" "$sb/real/profiles/$name.yaml"
+}
+
+# ---------------------------------------------------------------------------
+# test_whoami_full_profile
+#   Rendering a fully-populated profile must exit 0 and surface key fields.
+# ---------------------------------------------------------------------------
+test_whoami_full_profile() {
+    local sb="$1"
+    _install_fixture "$sb" acme acme-example.yaml
+    local out
+    out="$("${YCI_SCRIPTS_DIR}/render-whoami.sh" "$sb/real" acme)"
+    rc=$?
+    assert_exit 0 "$rc" "whoami full: exit 0"
+    assert_contains "$out" "acme"   "whoami full: shows customer id"
+    assert_contains "$out" "hipaa"  "whoami full: shows compliance regime"
+    assert_contains "$out" "review" "whoami full: shows safety posture"
+}
+
+# ---------------------------------------------------------------------------
+# test_whoami_minimal_profile
+#   Rendering a minimal (required-fields-only) profile must exit 0 and show id.
+# ---------------------------------------------------------------------------
+test_whoami_minimal_profile() {
+    local sb="$1"
+    _install_fixture "$sb" min minimal.yaml
+    local out
+    out="$("${YCI_SCRIPTS_DIR}/render-whoami.sh" "$sb/real" min)"
+    rc=$?
+    assert_exit 0 "$rc" "whoami minimal: exit 0"
+    assert_contains "$out" "min" "whoami minimal: shows customer id"
+}
+
+# ---------------------------------------------------------------------------
+# test_whoami_missing_profile
+#   Requesting a nonexistent profile must exit 1 and say "not found".
+# ---------------------------------------------------------------------------
+test_whoami_missing_profile() {
+    local sb="$1"
+    "${YCI_SCRIPTS_DIR}/render-whoami.sh" "$sb/real" nonexistent \
+        >/dev/null 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "whoami missing: exit 1"
+    assert_contains "$(cat "$sb/err")" "not found" "whoami missing: phrase"
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+    with_sandbox test_whoami_full_profile
+    with_sandbox test_whoami_minimal_profile
+    with_sandbox test_whoami_missing_profile
+    yci_test_summary
+}
+
+main

--- a/yci/skills/customer-profile/tests/test_resolve_customer.sh
+++ b/yci/skills/customer-profile/tests/test_resolve_customer.sh
@@ -24,7 +24,8 @@ test_env_wins() {
     echo beta > "$sb/cwd/.yci-customer"
     echo '{"active":"gamma"}' > "$sb/real/state.json"
     local out rc
-    YCI_CUSTOMER=acme out="$(_run_resolver "$sb/real")"; rc=$?
+    export YCI_CUSTOMER=acme
+    out="$(_run_resolver "$sb/real")"; rc=$?
     assert_exit 0 "$rc" "env_wins: exit 0"
     assert_eq "$out" "acme" "env_wins: output is acme"
 }
@@ -37,7 +38,7 @@ test_dotfile_at_cwd() {
     echo beta > "$sb/cwd/.yci-customer"
     echo '{"active":"gamma"}' > "$sb/real/state.json"
     local out rc
-    YCI_CUSTOMER="" out="$(_run_resolver "$sb/real")"; rc=$?
+    out="$(_run_resolver "$sb/real")"; rc=$?
     assert_exit 0 "$rc" "dotfile_cwd: exit 0"
     assert_eq "$out" "beta" "dotfile_cwd: output is beta"
 }
@@ -51,7 +52,7 @@ test_dotfile_ancestor() {
     mkdir -p "$sb/cwd/nested/deep"
     # Move to deep subdirectory; dotfile is two levels above (within home subtree)
     local out rc
-    YCI_CUSTOMER="" out="$(cd "$sb/cwd/nested/deep" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
+    out="$(cd "$sb/cwd/nested/deep" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
     assert_exit 0 "$rc" "dotfile_ancestor: exit 0"
     assert_eq "$out" "beta" "dotfile_ancestor: output is beta"
 }
@@ -63,7 +64,7 @@ test_mru_only() {
     local sb="$1"
     echo '{"active":"gamma","mru":["gamma"]}' > "$sb/real/state.json"
     local out rc
-    YCI_CUSTOMER="" out="$(_run_resolver "$sb/real")"; rc=$?
+    out="$(_run_resolver "$sb/real")"; rc=$?
     assert_exit 0 "$rc" "mru_only: exit 0"
     assert_eq "$out" "gamma" "mru_only: output is gamma"
 }
@@ -74,7 +75,7 @@ test_mru_only() {
 test_refuse_all_empty() {
     local sb="$1"
     local out rc
-    YCI_CUSTOMER="" out="$(_run_resolver "$sb/real" 2>"$sb/err")"; rc=$?
+    out="$(_run_resolver "$sb/real" 2>"$sb/err")"; rc=$?
     # Redirect stderr through the sandbox file
     "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
@@ -107,7 +108,7 @@ test_empty_env_ignored() {
     local sb="$1"
     echo beta > "$sb/cwd/.yci-customer"
     local out rc
-    YCI_CUSTOMER="" out="$(_run_resolver "$sb/real")"; rc=$?
+    out="$(_run_resolver "$sb/real")"; rc=$?
     assert_exit 0 "$rc" "empty_env: exit 0"
     assert_eq "$out" "beta" "empty_env: falls through to dotfile"
 }
@@ -124,7 +125,7 @@ test_whitespace_dotfile_fallthrough() {
     echo beta > "$sb/cwd/.yci-customer"
     export HOME="$sb/home"
     local out rc
-    YCI_CUSTOMER="" out="$(cd "$sb/cwd/sub" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
+    out="$(cd "$sb/cwd/sub" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
     assert_exit 0 "$rc" "whitespace_dotfile: falls through to ancestor"
     assert_eq "$out" "beta" "whitespace_dotfile: ancestor value beta"
 }
@@ -139,7 +140,7 @@ test_comment_dotfile_fallthrough() {
     echo beta > "$sb/cwd/.yci-customer"
     export HOME="$sb/home"
     local out rc
-    YCI_CUSTOMER="" out="$(cd "$sb/cwd/sub" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
+    out="$(cd "$sb/cwd/sub" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
     assert_exit 0 "$rc" "comment_dotfile: falls through to ancestor"
     assert_eq "$out" "beta" "comment_dotfile: ancestor value beta"
 }
@@ -202,7 +203,8 @@ test_whitespace_only_env() {
     local sb="$1"
     echo beta > "$sb/cwd/.yci-customer"
     local out rc
-    YCI_CUSTOMER="   " out="$(_run_resolver "$sb/real")"; rc=$?
+    export YCI_CUSTOMER="   "
+    out="$(_run_resolver "$sb/real")"; rc=$?
     assert_exit 0 "$rc" "whitespace_env: exit 0"
     assert_eq "$out" "beta" "whitespace_env: falls through to dotfile beta"
 }

--- a/yci/skills/customer-profile/tests/test_resolve_customer.sh
+++ b/yci/skills/customer-profile/tests/test_resolve_customer.sh
@@ -76,7 +76,7 @@ test_refuse_all_empty() {
     local out rc
     YCI_CUSTOMER="" out="$(_run_resolver "$sb/real" 2>"$sb/err")"; rc=$?
     # Redirect stderr through the sandbox file
-    "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "refuse_all: exit 1"
     assert_contains "$(cat "$sb/err")" "no active customer" "refuse_all: refusal phrase"
@@ -94,7 +94,7 @@ test_walkup_stops_at_home() {
     local rc
     "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
-    (cd "$sb/home/project" && "$RESOLVER" --data-root "$sb/real" >"$sb/out2" 2>"$sb/err2") || true
+    (cd "$sb/home/project" && "$RESOLVER" --data-root "$sb/real" >"$sb/out2" 2>"$sb/err2")
     rc=$?
     assert_exit 1 "$rc" "walkup_home: refused (did not ascend past HOME)"
     assert_contains "$(cat "$sb/err2")" "no active customer" "walkup_home: refusal message"
@@ -117,11 +117,12 @@ test_empty_env_ignored() {
 # ---------------------------------------------------------------------------
 test_whitespace_dotfile_fallthrough() {
     local sb="$1"
-    # CWD dotfile is whitespace-only; ancestor (cwd parent) has valid value
-    printf '   \n   \n' > "$sb/cwd/.yci-customer"
-    echo beta > "$sb/home/.yci-customer"
-    export HOME="$sb/home"
+    # Walk from $sb/cwd/sub: first visit $sb/cwd/sub/.yci-customer (whitespace
+    # → skip), then $sb/cwd/.yci-customer (valid → beta wins).
     mkdir -p "$sb/cwd/sub"
+    printf '   \n   \n' > "$sb/cwd/sub/.yci-customer"
+    echo beta > "$sb/cwd/.yci-customer"
+    export HOME="$sb/home"
     local out rc
     YCI_CUSTOMER="" out="$(cd "$sb/cwd/sub" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
     assert_exit 0 "$rc" "whitespace_dotfile: falls through to ancestor"
@@ -133,10 +134,10 @@ test_whitespace_dotfile_fallthrough() {
 # ---------------------------------------------------------------------------
 test_comment_dotfile_fallthrough() {
     local sb="$1"
-    printf '# comment only\n# another comment\n' > "$sb/cwd/.yci-customer"
-    echo beta > "$sb/home/.yci-customer"
-    export HOME="$sb/home"
     mkdir -p "$sb/cwd/sub"
+    printf '# comment only\n# another comment\n' > "$sb/cwd/sub/.yci-customer"
+    echo beta > "$sb/cwd/.yci-customer"
+    export HOME="$sb/home"
     local out rc
     YCI_CUSTOMER="" out="$(cd "$sb/cwd/sub" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
     assert_exit 0 "$rc" "comment_dotfile: falls through to ancestor"
@@ -149,7 +150,7 @@ test_comment_dotfile_fallthrough() {
 test_env_invalid_id_format() {
     local sb="$1"
     local rc
-    YCI_CUSTOMER="ACME" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    YCI_CUSTOMER="ACME" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "env_invalid: exit 1"
     assert_contains "$(cat "$sb/err")" "invalid customer id" "env_invalid: error phrase"
@@ -162,7 +163,7 @@ test_missing_state_json() {
     local sb="$1"
     # sb/real exists but no state.json inside
     local rc
-    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "missing_state: exit 1"
     assert_contains "$(cat "$sb/err")" "no active customer" "missing_state: refusal phrase"
@@ -175,7 +176,7 @@ test_state_json_no_active_field() {
     local sb="$1"
     echo '{}' > "$sb/real/state.json"
     local rc
-    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "state_no_active: exit 1"
     assert_contains "$(cat "$sb/err")" "no active customer" "state_no_active: refusal phrase"
@@ -188,7 +189,7 @@ test_state_json_active_null() {
     local sb="$1"
     echo '{"active":null}' > "$sb/real/state.json"
     local rc
-    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "state_null: exit 1"
     assert_contains "$(cat "$sb/err")" "no active customer" "state_null: refusal phrase"
@@ -225,7 +226,7 @@ test_whitespace_env_shows_empty_hint() {
     local sb="$1"
     # No dotfile, no state — so we see the full refusal with hint
     local rc
-    YCI_CUSTOMER="   " "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    YCI_CUSTOMER="   " "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "ws_env_hint: exit 1"
     assert_contains "$(cat "$sb/err")" "whitespace-only" "ws_env_hint: hint in stderr"
@@ -238,7 +239,7 @@ test_dotfile_invalid_id_format() {
     local sb="$1"
     echo "UPPERCASE_BAD" > "$sb/cwd/.yci-customer"
     local rc
-    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 1 "$rc" "dotfile_invalid: exit 1"
     assert_contains "$(cat "$sb/err")" "invalid customer id" "dotfile_invalid: format error phrase"

--- a/yci/skills/customer-profile/tests/test_resolve_customer.sh
+++ b/yci/skills/customer-profile/tests/test_resolve_customer.sh
@@ -214,7 +214,8 @@ test_multiline_dotfile_first_wins() {
     local sb="$1"
     printf '# comment\nreal-id\nother-id\n' > "$sb/cwd/.yci-customer"
     local out rc
-    YCI_CUSTOMER="" out="$(_run_resolver "$sb/real")"; rc=$?
+    # YCI_CUSTOMER is already exported empty by with_sandbox; no prefix needed.
+    out="$(_run_resolver "$sb/real")"; rc=$?
     assert_exit 0 "$rc" "multiline_dotfile: exit 0"
     assert_eq "$out" "real-id" "multiline_dotfile: first non-comment line wins"
 }

--- a/yci/skills/customer-profile/tests/test_resolve_customer.sh
+++ b/yci/skills/customer-profile/tests/test_resolve_customer.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Tests for resolve-customer.sh — covers every row of precedence.md test-case matrix.
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
+
+RESOLVER="${YCI_SCRIPTS_DIR}/resolve-customer.sh"
+
+_run_resolver() {
+    # _run_resolver <data_root> [extra args...]
+    # Captures stdout; stderr goes to $YCI_TEST_SANDBOX/stderr (caller must set sandbox).
+    local data_root="$1"; shift
+    if [ ! -f "$RESOLVER" ]; then
+        printf 'SKIP: resolver not found at %s\n' "$RESOLVER" >&2
+        return 127
+    fi
+    "$RESOLVER" --data-root "$data_root" "$@" 2>"${YCI_TEST_SANDBOX}/stderr"
+}
+
+# ---------------------------------------------------------------------------
+# Row 1: env wins — $YCI_CUSTOMER=acme, dotfile=beta, state.active=gamma → acme
+# ---------------------------------------------------------------------------
+test_env_wins() {
+    local sb="$1"
+    echo beta > "$sb/cwd/.yci-customer"
+    echo '{"active":"gamma"}' > "$sb/real/state.json"
+    local out rc
+    YCI_CUSTOMER=acme out="$(_run_resolver "$sb/real")"; rc=$?
+    assert_exit 0 "$rc" "env_wins: exit 0"
+    assert_eq "$out" "acme" "env_wins: output is acme"
+}
+
+# ---------------------------------------------------------------------------
+# Row 2: dotfile at cwd — env empty, dotfile=beta at cwd, state.active=gamma → beta
+# ---------------------------------------------------------------------------
+test_dotfile_at_cwd() {
+    local sb="$1"
+    echo beta > "$sb/cwd/.yci-customer"
+    echo '{"active":"gamma"}' > "$sb/real/state.json"
+    local out rc
+    YCI_CUSTOMER="" out="$(_run_resolver "$sb/real")"; rc=$?
+    assert_exit 0 "$rc" "dotfile_cwd: exit 0"
+    assert_eq "$out" "beta" "dotfile_cwd: output is beta"
+}
+
+# ---------------------------------------------------------------------------
+# Row 3: dotfile at ancestor — env empty, no cwd dotfile, ancestor=beta, state=gamma → beta
+# ---------------------------------------------------------------------------
+test_dotfile_ancestor() {
+    local sb="$1"
+    echo beta > "$sb/cwd/.yci-customer"
+    mkdir -p "$sb/cwd/nested/deep"
+    # Move to deep subdirectory; dotfile is two levels above (within home subtree)
+    local out rc
+    YCI_CUSTOMER="" out="$(cd "$sb/cwd/nested/deep" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
+    assert_exit 0 "$rc" "dotfile_ancestor: exit 0"
+    assert_eq "$out" "beta" "dotfile_ancestor: output is beta"
+}
+
+# ---------------------------------------------------------------------------
+# Row 4: mru only — env empty, no dotfile, state.active=gamma → gamma
+# ---------------------------------------------------------------------------
+test_mru_only() {
+    local sb="$1"
+    echo '{"active":"gamma","mru":["gamma"]}' > "$sb/real/state.json"
+    local out rc
+    YCI_CUSTOMER="" out="$(_run_resolver "$sb/real")"; rc=$?
+    assert_exit 0 "$rc" "mru_only: exit 0"
+    assert_eq "$out" "gamma" "mru_only: output is gamma"
+}
+
+# ---------------------------------------------------------------------------
+# Row 5: all empty — env unset, no dotfile, no state.json → refuse (exit 1)
+# ---------------------------------------------------------------------------
+test_refuse_all_empty() {
+    local sb="$1"
+    local out rc
+    YCI_CUSTOMER="" out="$(_run_resolver "$sb/real" 2>"$sb/err")"; rc=$?
+    # Redirect stderr through the sandbox file
+    "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "refuse_all: exit 1"
+    assert_contains "$(cat "$sb/err")" "no active customer" "refuse_all: refusal phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Row 6: walk stops at $HOME — dotfile exists only ABOVE $HOME → refuse (exit 1)
+# ---------------------------------------------------------------------------
+test_walkup_stops_at_home() {
+    local sb="$1"
+    # Put dotfile above HOME (in sb root, not in sb/home subtree)
+    echo outsider > "$sb/.yci-customer"
+    export HOME="$sb/home"
+    mkdir -p "$sb/home/project"
+    local rc
+    "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err"
+    rc=$?
+    (cd "$sb/home/project" && "$RESOLVER" --data-root "$sb/real" >"$sb/out2" 2>"$sb/err2") || true
+    rc=$?
+    assert_exit 1 "$rc" "walkup_home: refused (did not ascend past HOME)"
+    assert_contains "$(cat "$sb/err2")" "no active customer" "walkup_home: refusal message"
+}
+
+# ---------------------------------------------------------------------------
+# Row 7: empty env is ignored — YCI_CUSTOMER="" dotfile=beta → beta
+# ---------------------------------------------------------------------------
+test_empty_env_ignored() {
+    local sb="$1"
+    echo beta > "$sb/cwd/.yci-customer"
+    local out rc
+    YCI_CUSTOMER="" out="$(_run_resolver "$sb/real")"; rc=$?
+    assert_exit 0 "$rc" "empty_env: exit 0"
+    assert_eq "$out" "beta" "empty_env: falls through to dotfile"
+}
+
+# ---------------------------------------------------------------------------
+# Row 8: whitespace-only dotfile at cwd, valid ancestor dotfile=beta → beta
+# ---------------------------------------------------------------------------
+test_whitespace_dotfile_fallthrough() {
+    local sb="$1"
+    # CWD dotfile is whitespace-only; ancestor (cwd parent) has valid value
+    printf '   \n   \n' > "$sb/cwd/.yci-customer"
+    echo beta > "$sb/home/.yci-customer"
+    export HOME="$sb/home"
+    mkdir -p "$sb/cwd/sub"
+    local out rc
+    YCI_CUSTOMER="" out="$(cd "$sb/cwd/sub" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
+    assert_exit 0 "$rc" "whitespace_dotfile: falls through to ancestor"
+    assert_eq "$out" "beta" "whitespace_dotfile: ancestor value beta"
+}
+
+# ---------------------------------------------------------------------------
+# Row 9: comment-only dotfile at cwd, ancestor dotfile=beta → beta
+# ---------------------------------------------------------------------------
+test_comment_dotfile_fallthrough() {
+    local sb="$1"
+    printf '# comment only\n# another comment\n' > "$sb/cwd/.yci-customer"
+    echo beta > "$sb/home/.yci-customer"
+    export HOME="$sb/home"
+    mkdir -p "$sb/cwd/sub"
+    local out rc
+    YCI_CUSTOMER="" out="$(cd "$sb/cwd/sub" && "$RESOLVER" --data-root "$sb/real" 2>"${sb}/stderr")"; rc=$?
+    assert_exit 0 "$rc" "comment_dotfile: falls through to ancestor"
+    assert_eq "$out" "beta" "comment_dotfile: ancestor value beta"
+}
+
+# ---------------------------------------------------------------------------
+# Row 10: invalid id format — YCI_CUSTOMER=ACME (uppercase) → exit 1
+# ---------------------------------------------------------------------------
+test_env_invalid_id_format() {
+    local sb="$1"
+    local rc
+    YCI_CUSTOMER="ACME" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "env_invalid: exit 1"
+    assert_contains "$(cat "$sb/err")" "invalid customer id" "env_invalid: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Row 11: missing state.json — no env, no dotfile, no state.json → refuse (exit 1)
+# ---------------------------------------------------------------------------
+test_missing_state_json() {
+    local sb="$1"
+    # sb/real exists but no state.json inside
+    local rc
+    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "missing_state: exit 1"
+    assert_contains "$(cat "$sb/err")" "no active customer" "missing_state: refusal phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Row 12: state.json with no .active field ({}) → refuse (exit 1)
+# ---------------------------------------------------------------------------
+test_state_json_no_active_field() {
+    local sb="$1"
+    echo '{}' > "$sb/real/state.json"
+    local rc
+    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "state_no_active: exit 1"
+    assert_contains "$(cat "$sb/err")" "no active customer" "state_no_active: refusal phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Row 13: state.json .active=null → refuse (exit 1)
+# ---------------------------------------------------------------------------
+test_state_json_active_null() {
+    local sb="$1"
+    echo '{"active":null}' > "$sb/real/state.json"
+    local rc
+    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "state_null: exit 1"
+    assert_contains "$(cat "$sb/err")" "no active customer" "state_null: refusal phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Row 14: whitespace-only env — YCI_CUSTOMER="   " dotfile=beta → beta
+# ---------------------------------------------------------------------------
+test_whitespace_only_env() {
+    local sb="$1"
+    echo beta > "$sb/cwd/.yci-customer"
+    local out rc
+    YCI_CUSTOMER="   " out="$(_run_resolver "$sb/real")"; rc=$?
+    assert_exit 0 "$rc" "whitespace_env: exit 0"
+    assert_eq "$out" "beta" "whitespace_env: falls through to dotfile beta"
+}
+
+# ---------------------------------------------------------------------------
+# Row 15: multi-line dotfile — first non-comment line wins
+# ---------------------------------------------------------------------------
+test_multiline_dotfile_first_wins() {
+    local sb="$1"
+    printf '# comment\nreal-id\nother-id\n' > "$sb/cwd/.yci-customer"
+    local out rc
+    YCI_CUSTOMER="" out="$(_run_resolver "$sb/real")"; rc=$?
+    assert_exit 0 "$rc" "multiline_dotfile: exit 0"
+    assert_eq "$out" "real-id" "multiline_dotfile: first non-comment line wins"
+}
+
+# ---------------------------------------------------------------------------
+# Extra: whitespace-only env shows hint in stderr
+# ---------------------------------------------------------------------------
+test_whitespace_env_shows_empty_hint() {
+    local sb="$1"
+    # No dotfile, no state — so we see the full refusal with hint
+    local rc
+    YCI_CUSTOMER="   " "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "ws_env_hint: exit 1"
+    assert_contains "$(cat "$sb/err")" "whitespace-only" "ws_env_hint: hint in stderr"
+}
+
+# ---------------------------------------------------------------------------
+# Extra: invalid id in dotfile → exit 1 with format error
+# ---------------------------------------------------------------------------
+test_dotfile_invalid_id_format() {
+    local sb="$1"
+    echo "UPPERCASE_BAD" > "$sb/cwd/.yci-customer"
+    local rc
+    YCI_CUSTOMER="" "$RESOLVER" --data-root "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 1 "$rc" "dotfile_invalid: exit 1"
+    assert_contains "$(cat "$sb/err")" "invalid customer id" "dotfile_invalid: format error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    if [ ! -f "$RESOLVER" ]; then
+        printf 'DIAGNOSTIC: resolver not found at %s — tests will be skipped at runtime\n' "$RESOLVER" >&2
+        printf '  (expected after B5.1 merges)\n' >&2
+    fi
+
+    with_sandbox test_env_wins
+    with_sandbox test_dotfile_at_cwd
+    with_sandbox test_dotfile_ancestor
+    with_sandbox test_mru_only
+    with_sandbox test_refuse_all_empty
+    with_sandbox test_walkup_stops_at_home
+    with_sandbox test_empty_env_ignored
+    with_sandbox test_whitespace_dotfile_fallthrough
+    with_sandbox test_comment_dotfile_fallthrough
+    with_sandbox test_env_invalid_id_format
+    with_sandbox test_missing_state_json
+    with_sandbox test_state_json_no_active_field
+    with_sandbox test_state_json_active_null
+    with_sandbox test_whitespace_only_env
+    with_sandbox test_multiline_dotfile_first_wins
+    with_sandbox test_whitespace_env_shows_empty_hint
+    with_sandbox test_dotfile_invalid_id_format
+    yci_test_summary
+}
+
+main

--- a/yci/skills/customer-profile/tests/test_state_io.sh
+++ b/yci/skills/customer-profile/tests/test_state_io.sh
@@ -8,10 +8,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
 STATE_IO="${YCI_SCRIPTS_DIR}/state-io.sh"
 
 _state_io_missing_diagnostic() {
+    # Fail fast: a missing state-io.sh means the tree is broken. Never skip.
     if [ ! -f "$STATE_IO" ]; then
-        printf 'DIAGNOSTIC: state-io.sh not found at %s\n' "$STATE_IO" >&2
-        printf '  (expected after B5.1/B3 merges)\n' >&2
-        return 1
+        printf 'FATAL: state-io.sh not found at %s\n' "$STATE_IO" >&2
+        printf '  this script is required; missing it means the tree is broken\n' >&2
+        exit 1
     fi
     return 0
 }
@@ -187,6 +188,7 @@ test_missing_state_get_active() {
     local out rc
     out="$(state_get_active "$sb/real" 2>"$sb/err")"; rc=$?
     assert_exit 0 "$rc" "missing_get_active: exit 0 (no file is ok)"
+    assert_eq "$out" "" "missing_get_active: stdout is empty (no file → no active)"
 }
 
 # ---------------------------------------------------------------------------
@@ -231,15 +233,31 @@ test_concurrent_writes() {
     local sb="$1"
     _state_io_missing_diagnostic || { _yci_test_report PASS "concurrent: skipped (absent)"; return 0; }
 
-    local i
+    local i pid
+    local -a pids=()
     for i in $(seq 1 5); do
         (
             # shellcheck source=/dev/null
             source "$STATE_IO"
             state_write_active "$sb/real" "writer-$i"
         ) &
+        pids+=("$!")
     done
-    wait
+
+    # Wait on each writer individually so a single failure is detected; bare
+    # `wait` only returns the last child's status and masks earlier failures.
+    local failed=0 writer_rc
+    for pid in "${pids[@]}"; do
+        if wait "$pid"; then
+            writer_rc=0
+        else
+            writer_rc=$?
+            printf '  writer pid=%s exited %d\n' "$pid" "$writer_rc" >&2
+            failed=1
+        fi
+    done
+
+    assert_eq "$failed" "0" "concurrent: all writers exited 0"
     assert_json_valid "$sb/real/state.json" "concurrent: state.json is valid JSON after concurrent writes"
 }
 
@@ -263,8 +281,9 @@ test_updated_at_set() {
 
 main() {
     if [ ! -f "$STATE_IO" ]; then
-        printf 'DIAGNOSTIC: state-io.sh not found at %s\n' "$STATE_IO" >&2
-        printf '  (expected after B3/B5 merges)\n' >&2
+        printf 'FATAL: state-io.sh not found at %s\n' "$STATE_IO" >&2
+        printf '  this script is required; missing it means the tree is broken\n' >&2
+        exit 1
     fi
 
     with_sandbox test_write_read_roundtrip

--- a/yci/skills/customer-profile/tests/test_state_io.sh
+++ b/yci/skills/customer-profile/tests/test_state_io.sh
@@ -97,12 +97,12 @@ test_push_mru_dedupe() {
     state_push_mru "$sb/real" beta
     state_push_mru "$sb/real" gamma
     state_push_mru "$sb/real" beta
-    # beta should appear exactly once (moved to front)
-    local mru_json
-    mru_json="$(python3 -c "import json; d=json.load(open('$sb/real/state.json')); print(d['mru'])")"
-    local count
+    # beta should appear exactly once and be at the front after the second push
+    local front count
+    front="$(python3 -c "import json; d=json.load(open('$sb/real/state.json')); print(d['mru'][0])")"
     count="$(python3 -c "import json; d=json.load(open('$sb/real/state.json')); print(d['mru'].count('beta'))")"
-    assert_eq "$count" "1" "push_mru_dedupe: beta appears exactly once"
+    assert_eq "$count" "1"    "push_mru_dedupe: beta appears exactly once"
+    assert_eq "$front" "beta" "push_mru_dedupe: beta moved to front"
     # active still unchanged
     local active
     active="$(state_get_active "$sb/real")"

--- a/yci/skills/customer-profile/tests/test_state_io.sh
+++ b/yci/skills/customer-profile/tests/test_state_io.sh
@@ -138,7 +138,7 @@ test_corrupt_json() {
     mkdir -p "$sb/real"
     printf '{ not valid json at all\n' > "$sb/real/state.json"
     local rc
-    state_get_active "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    state_get_active "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "corrupt_json: exit 2"
     assert_contains "$(cat "$sb/err")" "corrupt state file" "corrupt_json: error phrase"
@@ -155,7 +155,7 @@ test_corrupt_json_state_read() {
     mkdir -p "$sb/real"
     printf 'TRUNCATED GARBAGE' > "$sb/real/state.json"
     local rc
-    state_read "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    state_read "$sb/real" >"$sb/out" 2>"$sb/err"
     rc=$?
     assert_exit 2 "$rc" "corrupt_read: exit 2"
     assert_contains "$(cat "$sb/err")" "corrupt state file" "corrupt_read: error phrase"
@@ -201,7 +201,7 @@ test_write_permission_denied() {
     mkdir -p "$sb/real"
     chmod 0500 "$sb/real"
     local rc
-    state_write_active "$sb/real" acme >"$sb/out" 2>"$sb/err" || true
+    state_write_active "$sb/real" acme >"$sb/out" 2>"$sb/err"
     rc=$?
     # restore before cleanup
     chmod 0700 "$sb/real"

--- a/yci/skills/customer-profile/tests/test_state_io.sh
+++ b/yci/skills/customer-profile/tests/test_state_io.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Tests for state-io.sh — covers read/write round-trip, MRU dedupe, MRU cap,
+# push_mru doesn't change active, corrupt JSON, atomic concurrency,
+# and write-permission-denied error.
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/helpers.sh"
+
+STATE_IO="${YCI_SCRIPTS_DIR}/state-io.sh"
+
+_state_io_missing_diagnostic() {
+    if [ ! -f "$STATE_IO" ]; then
+        printf 'DIAGNOSTIC: state-io.sh not found at %s\n' "$STATE_IO" >&2
+        printf '  (expected after B5.1/B3 merges)\n' >&2
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# write → read round-trip
+# ---------------------------------------------------------------------------
+test_write_read_roundtrip() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "state_roundtrip: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    state_write_active "$sb/real" acme
+    local got
+    got="$(state_get_active "$sb/real")"
+    assert_eq "$got" "acme" "state_roundtrip: write→read active"
+    assert_file_exists "$sb/real/state.json" "state_roundtrip: state.json created"
+}
+
+# ---------------------------------------------------------------------------
+# MRU dedupe — writing same id multiple times keeps only one entry
+# ---------------------------------------------------------------------------
+test_mru_dedupe() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "mru_dedupe: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    state_write_active "$sb/real" acme
+    state_write_active "$sb/real" beta
+    state_write_active "$sb/real" acme
+    local mru
+    mru="$(python3 -c "import json; print(','.join(json.load(open('$sb/real/state.json'))['mru']))")"
+    assert_eq "$mru" "acme,beta" "mru_dedupe: acme deduplicated to front"
+}
+
+# ---------------------------------------------------------------------------
+# MRU cap — writing 25 customers trims MRU to 20
+# ---------------------------------------------------------------------------
+test_mru_cap() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "mru_cap: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    local i
+    for i in $(seq 1 25); do
+        state_write_active "$sb/real" "cust-$i"
+    done
+    local n
+    n="$(python3 -c "import json; print(len(json.load(open('$sb/real/state.json'))['mru']))")"
+    assert_eq "$n" "20" "mru_cap: MRU trimmed to 20"
+    local active
+    active="$(state_get_active "$sb/real")"
+    assert_eq "$active" "cust-25" "mru_cap: active is the last written"
+}
+
+# ---------------------------------------------------------------------------
+# push_mru does NOT change .active
+# ---------------------------------------------------------------------------
+test_push_mru_no_active_change() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "push_mru_no_change: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    state_write_active "$sb/real" acme
+    state_push_mru "$sb/real" beta
+    local active
+    active="$(state_get_active "$sb/real")"
+    assert_eq "$active" "acme" "push_mru_no_change: active remains acme"
+    local mru
+    mru="$(python3 -c "import json; print(','.join(json.load(open('$sb/real/state.json'))['mru']))")"
+    assert_contains "$mru" "beta" "push_mru_no_change: beta appears in MRU"
+}
+
+# ---------------------------------------------------------------------------
+# push_mru deduplicates within MRU without touching active
+# ---------------------------------------------------------------------------
+test_push_mru_dedupe() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "push_mru_dedupe: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    state_write_active "$sb/real" acme
+    state_push_mru "$sb/real" beta
+    state_push_mru "$sb/real" gamma
+    state_push_mru "$sb/real" beta
+    # beta should appear exactly once (moved to front)
+    local mru_json
+    mru_json="$(python3 -c "import json; d=json.load(open('$sb/real/state.json')); print(d['mru'])")"
+    local count
+    count="$(python3 -c "import json; d=json.load(open('$sb/real/state.json')); print(d['mru'].count('beta'))")"
+    assert_eq "$count" "1" "push_mru_dedupe: beta appears exactly once"
+    # active still unchanged
+    local active
+    active="$(state_get_active "$sb/real")"
+    assert_eq "$active" "acme" "push_mru_dedupe: active still acme"
+}
+
+# ---------------------------------------------------------------------------
+# push_mru --cap N honours custom cap
+# ---------------------------------------------------------------------------
+test_push_mru_custom_cap() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "push_mru_cap: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    state_write_active "$sb/real" base
+    local i
+    for i in $(seq 1 10); do
+        state_push_mru "$sb/real" "extra-$i" --cap 5
+    done
+    local n
+    n="$(python3 -c "import json; print(len(json.load(open('$sb/real/state.json'))['mru']))")"
+    assert_eq "$n" "5" "push_mru_cap: MRU trimmed to custom cap 5"
+}
+
+# ---------------------------------------------------------------------------
+# Corrupt JSON → state_get_active exits 2
+# ---------------------------------------------------------------------------
+test_corrupt_json() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "corrupt_json: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    mkdir -p "$sb/real"
+    printf '{ not valid json at all\n' > "$sb/real/state.json"
+    local rc
+    state_get_active "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "corrupt_json: exit 2"
+    assert_contains "$(cat "$sb/err")" "corrupt state file" "corrupt_json: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# state_read on corrupt JSON → exits 2
+# ---------------------------------------------------------------------------
+test_corrupt_json_state_read() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "corrupt_read: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    mkdir -p "$sb/real"
+    printf 'TRUNCATED GARBAGE' > "$sb/real/state.json"
+    local rc
+    state_read "$sb/real" >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    assert_exit 2 "$rc" "corrupt_read: exit 2"
+    assert_contains "$(cat "$sb/err")" "corrupt state file" "corrupt_read: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# Missing state.json → state_read returns default, exit 1 (file missing)
+# ---------------------------------------------------------------------------
+test_missing_state_read_default() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "missing_state_read: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    # sb/real exists but no state.json
+    local out rc
+    out="$(state_read "$sb/real" 2>"$sb/err")"; rc=$?
+    assert_exit 1 "$rc" "missing_state_read: exit 1 (file missing)"
+    assert_contains "$out" "null" "missing_state_read: default JSON has null active"
+}
+
+# ---------------------------------------------------------------------------
+# state_get_active on missing file → empty line, exit 0
+# ---------------------------------------------------------------------------
+test_missing_state_get_active() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "missing_get_active: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    local out rc
+    out="$(state_get_active "$sb/real" 2>"$sb/err")"; rc=$?
+    assert_exit 0 "$rc" "missing_get_active: exit 0 (no file is ok)"
+}
+
+# ---------------------------------------------------------------------------
+# Write permission denied → state_write_active exits 3
+# ---------------------------------------------------------------------------
+test_write_permission_denied() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "write_perm: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    # Make the real/ directory read-only
+    mkdir -p "$sb/real"
+    chmod 0500 "$sb/real"
+    local rc
+    state_write_active "$sb/real" acme >"$sb/out" 2>"$sb/err" || true
+    rc=$?
+    # restore before cleanup
+    chmod 0700 "$sb/real"
+    assert_exit 3 "$rc" "write_perm: exit 3"
+    assert_contains "$(cat "$sb/err")" "cannot write state file" "write_perm: error phrase"
+}
+
+# ---------------------------------------------------------------------------
+# JSON validity after multiple writes
+# ---------------------------------------------------------------------------
+test_json_valid_after_writes() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "json_valid_writes: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    local i
+    for i in alpha beta gamma delta; do
+        state_write_active "$sb/real" "$i"
+    done
+    assert_json_valid "$sb/real/state.json" "json_valid_writes: state.json is valid JSON after writes"
+}
+
+# ---------------------------------------------------------------------------
+# Concurrent writes → final file is valid JSON
+# ---------------------------------------------------------------------------
+test_concurrent_writes() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "concurrent: skipped (absent)"; return 0; }
+
+    local i
+    for i in $(seq 1 5); do
+        (
+            # shellcheck source=/dev/null
+            source "$STATE_IO"
+            state_write_active "$sb/real" "writer-$i"
+        ) &
+    done
+    wait
+    assert_json_valid "$sb/real/state.json" "concurrent: state.json is valid JSON after concurrent writes"
+}
+
+# ---------------------------------------------------------------------------
+# updated_at field is set on write
+# ---------------------------------------------------------------------------
+test_updated_at_set() {
+    local sb="$1"
+    _state_io_missing_diagnostic || { _yci_test_report PASS "updated_at: skipped (absent)"; return 0; }
+    # shellcheck source=/dev/null
+    source "$STATE_IO"
+    state_write_active "$sb/real" acme
+    local has_updated
+    has_updated="$(python3 -c "import json; d=json.load(open('$sb/real/state.json')); print('yes' if 'updated_at' in d else 'no')")"
+    assert_eq "$has_updated" "yes" "updated_at: field present after write"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    if [ ! -f "$STATE_IO" ]; then
+        printf 'DIAGNOSTIC: state-io.sh not found at %s\n' "$STATE_IO" >&2
+        printf '  (expected after B3/B5 merges)\n' >&2
+    fi
+
+    with_sandbox test_write_read_roundtrip
+    with_sandbox test_mru_dedupe
+    with_sandbox test_mru_cap
+    with_sandbox test_push_mru_no_active_change
+    with_sandbox test_push_mru_dedupe
+    with_sandbox test_push_mru_custom_cap
+    with_sandbox test_corrupt_json
+    with_sandbox test_corrupt_json_state_read
+    with_sandbox test_missing_state_read_default
+    with_sandbox test_missing_state_get_active
+    with_sandbox test_write_permission_denied
+    with_sandbox test_json_valid_after_writes
+    with_sandbox test_concurrent_writes
+    with_sandbox test_updated_at_set
+    yci_test_summary
+}
+
+main


### PR DESCRIPTION
## Summary

Ships the load-bearing yci customer-context primitive (Issue #27). Adds the `yci:customer-profile` skill and three slash commands (`/yci:switch`, `/yci:whoami`, `/yci:init`) that resolve the active customer via a 4-tier precedence chain, load a schema-validated YAML profile, persist active state + MRU to `state.json`, and scaffold new profiles from a template. Every downstream yci skill will depend on this one — it is the foundation for customer isolation.

Closes #27

## Changes

- `yci/skills/customer-profile/` — `SKILL.md` prompt, 4 reference docs (`schema.md`, `precedence.md`, `error-messages.md`, `_template.yaml`), 7 bash scripts (resolver / state I/O / schema lib / loader / switch / whoami / init)
- `yci/skills/_shared/scripts/resolve-data-root.sh` — shared data-root helper honoring `--data-root` > `$YCI_DATA_ROOT` > `~/.config/yci/`
- `yci/commands/{switch,whoami,init}.md` — thin slash-command wrappers that delegate to the skill
- `yci/skills/customer-profile/tests/` — bash test harness (`run-all.sh`, `helpers.sh`) with 5 test files covering resolver precedence (all 4 tiers + edge cases), loader schema validation, state.json atomicity + MRU, init scaffolding, and whoami rendering. Fixtures at `tests/fixtures/{acme-example,minimal}.yaml`.
- `scripts/validate-yci-skills.sh` — extended with 38 new checks covering SKILL.md frontmatter, references, scripts, commands, test harness invocation, and shellcheck on all 15 shell files. Preserves existing `hello` skill checks verbatim.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Build / CI
- [ ] Chore

## Testing

- [x] Linter passes (`shellcheck --severity=warning` clean on 15 shell files)
- [x] Tests pass (5/5 test files via the new bash harness)
- [x] `npm run lint` passes (lefthook pre-push + pre-commit enforced)
- [x] `./scripts/validate.sh --only yci` — ALL CHECKS PASSED
- [x] `./scripts/validate.sh` (full) — all 6 targets green (`inventory cursor codex opencode json yci`)
- [x] Live end-to-end smoke test — `/yci:init` → edit → `/yci:switch` → `/yci:whoami` plus three refusal paths (no env + dotfile + MRU; invalid env id; init-refuses-overwrite)

### Acceptance criteria (from #27)

- [x] `/yci:switch <customer>` loads YAML from `<data-root>/profiles/<customer>.yaml` and persists active state to `state.json`
- [x] `/yci:whoami` prints customer id, display name, engagement, compliance regime, safety posture
- [x] `/yci:init <customer>` scaffolds from `_template.yaml`; refuses overwrite without `--force`; rejects invalid/reserved ids
- [x] Scope precedence: `$YCI_CUSTOMER` > `.yci-customer` dotfile (walk-up, stops at `$HOME`) > MRU from `state.json` > refuse with canonical error
- [x] Unit tests cover load, precedence (all 4 tiers including edge cases), error paths, and state.json persistence

## Reviewer Notes

- **Load-bearing security surface**: the precedence resolver (`scripts/resolve-customer.sh`) is THE primitive every downstream yci hook will call — precedence bugs here leak cross-customer context. Test coverage in `test_resolve_customer.sh` exercises all 4 tiers and the key edge cases (empty env falls through, whitespace-only dotfile falls through, comment-only dotfile falls through, walk-up stops at `$HOME`, invalid id rejected). PRD §2 / §11.1 are the authoritative specs.
- **Data-root resolution**: no hardcoded `~/.config/yci/` literals in scripts. Everything routes through `yci/skills/_shared/scripts/resolve-data-root.sh` so the follow-up "make data-root configurable" work can land without rewriting.
- **Schema authority**: `references/schema.md` mirrors PRD §5.2; `scripts/profile-schema.sh` is the machine-readable mirror. Drift between them is a validator failure. Loader validates required keys + four enum fields (`compliance.regime`, `safety.default_posture`, `engagement.type`, `safety.scope_enforcement`) plus `deliverable.handoff_format`.
- **No secrets policy (PRD §11.9)**: the template ships only `credential_ref:` pointers. Fixtures and tests never include inline secrets.
- **Phase-0 scope**: Claude-native only. Codex / Cursor / opencode generators still hardcode `ycc` — parameterizing them for yci is Phase 1a (tracked separately).
- **Known cosmetic nit**: `/yci:whoami` renders `change-window-required: False` (Python capitalization from `json.dumps` → bash string). Does not fail any test or block functionality; worth a one-line follow-up.
- **Worktree workflow**: implemented via parallel child worktrees under `~/.claude-worktrees/claude-plugins-yci-customer-profile-*/` across 8 batches (B1–B8), fanned in via `ycc/skills/_shared/scripts/merge-children.sh` with per-batch validation. All child worktrees and branches were cleaned up post-merge.

## Commit audit

30 commits on this branch, all Conventional Commits 1.0.0 compliant. `git log main..HEAD --oneline` from the parent worktree shows the phased landing order:

- B1 foundations: schema / precedence / template references (`docs(yci): …`)
- B2 error-messages reference (`docs(yci): …`)
- B3 core scripts: data-root / resolver / state-io / schema lib (`feat(yci): …`)
- B4 SKILL.md (`feat(yci): …`)
- B5 workflow scripts + tests (`feat(yci): …`)
- B6 slash-command wrappers (`feat(yci): …`)
- B7 validator extension (`feat(yci): …`)
- post-merge fix commit for test-harness bugs + handoff_format enum (`fix(yci): …`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full customer-profile skill (init, switch, whoami), data-root resolution, profile scaffolding, profile loading/validation, state persistence, and human-readable whoami rendering.

* **Documentation**
  * Added command docs, a profile schema/template, precedence rules, and a canonical error catalog.

* **Tests**
  * Added test harness, fixtures, and comprehensive suites covering init, load, render, resolver, and state I/O.

* **Chores**
  * Reworked validator to aggregate per-check ok/warn/fail results and report totals before exiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->