### PR TITLE
fix(yci): wire change-reviewer delegation

### DIFF
--- a/scripts/validate-yci-skills.sh
+++ b/scripts/validate-yci-skills.sh
@@ -943,7 +943,8 @@ PY
 
     local t
     for t in test_parse_change.sh test_derive_rollback.sh test_build_check_catalogs.sh \
-              test_render_artifact.sh test_render_evidence_stub.sh test_end_to_end.sh; do
+              test_render_artifact.sh test_render_evidence_stub.sh test_end_to_end.sh \
+              test_agent_delegation.sh; do
         if [ -f "${tests_dir}/${t}" ]; then
             ok "test file ${t} present"
         else
@@ -958,6 +959,13 @@ PY
             fail "tests/fixtures/${fx_dir}/ missing"
         fi
     done
+
+    printf '\n--- network-change-review test harness ---\n'
+    if bash "${tests_dir}/run-all.sh"; then
+        ok "network-change-review test harness passed"
+    else
+        fail "network-change-review test harness: one or more tests failed"
+    fi
 
     # 6. Command and agent registration
     local review_cmd="${REPO_ROOT}/yci/commands/review.md"
@@ -983,6 +991,30 @@ PY
         fail "commands/review.md missing"
     fi
 
+    if grep -q 'subagent_type: "yci:change-reviewer"' "${skill_root}/SKILL.md"; then
+        ok 'network-change-review/SKILL.md delegates diff review to yci:change-reviewer'
+    else
+        fail 'network-change-review/SKILL.md must delegate diff review to yci:change-reviewer'
+    fi
+
+    if grep -q '<profile-json-path>' "${skill_root}/SKILL.md" && \
+       grep -q '<inventory-root>' "${skill_root}/SKILL.md" && \
+       grep -q '<customer-id>' "${skill_root}/SKILL.md" && \
+       grep -q 'absolute path, keep' "${skill_root}/SKILL.md" && \
+       grep -q '<resolved-data-root>/profiles/<inventory-root>' "${skill_root}/SKILL.md" && \
+       grep -q '<resolved-data-root>/<inventory-root>' "${skill_root}/SKILL.md"; then
+        ok "network-change-review/SKILL.md matches review.sh inventory-root precedence and context handoff"
+    else
+        fail "network-change-review/SKILL.md must pass customer-id, staged profile.json, and the full review.sh inventory-root precedence"
+    fi
+
+    if grep -q 'yci:change-reviewer' "${skill_root}/scripts/review.sh" && \
+       ! grep -q 'ycc:code-reviewer' "${skill_root}/scripts/review.sh"; then
+        ok "review.sh text matches yci:change-reviewer delegation"
+    else
+        fail "review.sh text must reference yci:change-reviewer and not ycc:code-reviewer"
+    fi
+
     local change_reviewer_agent="${REPO_ROOT}/yci/agents/change-reviewer.md"
     if [ -f "$change_reviewer_agent" ]; then
         if python3 - "$change_reviewer_agent" <<'PY'; then
@@ -1001,6 +1033,15 @@ PY
             ok "agents/change-reviewer.md frontmatter valid"
         else
             fail "agents/change-reviewer.md: frontmatter invalid"
+        fi
+
+        if grep -q 'profile.json' "$change_reviewer_agent" && \
+           grep -q 'inventory root' "$change_reviewer_agent" && \
+           grep -q 'source of truth for active-customer state' "$change_reviewer_agent" && \
+           grep -q 'do not require them to live under the inventory root' "$change_reviewer_agent"; then
+            ok "agents/change-reviewer.md documents profile snapshot and isolation contract"
+        else
+            fail "agents/change-reviewer.md must document profile.json, inventory-root-only read boundaries, and caller-supplied diff/profile paths"
         fi
     else
         fail "agents/change-reviewer.md missing"

--- a/scripts/validate-yci-skills.sh
+++ b/scripts/validate-yci-skills.sh
@@ -1000,7 +1000,6 @@ PY
     if grep -q '<profile-json-path>' "${skill_root}/SKILL.md" && \
        grep -q '<inventory-root>' "${skill_root}/SKILL.md" && \
        grep -q '<customer-id>' "${skill_root}/SKILL.md" && \
-       grep -q 'absolute path, keep' "${skill_root}/SKILL.md" && \
        grep -q '<resolved-data-root>/profiles/<inventory-root>' "${skill_root}/SKILL.md" && \
        grep -q '<resolved-data-root>/<inventory-root>' "${skill_root}/SKILL.md"; then
         ok "network-change-review/SKILL.md matches review.sh inventory-root precedence and context handoff"

--- a/yci/CONTRIBUTING.md
+++ b/yci/CONTRIBUTING.md
@@ -331,7 +331,7 @@ above — never relax redaction for normal customer engagements.
 `yci:network-change-review` is the P0.5 keystone skill (PRD §6.1). It composes
 `yci:customer-profile`, `yci:customer-guard` (via the automatic PreToolUse hook),
 `yci:telemetry-sanitizer`, the compliance adapter, `yci:blast-radius`, and — via
-the Agent tool — `ycc:plan` plus the delegated `yci:change-reviewer` into a
+the Agent tool — `ycc:planner` plus the delegated `yci:change-reviewer` into a
 single dual-branded deliverable. It is "keystone" because every downstream P0/P1 skill (`yci:mop`,
 `yci:evidence-bundle`, `yci:cab-prep`) either consumes its outputs or follows its
 composition pattern (PRD §5.6, PRD §6.1). Shipping a reliable
@@ -378,7 +378,7 @@ From the project `CLAUDE.md`:
 > the same helper, duplicate it (the duplication cost is low, the coupling cost
 > is high).
 
-`ycc:plan` is invoked via the Agent tool with `subagent_type: "ycc:planner"` —
+`ycc:planner` is invoked via the Agent tool with `subagent_type: "ycc:planner"` —
 structured prompt in, text out. The diff-review slice is delegated to
 `subagent_type: "yci:change-reviewer"` with a staged `profile.json` and inventory
 root so the reviewer stays inside the active customer boundary. `review.sh` is a

--- a/yci/CONTRIBUTING.md
+++ b/yci/CONTRIBUTING.md
@@ -331,8 +331,8 @@ above — never relax redaction for normal customer engagements.
 `yci:network-change-review` is the P0.5 keystone skill (PRD §6.1). It composes
 `yci:customer-profile`, `yci:customer-guard` (via the automatic PreToolUse hook),
 `yci:telemetry-sanitizer`, the compliance adapter, `yci:blast-radius`, and — via
-the Agent tool — `ycc:plan` and `ycc:code-review` into a single dual-branded
-deliverable. It is "keystone" because every downstream P0/P1 skill (`yci:mop`,
+the Agent tool — `ycc:plan` plus the delegated `yci:change-reviewer` into a
+single dual-branded deliverable. It is "keystone" because every downstream P0/P1 skill (`yci:mop`,
 `yci:evidence-bundle`, `yci:cab-prep`) either consumes its outputs or follows its
 composition pattern (PRD §5.6, PRD §6.1). Shipping a reliable
 `yci:network-change-review` is the prerequisite for every subsequent workflow skill
@@ -357,9 +357,10 @@ The orchestrator (`review.sh`) runs these stages in order:
 7. **Catalogs** — `build-check-catalogs.sh` produces pre/post-check catalog JSON
    from the adapter's `evidence-template.md` and `evidence-schema.json`.
 8. **Plan + review** (SKILL layer, before `review.sh`) — run the same cross-customer
-   preflight as `review.sh` (`preflight-cross-customer.sh`), then dispatch
-   `ycc:planner` and `ycc:code-reviewer` in parallel via the Agent tool; pass their
-   outputs with `--change-plan` and `--diff-review` into `review.sh`.
+   preflight as `review.sh` (`preflight-cross-customer.sh`), stage the active
+   profile snapshot, then dispatch `ycc:planner` and `yci:change-reviewer` in
+   parallel via the Agent tool; pass their outputs with `--change-plan` and
+   `--diff-review` into `review.sh`.
 9. **Render** — `render-evidence-stub.sh` then `render-artifact.sh` assemble the
    full review markdown in memory.
 10. **Sanitize** — `pre-write-artifact.sh` (strict mode, sanitizer pass 2) runs
@@ -377,12 +378,14 @@ From the project `CLAUDE.md`:
 > the same helper, duplicate it (the duplication cost is low, the coupling cost
 > is high).
 
-`ycc:plan` and `ycc:code-review` are invoked via the Agent tool with
-`subagent_type: "ycc:planner"` / `"ycc:code-reviewer"` — structured prompt in,
-text out. `review.sh` is a `yci` artifact; it cannot and must not `source` or
-`bash` any file from the `ycc/` source tree. The only supported cross-plugin
-channel is the Agent tool, which treats the other plugin's skill as a black box.
-No `ycc` filesystem path is ever embedded in any `yci` script. This boundary
+`ycc:plan` is invoked via the Agent tool with `subagent_type: "ycc:planner"` —
+structured prompt in, text out. The diff-review slice is delegated to
+`subagent_type: "yci:change-reviewer"` with a staged `profile.json` and inventory
+root so the reviewer stays inside the active customer boundary. `review.sh` is a
+`yci` artifact; it cannot and must not `source` or `bash` any file from the
+`ycc/` source tree. The only supported cross-plugin channel is the Agent tool,
+which treats the other plugin's skill as a black box. No `ycc` filesystem path is
+ever embedded in any `yci` script. This boundary
 discipline mirrors the adapter-boundary precedent documented in the
 [Compliance-Adapter Pattern](#compliance-adapter-pattern) section above: `yci`
 defines its own interface and calls `ycc` only through documented,

--- a/yci/agents/change-reviewer.md
+++ b/yci/agents/change-reviewer.md
@@ -16,21 +16,41 @@ deliverable. You do not apply changes, do not bless rollback plans as safe (that
 is a separate check), and do not replace compliance sign-off. You read, reason,
 and report.
 
+## Runtime contract
+
+When `yci:network-change-review` spawns you, the prompt must include all of the
+following:
+
+- The absolute diff path to review.
+- The resolved customer id.
+- A caller-staged `profile.json` snapshot path produced by
+  `customer-profile/scripts/load-profile.sh`.
+- The active inventory root derived from that same profile snapshot.
+
+Treat the staged `profile.json` as the source of truth for active-customer state,
+and treat the inventory root as the boundary for any inventory reads you perform.
+Read them directly from disk when supplied; do not invent a second
+profile-resolution flow and do not infer a broader customer scope from the raw
+diff alone.
+
 ## When to use
 
 Spawn this agent via `subagent_type: "yci:change-reviewer"` in two scenarios:
 
 1. **From `yci:network-change-review`** — the skill delegates diff analysis here
    to keep the main conversation context from being bloated by verbose review
-   output. The skill provides the diff path and any relevant inventory context; this
-   agent returns markdown findings for embedding in the final artifact.
+   output. The skill provides the diff path, customer id, staged profile snapshot,
+   and inventory root; this agent returns markdown findings for embedding in the
+   final artifact.
 
 2. **Direct invocation by a human reviewer** — when you want a focused, second-
    opinion review of a network change diff without running the full
    `yci:network-change-review` workflow. Pass the diff file path as the argument.
 
 In both cases, the agent operates read-only. It does not write to any customer
-artifact directory — it returns findings inline for the caller to embed.
+artifact directory — it returns findings inline for the caller to embed. If the
+caller omits profile context in a direct human invocation, state that profile-
+specific assertions are limited and do not claim active-profile validation.
 
 ## Review focus
 
@@ -111,6 +131,9 @@ not pad. If the diff has many issues, prioritize `[high]` findings; group relate
   queries, no DNS lookups.
 - No execution of config commands — `Bash` permission is restricted to read-only
   inspection (`cat`, `head`, `tail`, `wc`, `test`) and git history reads.
-- Customer data never crosses to a different customer context. If the diff or
-  inventory file path resolves outside the active customer's declared inventory
-  path, refuse and return a `[high]` finding explaining the isolation violation.
+- Customer data never crosses to a different customer context. Honor the same
+  customer-guard boundary as the parent workflow: use the staged `profile.json`
+  as the active-customer source of truth, constrain inventory reads to the
+  declared inventory root, and do not reach into any other customer's inventory
+  or artifact paths. The diff path and staged profile path are caller-supplied
+  inputs; do not require them to live under the inventory root.

--- a/yci/skills/network-change-review/SKILL.md
+++ b/yci/skills/network-change-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: network-change-review
-description: 'Produce a full network-change review artifact (change plan, diff review, blast-radius, rollback, pre/post checklists, compliance evidence stub) for the active customer. Use when the user runs /yci:review <change>, asks to "review a network change", needs a customer-deliverable change document, or is preparing a CAB submission or MOP handoff. Composes ycc:planner and ycc:code-reviewer via the Agent tool for the change-plan and diff-review sections, then invokes the review.sh orchestrator for all remaining sections.'
+description: 'Produce a full network-change review artifact (change plan, diff review, blast-radius, rollback, pre/post checklists, compliance evidence stub) for the active customer. Use when the user runs /yci:review <change>, asks to "review a network change", needs a customer-deliverable change document, or is preparing a CAB submission or MOP handoff. Composes ycc:planner and yci:change-reviewer via the Agent tool for the change-plan and diff-review sections, then invokes the review.sh orchestrator for all remaining sections.'
 argument-hint: '<change-path> [--customer <name>] [--data-root <path>] [--adapter <regime>] [--format <format>] [--output-dir <path>]'
 allowed-tools:
   - Read
@@ -21,7 +21,7 @@ allowed-tools:
 Produces a complete, customer-deliverable network-change review artifact for the
 active customer engagement. Given a change file (unified diff, structured YAML, or
 playbook), this skill runs a 22-step composition pipeline: it spawns `ycc:planner`
-and `ycc:code-reviewer` in parallel to generate the change-plan and diff-review
+and `yci:change-reviewer` in parallel to generate the change-plan and diff-review
 sections, then invokes `review.sh` to produce blast-radius analysis, rollback plan,
 pre/post check catalogs, a compliance evidence stub, and the final rendered artifact.
 The output is a single markdown file at a customer-scoped path under
@@ -119,19 +119,31 @@ bash "${CLAUDE_PLUGIN_ROOT}/skills/network-change-review/scripts/preflight-cross
 ```
 
 On exit 7, stop with `ncr-cross-customer-leak-detected` — do **not** spawn
-`ycc:planner` or `ycc:code-reviewer`.
+`ycc:planner` or `yci:change-reviewer`.
 
-### Step 3 — Spawn ycc:planner and ycc:code-reviewer in parallel
+### Step 3 — Stage profile context and spawn reviewers in parallel
 
 After preflight succeeds, dispatch both subagents in **one message with two Agent
 tool calls**. **Do not** paste the raw change file into prompts (avoids leaking
 content across customers before the orchestrator runs). Give each subagent the
-**absolute path** to the change file only and instruct them to read it themselves
-via their normal file access. Save each output to a temp file:
+**absolute path** to the change file and explicit active-customer context. Before
+the Agent calls, create a temp workdir and stage the same normalized profile data
+the orchestrator will consume:
 
 ```
 NCR_WORKDIR=$(mktemp -d -t yci-ncr-skill-XXXX)
+
+bash "${CLAUDE_PLUGIN_ROOT}/skills/customer-profile/scripts/load-profile.sh" \
+  "<resolved-data-root>" "<customer-id>" \
+  > "${NCR_WORKDIR}/profile.json"
 ```
+
+Derive the active inventory root from the staged profile snapshot using the same
+precedence as `review.sh`: if `profile.inventory.root` is an absolute path, keep
+it as-is; otherwise try `<resolved-data-root>/profiles/<inventory-root>` first
+when that directory exists, then `<resolved-data-root>/<inventory-root>`, else
+empty string when no inventory root is declared. Pass the staged profile snapshot
+path and derived inventory root to the delegated reviewer.
 
 #### Agent call 1 — ycc:planner
 
@@ -149,17 +161,20 @@ prompt: >
 
 Save output to `$NCR_WORKDIR/change-plan.md`.
 
-#### Agent call 2 — ycc:code-reviewer
+#### Agent call 2 — yci:change-reviewer
 
 ```
-subagent_type: "ycc:code-reviewer"
+subagent_type: "yci:change-reviewer"
 prompt: >
   A network change has been proposed for customer <customer-id>. The change file is
-  at <absolute-path>; read it from disk and review it for correctness, risk, and
-  operational concerns. Focus on: (a) syntax / config correctness, (b) rollback
-  readiness, (c) cross-device side effects, (d) monitoring coverage. Use your standard
-  review format, medium severity threshold. Target length: 40–80 lines. Output as
-  markdown findings, no preamble, no trailing summary.
+  at <absolute-path>. The caller staged the active profile snapshot at
+  <profile-json-path> and resolved the active inventory root as <inventory-root>.
+  Read all three paths from disk and treat them as the active-customer boundary for
+  this review. Review the change for correctness, risk, and operational concerns.
+  Focus on: (a) syntax / config correctness, (b) rollback readiness, (c) cross-device
+  side effects, (d) monitoring coverage. Use your standard review format, medium
+  severity threshold. Target length: 40–80 lines. Output as markdown findings, no
+  preamble, no trailing summary.
 ```
 
 Save output to `$NCR_WORKDIR/diff-review.md`.
@@ -207,7 +222,8 @@ to parse the change, then spawn subagents, then again with the real files) exist
 is heavier and unnecessary when the subagents can reason against the raw diff
 directly. The single-pass pattern is known-good for Phase 1. Revisit when the change
 parser's normalized JSON is more stable and the subagents benefit from structured
-target context.
+target context. The delegated reviewer already gets the staged profile snapshot and
+inventory root so it does not have to invent its own profile-resolution flow.
 
 ## Error handling
 
@@ -256,7 +272,7 @@ introduces auto-apply behavior is a defect.
 This skill composes `yci:blast-radius` (via `blast-radius/scripts/reason.sh` and
 `render-markdown.sh`), `yci:customer-profile` (via `resolve-customer.sh` and
 `load-profile.sh`), the `yci:_shared` compliance adapter and telemetry sanitizer,
-and — via the Agent tool — `ycc:planner` and `ycc:code-reviewer`. The Agent tool
+and — via the Agent tool — `ycc:planner` and `yci:change-reviewer`. The Agent tool
 is the only supported cross-plugin channel: no `ycc` filesystem path is sourced or
 referenced in any `yci` script (per `CLAUDE.md` cross-plugin helper sharing rule).
 The full composition order, data-flow diagram, and invocation mechanics by boundary

--- a/yci/skills/network-change-review/references/artifact-template.md
+++ b/yci/skills/network-change-review/references/artifact-template.md
@@ -24,7 +24,7 @@ slot source failed, and discards the partially-rendered artifact.
 | `{{compliance_regime}}`           | `evidence_stub.compliance_regime` — e.g. `commercial`, `none`                                    | fatal (hard stop)                  |
 | `{{change_summary}}`              | `parse-change.sh` normalized JSON `summary` field                                                | fatal (hard stop)                  |
 | `{{change_plan}}`                 | `ycc:plan` subagent output (markdown)                                                            | fatal (hard stop)                  |
-| `{{diff_review}}`                 | `ycc:code-review` subagent output (markdown)                                                     | fatal (hard stop)                  |
+| `{{diff_review}}`                 | `yci:change-reviewer` subagent output (markdown)                                                 | fatal (hard stop)                  |
 | `{{blast_radius}}`                | `yci:blast-radius` rendered markdown output                                                      | fatal (hard stop)                  |
 | `{{rollback_plan}}`               | `derive-rollback.sh` rendered rollback steps (markdown)                                          | fatal (hard stop)                  |
 | `{{rollback_confidence_callout}}` | Empty string when `rollback_confidence` is `high`; visible warning block when `low` or `medium`  | n/a (always computed)              |

--- a/yci/skills/network-change-review/references/composition-contract.md
+++ b/yci/skills/network-change-review/references/composition-contract.md
@@ -140,7 +140,7 @@ in this order.
 | `yci:telemetry-sanitizer`                   | `pre-write-artifact.sh` on the rendered artifact (strict / internal per profile); optional `sanitize-output.sh` for other CLIs — **not** used on the raw `--change` file before parse in `review.sh` | `review.sh` (post-render pass); raw change is scanned in preflight instead of sanitized early                                           |
 | Compliance adapter                          | `_shared/scripts/load-compliance-adapter.sh --export --profile-json-path <path>` + filesystem reads of `evidence-template.md`, `evidence-schema.json`, `handoff-checklist.md` from `YCI_ADAPTER_DIR` | `review.sh` (step 5) and consumed by check-catalog builder (step 12), evidence-stub renderer (step 14), and artifact renderer (step 15) |
 | `yci:blast-radius`                          | Shell scripts: `blast-radius/scripts/reason.sh`, `blast-radius/scripts/render-markdown.sh`                                                                                                           | `review.sh` (after rollback derivation)                                                                                                 |
-| `ycc:plan` (Change Plan section)            | Agent tool with `subagent_type: "ycc:planner"` — prompt in, structured plan text out                                                                                                                 | SKILL.md prompt — NOT `review.sh`                                                                                                       |
+| `ycc:planner` (Change Plan section)         | Agent tool with `subagent_type: "ycc:planner"` — prompt in, structured plan text out                                                                                                                 | SKILL.md prompt — NOT `review.sh`                                                                                                       |
 | `yci:change-reviewer` (Diff Review section) | Agent tool with `subagent_type: "yci:change-reviewer"` — prompt in, findings text out using staged `profile.json` and inventory-root context                                                         | SKILL.md prompt — NOT `review.sh`                                                                                                       |
 
 ---
@@ -153,7 +153,7 @@ From the project `CLAUDE.md`:
 > the same helper, duplicate it (the duplication cost is low, the coupling cost
 > is high).
 
-This rule is why `ycc:plan` is invoked via the Agent tool (prompt in, text out)
+This rule is why `ycc:planner` is invoked via the Agent tool (prompt in, text out)
 rather than by sourcing any `ycc` helper scripts directly. `review.sh` is a `yci`
 artifact; it cannot and must not `source` or `bash` any file from the `ycc/`
 source tree. The only supported cross-plugin channel is the Agent tool, which

--- a/yci/skills/network-change-review/references/composition-contract.md
+++ b/yci/skills/network-change-review/references/composition-contract.md
@@ -81,7 +81,7 @@ in this order.
 
 11. **Populate change-plan and diff-review slots.** Copy `--change-plan` /
     `--diff-review` inputs when provided; otherwise write placeholders. (These files are
-    produced by `ycc:planner` / `ycc:code-reviewer` at the SKILL layer.)
+    produced by `ycc:planner` / `yci:change-reviewer` at the SKILL layer.)
 
 12. **Build check catalogs.** Invoke `scripts/build-check-catalogs.sh` with
     `--adapter-dir` and `--blast-radius-label`. Capture pre-check and post-check JSON
@@ -132,16 +132,16 @@ in this order.
 
 ## Invocation Mechanics by Boundary
 
-| Composed piece                             | Invocation style                                                                                                                                                                                     | Invoked by                                                                                                                              |
-| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `yci:customer-profile`                     | Shell scripts: `resolve-customer.sh`, `load-profile.sh`                                                                                                                                              | `review.sh`                                                                                                                             |
-| `yci:customer-guard` (PreToolUse hook)     | Automatic hook intercept; NOT invoked directly                                                                                                                                                       | Claude Code runtime — NOT `review.sh`                                                                                                   |
-| `yci:_shared/customer-isolation/detect.sh` | Shell script sourced and function called                                                                                                                                                             | `review.sh` (step 17 — final belt-and-suspenders negative check)                                                                        |
-| `yci:telemetry-sanitizer`                  | `pre-write-artifact.sh` on the rendered artifact (strict / internal per profile); optional `sanitize-output.sh` for other CLIs — **not** used on the raw `--change` file before parse in `review.sh` | `review.sh` (post-render pass); raw change is scanned in preflight instead of sanitized early                                           |
-| Compliance adapter                         | `_shared/scripts/load-compliance-adapter.sh --export --profile-json-path <path>` + filesystem reads of `evidence-template.md`, `evidence-schema.json`, `handoff-checklist.md` from `YCI_ADAPTER_DIR` | `review.sh` (step 5) and consumed by check-catalog builder (step 12), evidence-stub renderer (step 14), and artifact renderer (step 15) |
-| `yci:blast-radius`                         | Shell scripts: `blast-radius/scripts/reason.sh`, `blast-radius/scripts/render-markdown.sh`                                                                                                           | `review.sh` (after rollback derivation)                                                                                                 |
-| `ycc:plan` (Change Plan section)           | Agent tool with `subagent_type: "ycc:planner"` — prompt in, structured plan text out                                                                                                                 | SKILL.md prompt — NOT `review.sh`                                                                                                       |
-| `ycc:code-review` (Diff Review section)    | Agent tool with `subagent_type: "ycc:code-reviewer"` — prompt in, findings text out                                                                                                                  | SKILL.md prompt — NOT `review.sh`                                                                                                       |
+| Composed piece                              | Invocation style                                                                                                                                                                                     | Invoked by                                                                                                                              |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `yci:customer-profile`                      | Shell scripts: `resolve-customer.sh`, `load-profile.sh`                                                                                                                                              | `review.sh`                                                                                                                             |
+| `yci:customer-guard` (PreToolUse hook)      | Automatic hook intercept; NOT invoked directly                                                                                                                                                       | Claude Code runtime — NOT `review.sh`                                                                                                   |
+| `yci:_shared/customer-isolation/detect.sh`  | Shell script sourced and function called                                                                                                                                                             | `review.sh` (step 17 — final belt-and-suspenders negative check)                                                                        |
+| `yci:telemetry-sanitizer`                   | `pre-write-artifact.sh` on the rendered artifact (strict / internal per profile); optional `sanitize-output.sh` for other CLIs — **not** used on the raw `--change` file before parse in `review.sh` | `review.sh` (post-render pass); raw change is scanned in preflight instead of sanitized early                                           |
+| Compliance adapter                          | `_shared/scripts/load-compliance-adapter.sh --export --profile-json-path <path>` + filesystem reads of `evidence-template.md`, `evidence-schema.json`, `handoff-checklist.md` from `YCI_ADAPTER_DIR` | `review.sh` (step 5) and consumed by check-catalog builder (step 12), evidence-stub renderer (step 14), and artifact renderer (step 15) |
+| `yci:blast-radius`                          | Shell scripts: `blast-radius/scripts/reason.sh`, `blast-radius/scripts/render-markdown.sh`                                                                                                           | `review.sh` (after rollback derivation)                                                                                                 |
+| `ycc:plan` (Change Plan section)            | Agent tool with `subagent_type: "ycc:planner"` — prompt in, structured plan text out                                                                                                                 | SKILL.md prompt — NOT `review.sh`                                                                                                       |
+| `yci:change-reviewer` (Diff Review section) | Agent tool with `subagent_type: "yci:change-reviewer"` — prompt in, findings text out using staged `profile.json` and inventory-root context                                                         | SKILL.md prompt — NOT `review.sh`                                                                                                       |
 
 ---
 
@@ -153,13 +153,13 @@ From the project `CLAUDE.md`:
 > the same helper, duplicate it (the duplication cost is low, the coupling cost
 > is high).
 
-This rule is why `ycc:plan` and `ycc:code-review` are invoked via the Agent tool
-(prompt in, text out) rather than by sourcing any `ycc` helper scripts directly.
-`review.sh` is a `yci` artifact; it cannot and must not `source` or `bash` any
-file from the `ycc/` source tree. The only supported cross-plugin channel is the
-Agent tool, which treats the other plugin's skill as a black box: the invoking
-SKILL prompt provides a structured prompt and receives text output. No `ycc`
-filesystem path is ever embedded in any `yci` script.
+This rule is why `ycc:plan` is invoked via the Agent tool (prompt in, text out)
+rather than by sourcing any `ycc` helper scripts directly. `review.sh` is a `yci`
+artifact; it cannot and must not `source` or `bash` any file from the `ycc/`
+source tree. The only supported cross-plugin channel is the Agent tool, which
+treats the other plugin's skill as a black box: the invoking SKILL prompt provides
+a structured prompt and receives text output. No `ycc` filesystem path is ever
+embedded in any `yci` script.
 
 Stated explicitly: **If `ycc` and `yci` both need the same helper, duplicate the
 helper — do not cross the plugin boundary.**
@@ -274,12 +274,12 @@ The schema version field in the stub allows `evidence-bundle` to detect and reje
 stubs produced by an older schema revision. Do not change the stub schema without
 bumping the schema version and updating `evidence-bundle` accordingly.
 
-**`yci:change-reviewer` agent (P0).** The `yci:change-reviewer` agent delegates
-the code-review slice of this composition: it invokes `ycc:code-review` (via the
-Agent tool) for a focused deep review of the diff and returns findings that the
-SKILL prompt incorporates into the final artifact. The agent does not replace
-`review.sh`; it is an optional delegation path for the code-review phase that keeps
-the orchestrator's scope narrow.
+**`yci:change-reviewer` agent (P0).** The `yci:change-reviewer` agent owns the
+diff-review slice of this composition. The SKILL prompt hands it the diff path,
+staged `profile.json`, customer id, and inventory root so it can reason inside the
+active-customer boundary without re-resolving profile state. The agent does not
+replace `review.sh`; it is the delegated reviewer phase that keeps the orchestrator's
+scope narrow.
 
 **Generator wiring.** As of Phase 0, `yci` skills are Claude-native only. The
 cross-target generators (`generate_codex_common.py`, `generate_cursor_skills.py`,

--- a/yci/skills/network-change-review/scripts/render-artifact.sh
+++ b/yci/skills/network-change-review/scripts/render-artifact.sh
@@ -10,7 +10,7 @@
 #     --profile <path>               \  # profile JSON (load-profile.sh output)
 #     --adapter-dir <path>           \  # resolved compliance adapter directory
 #     --change-plan <path>           \  # markdown: ycc:plan subagent output
-#     --diff-review <path>           \  # markdown: ycc:code-review output
+#     --diff-review <path>           \  # markdown: yci:change-reviewer output
 #     --blast-radius-markdown <path> \  # markdown: blast-radius/render-markdown.sh output
 #     --rollback <path>              \  # text: derive-rollback.sh rollback steps
 #     --rollback-confidence <level>  \  # high|medium|low
@@ -46,7 +46,7 @@ Options:
   --profile <path>               Profile JSON (load-profile.sh output)        [required]
   --adapter-dir <path>           Resolved compliance adapter directory         [required]
   --change-plan <path>           Markdown: ycc:plan subagent output            [required]
-  --diff-review <path>           Markdown: ycc:code-review output              [required]
+  --diff-review <path>           Markdown: yci:change-reviewer output          [required]
   --blast-radius-markdown <path> Markdown: blast-radius/render-markdown.sh     [required]
   --rollback <path>              Text: derive-rollback.sh rollback steps       [required]
   --rollback-confidence <level>  high|medium|low                               [required]

--- a/yci/skills/network-change-review/scripts/review.sh
+++ b/yci/skills/network-change-review/scripts/review.sh
@@ -14,14 +14,14 @@
 #   --format <format>    deliverable format override (else from profile.deliverable.format)
 #   --output-dir <path>  override final artifact directory
 #   --change-plan <path> pre-generated change plan markdown (from ycc:planner subagent)
-#   --diff-review <path> pre-generated diff review markdown (from ycc:code-reviewer subagent)
+#   --diff-review <path> pre-generated diff review markdown (from yci:change-reviewer subagent)
 #   -h, --help           show this help and exit 0
 #
 # Stdout:  final artifact path (one line) on success
 # Stderr:  yci-ncr: [step N/22] progress; [ncr-<id>] errors
 # Exit:    0 success | 2 setup | 3 input shape | 4 sanitizer | 5 composed | 6 render | 7 isolation
 #
-# Note: shell scripts cannot invoke Agent tools. ycc:planner and ycc:code-reviewer
+# Note: shell scripts cannot invoke Agent tools. ycc:planner and yci:change-reviewer
 # integrations happen at the SKILL.md prompt layer. Pass their output files here via
 # --change-plan and --diff-review; omitting either inserts a placeholder block.
 
@@ -53,7 +53,7 @@ Options:
   --format <format>    Deliverable format override (else from profile.deliverable.format)
   --output-dir <path>  Override final artifact directory
   --change-plan <path> Pre-generated change plan markdown (from ycc:planner)
-  --diff-review <path> Pre-generated diff review markdown (from ycc:code-reviewer)
+  --diff-review <path> Pre-generated diff review markdown (from yci:change-reviewer)
   -h, --help           Show this help and exit 0
 
 Exit codes (references/error-messages.md):
@@ -347,9 +347,9 @@ if [[ -n "$diff_review_path" ]]; then
   cp "$diff_review_path" "${workdir}/diff-review.md"
 else
   cat > "${workdir}/diff-review.md" <<'PLACEHOLDER'
-> **Diff Review** — Expected to be populated by `ycc:code-reviewer` subagent. The orchestrator
+> **Diff Review** — Expected to be populated by `yci:change-reviewer` subagent. The orchestrator
 > was invoked without a pre-generated diff review. The SKILL.md prompt layer is responsible for
-> spawning `ycc:code-reviewer` and passing `--diff-review <path>` to this orchestrator.
+> spawning `yci:change-reviewer` and passing `--diff-review <path>` to this orchestrator.
 PLACEHOLDER
 fi
 

--- a/yci/skills/network-change-review/tests/test_agent_delegation.sh
+++ b/yci/skills/network-change-review/tests/test_agent_delegation.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# yci network-change-review — delegation contract tests
+#
+# Verifies the skill-layer handoff to yci:change-reviewer remains wired and that
+# the delegated reviewer is given active-profile context rather than relying on
+# implicit runtime state.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=./helpers.sh
+source "${SCRIPT_DIR}/helpers.sh"
+
+SKILL_MD="${SKILL_ROOT}/SKILL.md"
+AGENT_MD="${PLUGIN_ROOT}/agents/change-reviewer.md"
+REVIEW_SH="${SKILL_ROOT}/scripts/review.sh"
+
+test_skill_delegates_to_yci_change_reviewer() {
+    printf '\n--- delegation: skill delegates to yci reviewer ---\n'
+
+    local skill_text
+    skill_text="$(cat "${SKILL_MD}")"
+
+    assert_contains 'subagent_type: "yci:change-reviewer"' "${skill_text}" \
+        'SKILL.md uses yci:change-reviewer for diff review'
+
+    assert_not_contains 'subagent_type: "ycc:code-reviewer"' "${skill_text}" \
+        'SKILL.md no longer uses ycc:code-reviewer for diff review'
+}
+
+test_skill_passes_profile_context() {
+    printf '\n--- delegation: skill passes active profile context ---\n'
+
+    local skill_text
+    skill_text="$(cat "${SKILL_MD}")"
+
+    assert_contains '<profile-json-path>' "${skill_text}" \
+        'SKILL.md prompt includes staged profile snapshot path'
+
+    assert_contains '<inventory-root>' "${skill_text}" \
+        'SKILL.md prompt includes inventory root'
+
+    assert_contains '<customer-id>' "${skill_text}" \
+        'SKILL.md prompt includes resolved customer id'
+
+    assert_contains 'load-profile.sh' "${skill_text}" \
+        'SKILL.md stages profile context via load-profile.sh'
+
+    assert_contains 'absolute path, keep' "${skill_text}" \
+        'SKILL.md documents absolute inventory-root precedence'
+
+    assert_contains '<resolved-data-root>/profiles/<inventory-root>' "${skill_text}" \
+        'SKILL.md documents profiles-relative inventory-root precedence'
+
+    assert_contains '<resolved-data-root>/<inventory-root>' "${skill_text}" \
+        'SKILL.md documents data-root-relative inventory-root precedence'
+}
+
+test_change_reviewer_contract_mentions_customer_guard() {
+    printf '\n--- delegation: reviewer contract documents isolation ---\n'
+
+    local agent_text
+    agent_text="$(cat "${AGENT_MD}")"
+
+    assert_contains 'profile.json' "${agent_text}" \
+        'change-reviewer.md references staged profile snapshot'
+
+    assert_contains 'inventory root' "${agent_text}" \
+        'change-reviewer.md references inventory root boundary'
+
+    assert_contains 'source of truth for active-customer state' "${agent_text}" \
+        'change-reviewer.md treats profile snapshot as customer source of truth'
+
+    assert_contains 'do not require them to live under the inventory root' "${agent_text}" \
+        'change-reviewer.md allows caller-supplied diff/profile paths outside inventory root'
+}
+
+test_review_sh_text_matches_delegation() {
+    printf '\n--- delegation: review.sh help text matches reviewer path ---\n'
+
+    local review_text
+    review_text="$(cat "${REVIEW_SH}")"
+
+    assert_contains 'yci:change-reviewer' "${review_text}" \
+        'review.sh references yci:change-reviewer'
+
+    assert_not_contains 'ycc:code-reviewer' "${review_text}" \
+        'review.sh no longer references ycc:code-reviewer'
+}
+
+test_skill_delegates_to_yci_change_reviewer
+test_skill_passes_profile_context
+test_change_reviewer_contract_mentions_customer_guard
+test_review_sh_text_matches_delegation
+
+summary

--- a/yci/skills/network-change-review/tests/test_agent_delegation.sh
+++ b/yci/skills/network-change-review/tests/test_agent_delegation.sh
@@ -19,6 +19,7 @@ test_skill_delegates_to_yci_change_reviewer() {
     printf '\n--- delegation: skill delegates to yci reviewer ---\n'
 
     local skill_text
+    [ -f "${SKILL_MD}" ] || { echo "Error: required file ${SKILL_MD} not found" >&2; exit 1; }
     skill_text="$(cat "${SKILL_MD}")"
 
     assert_contains 'subagent_type: "yci:change-reviewer"' "${skill_text}" \
@@ -32,6 +33,7 @@ test_skill_passes_profile_context() {
     printf '\n--- delegation: skill passes active profile context ---\n'
 
     local skill_text
+    [ -f "${SKILL_MD}" ] || { echo "Error: required file ${SKILL_MD} not found" >&2; exit 1; }
     skill_text="$(cat "${SKILL_MD}")"
 
     assert_contains '<profile-json-path>' "${skill_text}" \
@@ -60,6 +62,7 @@ test_change_reviewer_contract_mentions_customer_guard() {
     printf '\n--- delegation: reviewer contract documents isolation ---\n'
 
     local agent_text
+    [ -f "${AGENT_MD}" ] || { echo "Error: required file ${AGENT_MD} not found" >&2; exit 1; }
     agent_text="$(cat "${AGENT_MD}")"
 
     assert_contains 'profile.json' "${agent_text}" \
@@ -79,6 +82,7 @@ test_review_sh_text_matches_delegation() {
     printf '\n--- delegation: review.sh help text matches reviewer path ---\n'
 
     local review_text
+    [ -f "${REVIEW_SH}" ] || { echo "Error: required file ${REVIEW_SH} not found" >&2; exit 1; }
     review_text="$(cat "${REVIEW_SH}")"
 
     assert_contains 'yci:change-reviewer' "${review_text}" \


### PR DESCRIPTION
## Summary

This PR closes out the remaining work for the `yci:change-reviewer` agent by wiring the `network-change-review` workflow to delegate its diff-review slice through the new yci-native reviewer path. It also aligns the skill, agent, orchestrator-facing references, and validation rules so the documented delegation contract matches the runtime behavior.

## Changes

- Switch `yci:network-change-review` from `ycc:code-reviewer` to `yci:change-reviewer` for the diff-review section while keeping `ycc:planner` for the change-plan slice.
- Tighten the `yci:change-reviewer` runtime contract around staged profile context, inventory-root precedence, and customer-boundary semantics.
- Update supporting references and shell help text so the delegated reviewer path is described consistently across the workflow.
- Add `test_agent_delegation.sh` and strengthen `validate-yci-skills.sh` to execute the full `network-change-review` harness and enforce the delegation contract.

## Documentation

- Updated: `yci/CONTRIBUTING.md`
- Updated: `yci/skills/network-change-review/references/composition-contract.md`
- Updated: `yci/skills/network-change-review/references/artifact-template.md`

## Testing

### Delegation Contract

**How to test:**

1. Run `bash yci/skills/network-change-review/tests/run-all.sh test_agent_delegation.sh`
2. Verify the delegation contract test passes

**Expected results:**

- `network-change-review` delegates diff review to `yci:change-reviewer`
- The staged customer/profile/inventory-root handoff is asserted

### Full Workflow Validation

**How to test:**

1. Run `bash yci/skills/network-change-review/tests/run-all.sh`
2. Run `bash scripts/validate-yci-skills.sh`

**Expected results:**

- All `network-change-review` tests pass, including end-to-end fixture coverage
- `validate-yci-skills.sh` passes and runs the `network-change-review` harness internally

## Related Issues

Closes #33
Closes #61

## Breaking Changes

- No breaking changes

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated where needed
- [x] Tests added/updated
- [x] All relevant tests passing locally
- [x] No new validation failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated network-change-review docs to delegate diff review to a new reviewer, require staging of an active profile snapshot, and define an inventory-root customer isolation contract.

* **Tests**
  * Added end-to-end validation that verifies delegation wiring, staged profile/context placeholders, and reviewer boundary expectations.

* **Chores**
  * Strengthened validation checks and overall test-harness reporting to enforce the delegation and customer-context requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->