### PR TITLE
build: pin shellcheck 0.10.0 for CI and local lint

### DIFF
--- a/.codex-plugin/ycc/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
+++ b/.codex-plugin/ycc/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+# Resolve which shellcheck binary to run and warn when it differs from .tool-versions.
+# Call after PROJECT_ROOT or REPO_ROOT is set. Defines:
+#   resolve_shellcheck_bin  -> sets SHELLCHECK_BIN, returns 0 on success
+#
+# Preference order: <repo>/tools/shellcheck, $HOME/.local/bin/shellcheck, then PATH.
+
+read_shellcheck_pinned_version() {
+  local root="$1"
+  local f="${root}/.tool-versions"
+  if [[ ! -f "$f" ]]; then
+    echo "shellcheck-resolve: missing ${f}" >&2
+    return 1
+  fi
+  local v
+  v="$(grep -E '^shellcheck[[:space:]]' "$f" | head -n1 | awk '{print $2}')"
+  if [[ -z "$v" ]]; then
+    echo "shellcheck-resolve: no shellcheck version in ${f}" >&2
+    return 1
+  fi
+  printf '%s\n' "$v"
+}
+
+shellcheck_repo_root() {
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    printf '%s\n' "$REPO_ROOT"
+  elif [[ -n "${PROJECT_ROOT:-}" ]]; then
+    printf '%s\n' "$PROJECT_ROOT"
+  else
+    echo "shellcheck-resolve: set REPO_ROOT or PROJECT_ROOT" >&2
+    return 1
+  fi
+}
+
+shellcheck_binary_version() {
+  local bin="$1"
+  "$bin" --version 2>/dev/null | grep -E '^version:' | head -n1 | awk '{print $2}'
+}
+
+resolve_shellcheck_bin() {
+  local root pinned want_ver chosen ver
+  SHELLCHECK_BIN=""
+
+  root="$(shellcheck_repo_root)" || return 1
+  want_ver="$(read_shellcheck_pinned_version "$root")" || return 1
+
+  for chosen in "${root}/tools/shellcheck" "${HOME}/.local/bin/shellcheck"; do
+    if [[ -n "$chosen" && -x "$chosen" ]]; then
+      SHELLCHECK_BIN="$chosen"
+      break
+    fi
+  done
+
+  if [[ -z "$SHELLCHECK_BIN" ]] && command -v shellcheck >/dev/null 2>&1; then
+    SHELLCHECK_BIN="$(command -v shellcheck)"
+  fi
+
+  if [[ -z "$SHELLCHECK_BIN" ]]; then
+    echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    return 1
+  fi
+
+  ver="$(shellcheck_binary_version "$SHELLCHECK_BIN")"
+  if [[ -n "$ver" && "$ver" != "$want_ver" ]]; then
+    echo "warn: using system shellcheck ${ver}; pinned version is ${want_ver} (install via scripts/install-shellcheck.sh)" >&2
+  fi
+
+  return 0
+}

--- a/.codex-plugin/ycc/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
+++ b/.codex-plugin/ycc/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
@@ -3,20 +3,25 @@
 # Call after PROJECT_ROOT or REPO_ROOT is set. Defines:
 #   resolve_shellcheck_bin  -> sets SHELLCHECK_BIN, returns 0 on success
 #
+# If .tool-versions is missing or has no shellcheck line, read_shellcheck_pinned_version
+# succeeds with no output; version comparison is skipped unless a pin is present.
+#
+# When SHELLCHECK_RESOLVE_OPTIONAL is non-empty and no shellcheck binary is found,
+# resolve_shellcheck_bin returns 1 without printing the "Missing required command" message
+# (for optional checks that print their own skip message).
+#
 # Preference order: <repo>/tools/shellcheck, $HOME/.local/bin/shellcheck, then PATH.
 
 read_shellcheck_pinned_version() {
   local root="$1"
   local f="${root}/.tool-versions"
   if [[ ! -f "$f" ]]; then
-    echo "shellcheck-resolve: missing ${f}" >&2
-    return 1
+    return 0
   fi
   local v
   v="$(grep -E '^shellcheck[[:space:]]' "$f" | head -n1 | awk '{print $2}')"
   if [[ -z "$v" ]]; then
-    echo "shellcheck-resolve: no shellcheck version in ${f}" >&2
-    return 1
+    return 0
   fi
   printf '%s\n' "$v"
 }
@@ -38,11 +43,11 @@ shellcheck_binary_version() {
 }
 
 resolve_shellcheck_bin() {
-  local root pinned want_ver chosen ver
+  local root want_ver chosen ver
   SHELLCHECK_BIN=""
 
   root="$(shellcheck_repo_root)" || return 1
-  want_ver="$(read_shellcheck_pinned_version "$root")" || return 1
+  want_ver="$(read_shellcheck_pinned_version "$root")"
 
   for chosen in "${root}/tools/shellcheck" "${HOME}/.local/bin/shellcheck"; do
     if [[ -n "$chosen" && -x "$chosen" ]]; then
@@ -56,12 +61,14 @@ resolve_shellcheck_bin() {
   fi
 
   if [[ -z "$SHELLCHECK_BIN" ]]; then
-    echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    if [[ -z "${SHELLCHECK_RESOLVE_OPTIONAL:-}" ]]; then
+      echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    fi
     return 1
   fi
 
   ver="$(shellcheck_binary_version "$SHELLCHECK_BIN")"
-  if [[ -n "$ver" && "$ver" != "$want_ver" ]]; then
+  if [[ -n "$want_ver" && -n "$ver" && "$ver" != "$want_ver" ]]; then
     echo "warn: using system shellcheck ${ver}; pinned version is ${want_ver} (install via scripts/install-shellcheck.sh)" >&2
   fi
 

--- a/.codex-plugin/ycc/skills/formatters/scripts/bundle/style.sh
+++ b/.codex-plugin/ycc/skills/formatters/scripts/bundle/style.sh
@@ -14,6 +14,8 @@ SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" >/dev/null 2>&1 && pwd)"
 
 # shellcheck source=bin/lib/modified-files.sh
 source "$SCRIPT_DIR/lib/modified-files.sh"
+# shellcheck source=bin/lib/shellcheck-resolve.sh
+source "$SCRIPT_DIR/lib/shellcheck-resolve.sh"
 
 PROJECT_ROOT="$(detect_project_root)"
 readonly PROJECT_ROOT
@@ -32,6 +34,7 @@ BUNDLE_MANAGED_FILES=(
   "init-formatters.sh"
   "go-tools.sh"
   "lib/modified-files.sh"
+  "lib/shellcheck-resolve.sh"
   "templates/markdownlint.json"
   "templates/markdownlintignore"
   "templates/prettierrc.json"
@@ -320,7 +323,7 @@ run_ts_lint() {
 run_shell_lint() {
   local git_scope="$1"
 
-  if ! require_command shellcheck; then
+  if ! resolve_shellcheck_bin; then
     return 1
   fi
 
@@ -342,7 +345,7 @@ run_shell_lint() {
   fi
 
   echo "=== Shell: shellcheck ==="
-  shellcheck --severity=warning "${shell_files[@]}"
+  "$SHELLCHECK_BIN" --severity=warning "${shell_files[@]}"
 }
 
 run_python_lint() {

--- a/.cursor-plugin/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
+++ b/.cursor-plugin/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+# Resolve which shellcheck binary to run and warn when it differs from .tool-versions.
+# Call after PROJECT_ROOT or REPO_ROOT is set. Defines:
+#   resolve_shellcheck_bin  -> sets SHELLCHECK_BIN, returns 0 on success
+#
+# Preference order: <repo>/tools/shellcheck, $HOME/.local/bin/shellcheck, then PATH.
+
+read_shellcheck_pinned_version() {
+  local root="$1"
+  local f="${root}/.tool-versions"
+  if [[ ! -f "$f" ]]; then
+    echo "shellcheck-resolve: missing ${f}" >&2
+    return 1
+  fi
+  local v
+  v="$(grep -E '^shellcheck[[:space:]]' "$f" | head -n1 | awk '{print $2}')"
+  if [[ -z "$v" ]]; then
+    echo "shellcheck-resolve: no shellcheck version in ${f}" >&2
+    return 1
+  fi
+  printf '%s\n' "$v"
+}
+
+shellcheck_repo_root() {
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    printf '%s\n' "$REPO_ROOT"
+  elif [[ -n "${PROJECT_ROOT:-}" ]]; then
+    printf '%s\n' "$PROJECT_ROOT"
+  else
+    echo "shellcheck-resolve: set REPO_ROOT or PROJECT_ROOT" >&2
+    return 1
+  fi
+}
+
+shellcheck_binary_version() {
+  local bin="$1"
+  "$bin" --version 2>/dev/null | grep -E '^version:' | head -n1 | awk '{print $2}'
+}
+
+resolve_shellcheck_bin() {
+  local root pinned want_ver chosen ver
+  SHELLCHECK_BIN=""
+
+  root="$(shellcheck_repo_root)" || return 1
+  want_ver="$(read_shellcheck_pinned_version "$root")" || return 1
+
+  for chosen in "${root}/tools/shellcheck" "${HOME}/.local/bin/shellcheck"; do
+    if [[ -n "$chosen" && -x "$chosen" ]]; then
+      SHELLCHECK_BIN="$chosen"
+      break
+    fi
+  done
+
+  if [[ -z "$SHELLCHECK_BIN" ]] && command -v shellcheck >/dev/null 2>&1; then
+    SHELLCHECK_BIN="$(command -v shellcheck)"
+  fi
+
+  if [[ -z "$SHELLCHECK_BIN" ]]; then
+    echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    return 1
+  fi
+
+  ver="$(shellcheck_binary_version "$SHELLCHECK_BIN")"
+  if [[ -n "$ver" && "$ver" != "$want_ver" ]]; then
+    echo "warn: using system shellcheck ${ver}; pinned version is ${want_ver} (install via scripts/install-shellcheck.sh)" >&2
+  fi
+
+  return 0
+}

--- a/.cursor-plugin/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
+++ b/.cursor-plugin/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
@@ -3,20 +3,25 @@
 # Call after PROJECT_ROOT or REPO_ROOT is set. Defines:
 #   resolve_shellcheck_bin  -> sets SHELLCHECK_BIN, returns 0 on success
 #
+# If .tool-versions is missing or has no shellcheck line, read_shellcheck_pinned_version
+# succeeds with no output; version comparison is skipped unless a pin is present.
+#
+# When SHELLCHECK_RESOLVE_OPTIONAL is non-empty and no shellcheck binary is found,
+# resolve_shellcheck_bin returns 1 without printing the "Missing required command" message
+# (for optional checks that print their own skip message).
+#
 # Preference order: <repo>/tools/shellcheck, $HOME/.local/bin/shellcheck, then PATH.
 
 read_shellcheck_pinned_version() {
   local root="$1"
   local f="${root}/.tool-versions"
   if [[ ! -f "$f" ]]; then
-    echo "shellcheck-resolve: missing ${f}" >&2
-    return 1
+    return 0
   fi
   local v
   v="$(grep -E '^shellcheck[[:space:]]' "$f" | head -n1 | awk '{print $2}')"
   if [[ -z "$v" ]]; then
-    echo "shellcheck-resolve: no shellcheck version in ${f}" >&2
-    return 1
+    return 0
   fi
   printf '%s\n' "$v"
 }
@@ -38,11 +43,11 @@ shellcheck_binary_version() {
 }
 
 resolve_shellcheck_bin() {
-  local root pinned want_ver chosen ver
+  local root want_ver chosen ver
   SHELLCHECK_BIN=""
 
   root="$(shellcheck_repo_root)" || return 1
-  want_ver="$(read_shellcheck_pinned_version "$root")" || return 1
+  want_ver="$(read_shellcheck_pinned_version "$root")"
 
   for chosen in "${root}/tools/shellcheck" "${HOME}/.local/bin/shellcheck"; do
     if [[ -n "$chosen" && -x "$chosen" ]]; then
@@ -56,12 +61,14 @@ resolve_shellcheck_bin() {
   fi
 
   if [[ -z "$SHELLCHECK_BIN" ]]; then
-    echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    if [[ -z "${SHELLCHECK_RESOLVE_OPTIONAL:-}" ]]; then
+      echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    fi
     return 1
   fi
 
   ver="$(shellcheck_binary_version "$SHELLCHECK_BIN")"
-  if [[ -n "$ver" && "$ver" != "$want_ver" ]]; then
+  if [[ -n "$want_ver" && -n "$ver" && "$ver" != "$want_ver" ]]; then
     echo "warn: using system shellcheck ${ver}; pinned version is ${want_ver} (install via scripts/install-shellcheck.sh)" >&2
   fi
 

--- a/.cursor-plugin/skills/formatters/scripts/bundle/style.sh
+++ b/.cursor-plugin/skills/formatters/scripts/bundle/style.sh
@@ -14,6 +14,8 @@ SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" >/dev/null 2>&1 && pwd)"
 
 # shellcheck source=bin/lib/modified-files.sh
 source "$SCRIPT_DIR/lib/modified-files.sh"
+# shellcheck source=bin/lib/shellcheck-resolve.sh
+source "$SCRIPT_DIR/lib/shellcheck-resolve.sh"
 
 PROJECT_ROOT="$(detect_project_root)"
 readonly PROJECT_ROOT
@@ -32,6 +34,7 @@ BUNDLE_MANAGED_FILES=(
   "init-formatters.sh"
   "go-tools.sh"
   "lib/modified-files.sh"
+  "lib/shellcheck-resolve.sh"
   "templates/markdownlint.json"
   "templates/markdownlintignore"
   "templates/prettierrc.json"
@@ -320,7 +323,7 @@ run_ts_lint() {
 run_shell_lint() {
   local git_scope="$1"
 
-  if ! require_command shellcheck; then
+  if ! resolve_shellcheck_bin; then
     return 1
   fi
 
@@ -342,7 +345,7 @@ run_shell_lint() {
   fi
 
   echo "=== Shell: shellcheck ==="
-  shellcheck --severity=warning "${shell_files[@]}"
+  "$SHELLCHECK_BIN" --severity=warning "${shell_files[@]}"
 }
 
 run_python_lint() {

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,5 +23,8 @@ jobs:
       - name: Install Python deps
         run: pip install pyyaml
 
+      - name: Install pinned shellcheck
+        run: ./scripts/install-shellcheck.sh
+
       - name: Run unified validator
         run: ./scripts/validate.sh

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ node_modules/
 .vscode/
 *.sublime-*
 
-# Pinned tools (scripts/install-shellcheck.sh)
-/tools/
+# Pinned tools (scripts/install-shellcheck.sh installs repo-local binary here)
+/tools/shellcheck
 
 # Python
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ node_modules/
 .vscode/
 *.sublime-*
 
+# Pinned tools (scripts/install-shellcheck.sh)
+/tools/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/.opencode-plugin/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
+++ b/.opencode-plugin/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+# Resolve which shellcheck binary to run and warn when it differs from .tool-versions.
+# Call after PROJECT_ROOT or REPO_ROOT is set. Defines:
+#   resolve_shellcheck_bin  -> sets SHELLCHECK_BIN, returns 0 on success
+#
+# Preference order: <repo>/tools/shellcheck, $HOME/.local/bin/shellcheck, then PATH.
+
+read_shellcheck_pinned_version() {
+  local root="$1"
+  local f="${root}/.tool-versions"
+  if [[ ! -f "$f" ]]; then
+    echo "shellcheck-resolve: missing ${f}" >&2
+    return 1
+  fi
+  local v
+  v="$(grep -E '^shellcheck[[:space:]]' "$f" | head -n1 | awk '{print $2}')"
+  if [[ -z "$v" ]]; then
+    echo "shellcheck-resolve: no shellcheck version in ${f}" >&2
+    return 1
+  fi
+  printf '%s\n' "$v"
+}
+
+shellcheck_repo_root() {
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    printf '%s\n' "$REPO_ROOT"
+  elif [[ -n "${PROJECT_ROOT:-}" ]]; then
+    printf '%s\n' "$PROJECT_ROOT"
+  else
+    echo "shellcheck-resolve: set REPO_ROOT or PROJECT_ROOT" >&2
+    return 1
+  fi
+}
+
+shellcheck_binary_version() {
+  local bin="$1"
+  "$bin" --version 2>/dev/null | grep -E '^version:' | head -n1 | awk '{print $2}'
+}
+
+resolve_shellcheck_bin() {
+  local root pinned want_ver chosen ver
+  SHELLCHECK_BIN=""
+
+  root="$(shellcheck_repo_root)" || return 1
+  want_ver="$(read_shellcheck_pinned_version "$root")" || return 1
+
+  for chosen in "${root}/tools/shellcheck" "${HOME}/.local/bin/shellcheck"; do
+    if [[ -n "$chosen" && -x "$chosen" ]]; then
+      SHELLCHECK_BIN="$chosen"
+      break
+    fi
+  done
+
+  if [[ -z "$SHELLCHECK_BIN" ]] && command -v shellcheck >/dev/null 2>&1; then
+    SHELLCHECK_BIN="$(command -v shellcheck)"
+  fi
+
+  if [[ -z "$SHELLCHECK_BIN" ]]; then
+    echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    return 1
+  fi
+
+  ver="$(shellcheck_binary_version "$SHELLCHECK_BIN")"
+  if [[ -n "$ver" && "$ver" != "$want_ver" ]]; then
+    echo "warn: using system shellcheck ${ver}; pinned version is ${want_ver} (install via scripts/install-shellcheck.sh)" >&2
+  fi
+
+  return 0
+}

--- a/.opencode-plugin/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
+++ b/.opencode-plugin/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
@@ -3,20 +3,25 @@
 # Call after PROJECT_ROOT or REPO_ROOT is set. Defines:
 #   resolve_shellcheck_bin  -> sets SHELLCHECK_BIN, returns 0 on success
 #
+# If .tool-versions is missing or has no shellcheck line, read_shellcheck_pinned_version
+# succeeds with no output; version comparison is skipped unless a pin is present.
+#
+# When SHELLCHECK_RESOLVE_OPTIONAL is non-empty and no shellcheck binary is found,
+# resolve_shellcheck_bin returns 1 without printing the "Missing required command" message
+# (for optional checks that print their own skip message).
+#
 # Preference order: <repo>/tools/shellcheck, $HOME/.local/bin/shellcheck, then PATH.
 
 read_shellcheck_pinned_version() {
   local root="$1"
   local f="${root}/.tool-versions"
   if [[ ! -f "$f" ]]; then
-    echo "shellcheck-resolve: missing ${f}" >&2
-    return 1
+    return 0
   fi
   local v
   v="$(grep -E '^shellcheck[[:space:]]' "$f" | head -n1 | awk '{print $2}')"
   if [[ -z "$v" ]]; then
-    echo "shellcheck-resolve: no shellcheck version in ${f}" >&2
-    return 1
+    return 0
   fi
   printf '%s\n' "$v"
 }
@@ -38,11 +43,11 @@ shellcheck_binary_version() {
 }
 
 resolve_shellcheck_bin() {
-  local root pinned want_ver chosen ver
+  local root want_ver chosen ver
   SHELLCHECK_BIN=""
 
   root="$(shellcheck_repo_root)" || return 1
-  want_ver="$(read_shellcheck_pinned_version "$root")" || return 1
+  want_ver="$(read_shellcheck_pinned_version "$root")"
 
   for chosen in "${root}/tools/shellcheck" "${HOME}/.local/bin/shellcheck"; do
     if [[ -n "$chosen" && -x "$chosen" ]]; then
@@ -56,12 +61,14 @@ resolve_shellcheck_bin() {
   fi
 
   if [[ -z "$SHELLCHECK_BIN" ]]; then
-    echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    if [[ -z "${SHELLCHECK_RESOLVE_OPTIONAL:-}" ]]; then
+      echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    fi
     return 1
   fi
 
   ver="$(shellcheck_binary_version "$SHELLCHECK_BIN")"
-  if [[ -n "$ver" && "$ver" != "$want_ver" ]]; then
+  if [[ -n "$want_ver" && -n "$ver" && "$ver" != "$want_ver" ]]; then
     echo "warn: using system shellcheck ${ver}; pinned version is ${want_ver} (install via scripts/install-shellcheck.sh)" >&2
   fi
 

--- a/.opencode-plugin/skills/formatters/scripts/bundle/style.sh
+++ b/.opencode-plugin/skills/formatters/scripts/bundle/style.sh
@@ -14,6 +14,8 @@ SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" >/dev/null 2>&1 && pwd)"
 
 # shellcheck source=bin/lib/modified-files.sh
 source "$SCRIPT_DIR/lib/modified-files.sh"
+# shellcheck source=bin/lib/shellcheck-resolve.sh
+source "$SCRIPT_DIR/lib/shellcheck-resolve.sh"
 
 PROJECT_ROOT="$(detect_project_root)"
 readonly PROJECT_ROOT
@@ -32,6 +34,7 @@ BUNDLE_MANAGED_FILES=(
   "init-formatters.sh"
   "go-tools.sh"
   "lib/modified-files.sh"
+  "lib/shellcheck-resolve.sh"
   "templates/markdownlint.json"
   "templates/markdownlintignore"
   "templates/prettierrc.json"
@@ -320,7 +323,7 @@ run_ts_lint() {
 run_shell_lint() {
   local git_scope="$1"
 
-  if ! require_command shellcheck; then
+  if ! resolve_shellcheck_bin; then
     return 1
   fi
 
@@ -342,7 +345,7 @@ run_shell_lint() {
   fi
 
   echo "=== Shell: shellcheck ==="
-  shellcheck --severity=warning "${shell_files[@]}"
+  "$SHELLCHECK_BIN" --severity=warning "${shell_files[@]}"
 }
 
 run_python_lint() {

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+# Single source of truth for toolchain pins (asdf-compatible; used by scripts/install-shellcheck.sh).
+shellcheck 0.10.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,6 +327,9 @@ The Claude Code harness defaults to creating worktrees inside the current repo a
 ## Commands
 
 ```bash
+# One-time: install pinned shellcheck (matches .tool-versions; same binary as CI)
+./scripts/install-shellcheck.sh
+
 # Lint (Python + Shell)
 npm run lint              # or: scripts/lint.sh --python --shell
 npm run lint:modified     # only files changed vs. git HEAD

--- a/scripts/install-shellcheck.sh
+++ b/scripts/install-shellcheck.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Download pinned shellcheck from GitHub releases into repo-local tools/ (gitignored).
 # Idempotent. Version is read from .tool-versions (shellcheck line).
-set -eu
+set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/scripts/install-shellcheck.sh
+++ b/scripts/install-shellcheck.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# Download pinned shellcheck from GitHub releases into repo-local tools/ (gitignored).
+# Idempotent. Version is read from .tool-versions (shellcheck line).
+set -eu
+
+SCRIPT_DIR="$(dirname "$0")"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TOOL_VERSIONS="${ROOT}/.tool-versions"
+
+if ! grep -E '^shellcheck[[:space:]]' "$TOOL_VERSIONS" >/dev/null 2>&1; then
+  echo "install-shellcheck: no shellcheck line in .tool-versions" >&2
+  exit 1
+fi
+
+VERSION="$(grep -E '^shellcheck[[:space:]]' "$TOOL_VERSIONS" | head -n1 | awk '{print $2}')"
+if [ -z "$VERSION" ]; then
+  echo "install-shellcheck: could not parse shellcheck version" >&2
+  exit 1
+fi
+
+DEST="${ROOT}/tools/shellcheck"
+mkdir -p "${ROOT}/tools"
+
+if [ -x "$DEST" ]; then
+  cur="$("$DEST" --version 2>/dev/null | grep -E '^version:' | head -n1 | awk '{print $2}')"
+  if [ "$cur" = "$VERSION" ]; then
+    echo "shellcheck ${VERSION} already installed at ${DEST}"
+    exit 0
+  fi
+fi
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+case "$OS" in
+  Linux) OS=linux ;;
+  Darwin) OS=darwin ;;
+  *) echo "install-shellcheck: unsupported OS: ${OS}" >&2; exit 1 ;;
+esac
+case "$ARCH" in
+  x86_64|amd64) ARCH=x86_64 ;;
+  aarch64|arm64) ARCH=aarch64 ;;
+  *) echo "install-shellcheck: unsupported architecture: ${ARCH}" >&2; exit 1 ;;
+esac
+
+TAG="v${VERSION}"
+NAME="shellcheck-${TAG}.${OS}.${ARCH}"
+URL="https://github.com/koalaman/shellcheck/releases/download/${TAG}/${NAME}.tar.xz"
+
+TMPDIR="${TMPDIR:-/tmp}"
+TMP="${TMPDIR}/shellcheck-install.$$"
+cleanup() {
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+mkdir -p "$TMP"
+
+echo "Downloading ${URL} ..."
+if command -v curl >/dev/null 2>&1; then
+  curl -fsSL "$URL" -o "${TMP}/archive.tar.xz"
+elif command -v wget >/dev/null 2>&1; then
+  wget -q "$URL" -O "${TMP}/archive.tar.xz"
+else
+  echo "install-shellcheck: need curl or wget" >&2
+  exit 1
+fi
+
+(
+  cd "$TMP" || exit 1
+  xz -dc "${TMP}/archive.tar.xz" | tar -xf -
+)
+
+BIN=""
+for candidate in "$TMP/shellcheck" "$TMP/shellcheck-${TAG}/shellcheck"; do
+  if [ -f "$candidate" ]; then
+    BIN="$candidate"
+    break
+  fi
+done
+if [ -z "$BIN" ]; then
+  BIN="$(find "$TMP" -name shellcheck -type f 2>/dev/null | head -n1)"
+fi
+if [ -z "$BIN" ] || [ ! -f "$BIN" ]; then
+  echo "install-shellcheck: could not find shellcheck binary in archive" >&2
+  exit 1
+fi
+
+cp "$BIN" "$DEST"
+chmod +x "$DEST"
+echo "Installed shellcheck ${VERSION} at ${DEST}"

--- a/scripts/lib/shellcheck-resolve.sh
+++ b/scripts/lib/shellcheck-resolve.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+# Resolve which shellcheck binary to run and warn when it differs from .tool-versions.
+# Call after PROJECT_ROOT or REPO_ROOT is set. Defines:
+#   resolve_shellcheck_bin  -> sets SHELLCHECK_BIN, returns 0 on success
+#
+# Preference order: <repo>/tools/shellcheck, $HOME/.local/bin/shellcheck, then PATH.
+
+read_shellcheck_pinned_version() {
+  local root="$1"
+  local f="${root}/.tool-versions"
+  if [[ ! -f "$f" ]]; then
+    echo "shellcheck-resolve: missing ${f}" >&2
+    return 1
+  fi
+  local v
+  v="$(grep -E '^shellcheck[[:space:]]' "$f" | head -n1 | awk '{print $2}')"
+  if [[ -z "$v" ]]; then
+    echo "shellcheck-resolve: no shellcheck version in ${f}" >&2
+    return 1
+  fi
+  printf '%s\n' "$v"
+}
+
+shellcheck_repo_root() {
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    printf '%s\n' "$REPO_ROOT"
+  elif [[ -n "${PROJECT_ROOT:-}" ]]; then
+    printf '%s\n' "$PROJECT_ROOT"
+  else
+    echo "shellcheck-resolve: set REPO_ROOT or PROJECT_ROOT" >&2
+    return 1
+  fi
+}
+
+shellcheck_binary_version() {
+  local bin="$1"
+  "$bin" --version 2>/dev/null | grep -E '^version:' | head -n1 | awk '{print $2}'
+}
+
+resolve_shellcheck_bin() {
+  local root pinned want_ver chosen ver
+  SHELLCHECK_BIN=""
+
+  root="$(shellcheck_repo_root)" || return 1
+  want_ver="$(read_shellcheck_pinned_version "$root")" || return 1
+
+  for chosen in "${root}/tools/shellcheck" "${HOME}/.local/bin/shellcheck"; do
+    if [[ -n "$chosen" && -x "$chosen" ]]; then
+      SHELLCHECK_BIN="$chosen"
+      break
+    fi
+  done
+
+  if [[ -z "$SHELLCHECK_BIN" ]] && command -v shellcheck >/dev/null 2>&1; then
+    SHELLCHECK_BIN="$(command -v shellcheck)"
+  fi
+
+  if [[ -z "$SHELLCHECK_BIN" ]]; then
+    echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    return 1
+  fi
+
+  ver="$(shellcheck_binary_version "$SHELLCHECK_BIN")"
+  if [[ -n "$ver" && "$ver" != "$want_ver" ]]; then
+    echo "warn: using system shellcheck ${ver}; pinned version is ${want_ver} (install via scripts/install-shellcheck.sh)" >&2
+  fi
+
+  return 0
+}

--- a/scripts/lib/shellcheck-resolve.sh
+++ b/scripts/lib/shellcheck-resolve.sh
@@ -3,20 +3,25 @@
 # Call after PROJECT_ROOT or REPO_ROOT is set. Defines:
 #   resolve_shellcheck_bin  -> sets SHELLCHECK_BIN, returns 0 on success
 #
+# If .tool-versions is missing or has no shellcheck line, read_shellcheck_pinned_version
+# succeeds with no output; version comparison is skipped unless a pin is present.
+#
+# When SHELLCHECK_RESOLVE_OPTIONAL is non-empty and no shellcheck binary is found,
+# resolve_shellcheck_bin returns 1 without printing the "Missing required command" message
+# (for optional checks that print their own skip message).
+#
 # Preference order: <repo>/tools/shellcheck, $HOME/.local/bin/shellcheck, then PATH.
 
 read_shellcheck_pinned_version() {
   local root="$1"
   local f="${root}/.tool-versions"
   if [[ ! -f "$f" ]]; then
-    echo "shellcheck-resolve: missing ${f}" >&2
-    return 1
+    return 0
   fi
   local v
   v="$(grep -E '^shellcheck[[:space:]]' "$f" | head -n1 | awk '{print $2}')"
   if [[ -z "$v" ]]; then
-    echo "shellcheck-resolve: no shellcheck version in ${f}" >&2
-    return 1
+    return 0
   fi
   printf '%s\n' "$v"
 }
@@ -38,11 +43,11 @@ shellcheck_binary_version() {
 }
 
 resolve_shellcheck_bin() {
-  local root pinned want_ver chosen ver
+  local root want_ver chosen ver
   SHELLCHECK_BIN=""
 
   root="$(shellcheck_repo_root)" || return 1
-  want_ver="$(read_shellcheck_pinned_version "$root")" || return 1
+  want_ver="$(read_shellcheck_pinned_version "$root")"
 
   for chosen in "${root}/tools/shellcheck" "${HOME}/.local/bin/shellcheck"; do
     if [[ -n "$chosen" && -x "$chosen" ]]; then
@@ -56,12 +61,14 @@ resolve_shellcheck_bin() {
   fi
 
   if [[ -z "$SHELLCHECK_BIN" ]]; then
-    echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    if [[ -z "${SHELLCHECK_RESOLVE_OPTIONAL:-}" ]]; then
+      echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    fi
     return 1
   fi
 
   ver="$(shellcheck_binary_version "$SHELLCHECK_BIN")"
-  if [[ -n "$ver" && "$ver" != "$want_ver" ]]; then
+  if [[ -n "$want_ver" && -n "$ver" && "$ver" != "$want_ver" ]]; then
     echo "warn: using system shellcheck ${ver}; pinned version is ${want_ver} (install via scripts/install-shellcheck.sh)" >&2
   fi
 

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -14,6 +14,8 @@ SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" >/dev/null 2>&1 && pwd)"
 
 # shellcheck source=bin/lib/modified-files.sh
 source "$SCRIPT_DIR/lib/modified-files.sh"
+# shellcheck source=bin/lib/shellcheck-resolve.sh
+source "$SCRIPT_DIR/lib/shellcheck-resolve.sh"
 
 PROJECT_ROOT="$(detect_project_root)"
 readonly PROJECT_ROOT
@@ -32,6 +34,7 @@ BUNDLE_MANAGED_FILES=(
   "init-formatters.sh"
   "go-tools.sh"
   "lib/modified-files.sh"
+  "lib/shellcheck-resolve.sh"
   "templates/markdownlint.json"
   "templates/markdownlintignore"
   "templates/prettierrc.json"
@@ -320,7 +323,7 @@ run_ts_lint() {
 run_shell_lint() {
   local git_scope="$1"
 
-  if ! require_command shellcheck; then
+  if ! resolve_shellcheck_bin; then
     return 1
   fi
 
@@ -342,7 +345,7 @@ run_shell_lint() {
   fi
 
   echo "=== Shell: shellcheck ==="
-  shellcheck --severity=warning "${shell_files[@]}"
+  "$SHELLCHECK_BIN" --severity=warning "${shell_files[@]}"
 }
 
 run_python_lint() {

--- a/scripts/validate-yci-skills.sh
+++ b/scripts/validate-yci-skills.sh
@@ -306,7 +306,7 @@ PY
 
     # --- shellcheck ---
     printf '\n--- shellcheck (customer-profile) ---\n'
-    if resolve_shellcheck_bin; then
+    if SHELLCHECK_RESOLVE_OPTIONAL=1 resolve_shellcheck_bin; then
         local sc_files=()
         # collect skill scripts
         while IFS= read -r f; do sc_files+=("$f"); done \

--- a/scripts/validate-yci-skills.sh
+++ b/scripts/validate-yci-skills.sh
@@ -12,6 +12,9 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# shellcheck source=lib/shellcheck-resolve.sh
+source "${SCRIPT_DIR}/lib/shellcheck-resolve.sh"
+
 ERRORS=0
 
 fail() { printf '  ✗ fail: %s\n' "$*" >&2; ERRORS=$((ERRORS + 1)); }
@@ -303,7 +306,7 @@ PY
 
     # --- shellcheck ---
     printf '\n--- shellcheck (customer-profile) ---\n'
-    if command -v shellcheck >/dev/null 2>&1; then
+    if resolve_shellcheck_bin; then
         local sc_files=()
         # collect skill scripts
         while IFS= read -r f; do sc_files+=("$f"); done \
@@ -315,7 +318,7 @@ PY
             < <(ls "${tests_dir}/run-all.sh" "${tests_dir}/helpers.sh" \
                     "${tests_dir}/"test_*.sh 2>/dev/null)
 
-        if shellcheck --severity=warning "${sc_files[@]}"; then
+        if "$SHELLCHECK_BIN" --severity=warning "${sc_files[@]}"; then
             ok "shellcheck clean on ${#sc_files[@]} files"
         else
             fail "shellcheck reported warnings/errors"

--- a/ycc/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
+++ b/ycc/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+# Resolve which shellcheck binary to run and warn when it differs from .tool-versions.
+# Call after PROJECT_ROOT or REPO_ROOT is set. Defines:
+#   resolve_shellcheck_bin  -> sets SHELLCHECK_BIN, returns 0 on success
+#
+# Preference order: <repo>/tools/shellcheck, $HOME/.local/bin/shellcheck, then PATH.
+
+read_shellcheck_pinned_version() {
+  local root="$1"
+  local f="${root}/.tool-versions"
+  if [[ ! -f "$f" ]]; then
+    echo "shellcheck-resolve: missing ${f}" >&2
+    return 1
+  fi
+  local v
+  v="$(grep -E '^shellcheck[[:space:]]' "$f" | head -n1 | awk '{print $2}')"
+  if [[ -z "$v" ]]; then
+    echo "shellcheck-resolve: no shellcheck version in ${f}" >&2
+    return 1
+  fi
+  printf '%s\n' "$v"
+}
+
+shellcheck_repo_root() {
+  if [[ -n "${REPO_ROOT:-}" ]]; then
+    printf '%s\n' "$REPO_ROOT"
+  elif [[ -n "${PROJECT_ROOT:-}" ]]; then
+    printf '%s\n' "$PROJECT_ROOT"
+  else
+    echo "shellcheck-resolve: set REPO_ROOT or PROJECT_ROOT" >&2
+    return 1
+  fi
+}
+
+shellcheck_binary_version() {
+  local bin="$1"
+  "$bin" --version 2>/dev/null | grep -E '^version:' | head -n1 | awk '{print $2}'
+}
+
+resolve_shellcheck_bin() {
+  local root pinned want_ver chosen ver
+  SHELLCHECK_BIN=""
+
+  root="$(shellcheck_repo_root)" || return 1
+  want_ver="$(read_shellcheck_pinned_version "$root")" || return 1
+
+  for chosen in "${root}/tools/shellcheck" "${HOME}/.local/bin/shellcheck"; do
+    if [[ -n "$chosen" && -x "$chosen" ]]; then
+      SHELLCHECK_BIN="$chosen"
+      break
+    fi
+  done
+
+  if [[ -z "$SHELLCHECK_BIN" ]] && command -v shellcheck >/dev/null 2>&1; then
+    SHELLCHECK_BIN="$(command -v shellcheck)"
+  fi
+
+  if [[ -z "$SHELLCHECK_BIN" ]]; then
+    echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    return 1
+  fi
+
+  ver="$(shellcheck_binary_version "$SHELLCHECK_BIN")"
+  if [[ -n "$ver" && "$ver" != "$want_ver" ]]; then
+    echo "warn: using system shellcheck ${ver}; pinned version is ${want_ver} (install via scripts/install-shellcheck.sh)" >&2
+  fi
+
+  return 0
+}

--- a/ycc/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
+++ b/ycc/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh
@@ -3,20 +3,25 @@
 # Call after PROJECT_ROOT or REPO_ROOT is set. Defines:
 #   resolve_shellcheck_bin  -> sets SHELLCHECK_BIN, returns 0 on success
 #
+# If .tool-versions is missing or has no shellcheck line, read_shellcheck_pinned_version
+# succeeds with no output; version comparison is skipped unless a pin is present.
+#
+# When SHELLCHECK_RESOLVE_OPTIONAL is non-empty and no shellcheck binary is found,
+# resolve_shellcheck_bin returns 1 without printing the "Missing required command" message
+# (for optional checks that print their own skip message).
+#
 # Preference order: <repo>/tools/shellcheck, $HOME/.local/bin/shellcheck, then PATH.
 
 read_shellcheck_pinned_version() {
   local root="$1"
   local f="${root}/.tool-versions"
   if [[ ! -f "$f" ]]; then
-    echo "shellcheck-resolve: missing ${f}" >&2
-    return 1
+    return 0
   fi
   local v
   v="$(grep -E '^shellcheck[[:space:]]' "$f" | head -n1 | awk '{print $2}')"
   if [[ -z "$v" ]]; then
-    echo "shellcheck-resolve: no shellcheck version in ${f}" >&2
-    return 1
+    return 0
   fi
   printf '%s\n' "$v"
 }
@@ -38,11 +43,11 @@ shellcheck_binary_version() {
 }
 
 resolve_shellcheck_bin() {
-  local root pinned want_ver chosen ver
+  local root want_ver chosen ver
   SHELLCHECK_BIN=""
 
   root="$(shellcheck_repo_root)" || return 1
-  want_ver="$(read_shellcheck_pinned_version "$root")" || return 1
+  want_ver="$(read_shellcheck_pinned_version "$root")"
 
   for chosen in "${root}/tools/shellcheck" "${HOME}/.local/bin/shellcheck"; do
     if [[ -n "$chosen" && -x "$chosen" ]]; then
@@ -56,12 +61,14 @@ resolve_shellcheck_bin() {
   fi
 
   if [[ -z "$SHELLCHECK_BIN" ]]; then
-    echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    if [[ -z "${SHELLCHECK_RESOLVE_OPTIONAL:-}" ]]; then
+      echo "Missing required command: shellcheck (install via scripts/install-shellcheck.sh)" >&2
+    fi
     return 1
   fi
 
   ver="$(shellcheck_binary_version "$SHELLCHECK_BIN")"
-  if [[ -n "$ver" && "$ver" != "$want_ver" ]]; then
+  if [[ -n "$want_ver" && -n "$ver" && "$ver" != "$want_ver" ]]; then
     echo "warn: using system shellcheck ${ver}; pinned version is ${want_ver} (install via scripts/install-shellcheck.sh)" >&2
   fi
 

--- a/ycc/skills/formatters/scripts/bundle/style.sh
+++ b/ycc/skills/formatters/scripts/bundle/style.sh
@@ -14,6 +14,8 @@ SCRIPT_DIR="$(cd -P "$(dirname "$SCRIPT_PATH")" >/dev/null 2>&1 && pwd)"
 
 # shellcheck source=bin/lib/modified-files.sh
 source "$SCRIPT_DIR/lib/modified-files.sh"
+# shellcheck source=bin/lib/shellcheck-resolve.sh
+source "$SCRIPT_DIR/lib/shellcheck-resolve.sh"
 
 PROJECT_ROOT="$(detect_project_root)"
 readonly PROJECT_ROOT
@@ -32,6 +34,7 @@ BUNDLE_MANAGED_FILES=(
   "init-formatters.sh"
   "go-tools.sh"
   "lib/modified-files.sh"
+  "lib/shellcheck-resolve.sh"
   "templates/markdownlint.json"
   "templates/markdownlintignore"
   "templates/prettierrc.json"
@@ -320,7 +323,7 @@ run_ts_lint() {
 run_shell_lint() {
   local git_scope="$1"
 
-  if ! require_command shellcheck; then
+  if ! resolve_shellcheck_bin; then
     return 1
   fi
 
@@ -342,7 +345,7 @@ run_shell_lint() {
   fi
 
   echo "=== Shell: shellcheck ==="
-  shellcheck --severity=warning "${shell_files[@]}"
+  "$SHELLCHECK_BIN" --severity=warning "${shell_files[@]}"
 }
 
 run_python_lint() {


### PR DESCRIPTION
Closes #67: single pinned shellcheck via `.tool-versions`, `scripts/install-shellcheck.sh`, resolver in `scripts/lib/shellcheck-resolve.sh`, CI install step, and docs in `CLAUDE.md`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added repo-local shellcheck installer and runtime resolution to ensure a usable shellcheck binary.

* **Documentation**
  * Added setup step instructing users to install the pinned shellcheck version.

* **Chores**
  * CI updated to install the pinned shellcheck before validation.
  * Repo ignore updated to exclude the local pinned shellcheck binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->