### PR TITLE
feat(quick-review): interactive inline review with confirm flow

### DIFF
--- a/.codex-plugin/ycc/shared/references/review-checklist.md
+++ b/.codex-plugin/ycc/shared/references/review-checklist.md
@@ -1,0 +1,168 @@
+# Review Checklist (Shared Reference)
+
+> Canonical review checklist, severity rubric, parallel-reviewer roster, and
+> standard findings format. Consumed by `code-review` (local + PR modes)
+> and `quick-review`. Skills that delegate here MUST NOT duplicate the
+> content below — reference this file instead.
+
+---
+
+## Severity Rubric
+
+| Severity     | Meaning                                     | Action                  |
+| ------------ | ------------------------------------------- | ----------------------- |
+| **CRITICAL** | Security vulnerability or data loss risk    | Must fix before merge   |
+| **HIGH**     | Bug or logic error likely to cause issues   | Should fix before merge |
+| **MEDIUM**   | Code quality issue or missing best practice | Fix recommended         |
+| **LOW**      | Style nit or minor suggestion               | Optional                |
+
+Findings are grouped by severity in the artifact under `### CRITICAL`,
+`### HIGH`, `### MEDIUM`, `### LOW`, in that order.
+
+---
+
+## Local / Quick Review — Single-Pass Checklist (Path A)
+
+Applied to uncommitted changes on `HEAD`. Read each changed file in full.
+
+**Security Issues (CRITICAL):**
+
+- Hardcoded credentials, API keys, tokens
+- SQL injection vulnerabilities
+- XSS vulnerabilities
+- Missing input validation
+- Insecure dependencies
+- Path traversal risks
+
+**Code Quality (HIGH):**
+
+- Functions > 50 lines
+- Files > 800 lines
+- Nesting depth > 4 levels
+- Missing error handling
+- `console.log` statements
+- TODO/FIXME comments
+- Missing JSDoc for public APIs
+
+**Best Practices (MEDIUM):**
+
+- Mutation patterns (use immutable instead)
+- Emoji usage in code/comments
+- Missing tests for new code
+- Accessibility issues (a11y)
+
+---
+
+## PR Review — Single-Pass Checklist (Path A, 7 Categories)
+
+Applied to PR head-revision file contents. Each category is independent —
+a single finding may touch several.
+
+| Category               | What to Check                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| **Correctness**        | Logic errors, off-by-ones, null handling, edge cases, race conditions         |
+| **Type Safety**        | Type mismatches, unsafe casts, `any` usage, missing generics                  |
+| **Pattern Compliance** | Matches project conventions (naming, file structure, error handling, imports) |
+| **Security**           | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS              |
+| **Performance**        | N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads   |
+| **Completeness**       | Missing tests, missing error handling, incomplete migrations, missing docs    |
+| **Maintainability**    | Dead code, magic numbers, deep nesting, unclear naming, missing types         |
+
+---
+
+## Parallel Reviewer Roster (Path B / Path C)
+
+Three standalone `code-reviewer` sub-agents (Path B) or agent-team teammates
+(Path C). The **focus split** differs between local/quick and PR modes because
+local mode has a narrower category set.
+
+### Local / Quick Mode Roster
+
+| Reviewer               | Focus           | Checklist Items                                                                                                               |
+| ---------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `correctness-reviewer` | Code Quality    | Functions > 50 lines, files > 800 lines, nesting > 4 levels, missing error handling, `console.log`, TODO/FIXME, missing JSDoc |
+| `security-reviewer`    | Security Issues | Hardcoded credentials/keys/tokens, SQL injection, XSS, missing input validation, insecure deps, path traversal                |
+| `quality-reviewer`     | Best Practices  | Mutation patterns, emoji in code/comments, missing tests, accessibility (a11y)                                                |
+
+### PR Mode Roster
+
+| Reviewer               | Categories                             | What to Check                                                                                                                                                             |
+| ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `correctness-reviewer` | Correctness, Type Safety, Completeness | Logic errors, off-by-ones, null handling, edge cases, race conditions, type mismatches, unsafe casts, `any` usage, missing generics, missing tests, incomplete migrations |
+| `security-reviewer`    | Security, Performance                  | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS, N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads                             |
+| `quality-reviewer`     | Pattern Compliance, Maintainability    | Project conventions (naming, file structure, error handling, imports), dead code, magic numbers, deep nesting, unclear naming, missing types                              |
+
+Each reviewer prompt MUST include:
+
+1. The list of changed files (mode-specific: `git diff --name-only HEAD` for
+   local/quick; PR number + head revision + changed-file list for PR).
+2. Relevant context (AGENTS.md rules, PRP artifacts, PR description) — PR mode only.
+3. Its assigned focus / categories and what to check (from the appropriate table
+   above).
+4. The severity rubric.
+5. A directive to return findings in the **Standard Findings Format** below.
+
+---
+
+## Standard Findings Format (Reviewer Output)
+
+Each parallel reviewer returns findings in this shape (pre-merge, before
+finding-ID assignment):
+
+```markdown
+## Findings
+
+### CRITICAL
+
+- `file.ts:42` — [description] [category]
+  - Suggested fix: [fix]
+
+### HIGH
+
+- ...
+
+### MEDIUM
+
+- ...
+
+### LOW
+
+- ...
+```
+
+The `[category]` tag applies to PR mode; local/quick mode may omit it (the focus
+split already implies a category).
+
+---
+
+## Merge Procedure (Path B / Path C)
+
+After all 3 reviewers return:
+
+1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW).
+2. De-duplicate findings at the same `file:line` (if two reviewers flagged the
+   same issue, keep the more severe one and annotate which reviewers concurred).
+3. Sort within each severity by file path.
+4. Attach the reviewer source to each finding (`[correctness]`, `[security]`,
+   `[quality]`) for traceability.
+
+Pass the merged findings to the REPORT phase as if they came from a single-pass
+review.
+
+---
+
+## Finding Artifact Fields
+
+After merging, each finding is promoted to an artifact-format block with these
+fields. The `[F###]` ID is assigned sequentially ordered by severity (CRITICAL
+first), then by file path. Status is always `Open` on first write.
+
+```markdown
+- **[F001]** `file:line` — description
+  - **Status**: Open
+  - **Category**: <category>
+  - **Suggested fix**: <fix>
+```
+
+See `$code-review` → "Review Artifact Format" for the full artifact schema
+(Header, Summary, Findings, Worktree Setup, Validation Results, Files Reviewed).

--- a/.codex-plugin/ycc/skills/code-review/SKILL.md
+++ b/.codex-plugin/ycc/skills/code-review/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: code-review
 description: Dual-mode code review — local uncommitted changes OR a GitHub pull request.
-  Both modes now write a machine-parseable review artifact (Local → docs/prps/reviews/local-{timestamp}-review.md,
+  Both modes write a machine-parseable review artifact (Local → docs/prps/reviews/local-{timestamp}-review.md,
   PR → docs/prps/reviews/pr-{N}-review.md) with sequential finding IDs (F001, F002,
   ...) and Status fields (Open/Fixed/Failed) so $review-fix can consume and update
   them in place. Local mode runs a full security + quality pass on the diff. PR mode
   fetches the PR, reads each changed file in full, builds context from AGENTS.md and
   PRP artifacts, applies a 7-category review checklist, runs validation commands (type-check/lint/test/build)
-  for detected stacks, assigns severity, and posts the review to GitHub via gh. Pass
-  `--parallel` to fan out the REVIEW phase across 3 standalone code-reviewer sub-agents
-  (correctness, security, quality) and merge findings.
+  for detected stacks, assigns severity, and posts the review to GitHub via gh. For
+  fast, inline, interactive reviews of short uncommitted changes (no file written
+  unless confirmed), use `$quick-review` directly — `--quick` here is kept as a thin
+  alias that delegates.
 ---
 
 # Code Review
@@ -24,17 +25,17 @@ description: Dual-mode code review — local uncommitted changes OR a GitHub pul
 
 Before selecting mode, extract flags from `$ARGUMENTS`:
 
-| Flag                | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--approve`         | Force the final decision to APPROVE regardless of findings (still reports all findings)                                                                                                                                                                                                                                                                                                                                                                                     |
-| `--request-changes` | Force the final decision to REQUEST CHANGES regardless of findings                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `--parallel`        | Fan out the REVIEW phase across 3 **standalone** `code-reviewer` sub-agents (correctness, security, quality) dispatched in parallel and merge findings. Works in Codex, Cursor, and Codex.                                                                                                                                                                                                                                                                        |
-| `--team`            | (Codex only) Fan out the REVIEW phase across the same 3 `code-reviewer` reviewers, but dispatched as an **agent team** with up-front `record the task`, shared `the task tracker` observability, inter-reviewer coordination via `send follow-up instructions`, and coordinated shutdown before merge. Heavier dispatch, richer communication.                                                                                                                                                 |
-| `--worktree`        | (legacy / now default; safe to omit) Check out the PR head branch into an isolated worktree at `~/.claude-worktrees/<repo>-pr-<N>/`. Worktree mode is on by default in PR mode; pass `--no-worktree` to opt out.                                                                                                                                                                                                                                                            |
-| `--no-worktree`     | Opt out of worktree isolation in PR mode. Skip worktree creation, artifact commit+push, and cleanup. Files are read directly from the main checkout.                                                                                                                                                                                                                                                                                                                        |
-| `--keep-draft`      | Skip the automatic draft→ready promotion in PR mode. Default: PR is promoted to Ready for Review before posting the review.                                                                                                                                                                                                                                                                                                                                                 |
-| `--keep-worktree`   | Skip removal of the PR worktree after the review is posted. The artifact is still committed and pushed to the PR branch. Default: worktree is removed via `git worktree remove <path>` after a clean review post.                                                                                                                                                                                                                                                           |
-| `--quick`           | Fast on-the-fly review of uncommitted changes. Skips worktree setup, toolchain validation (typecheck/lint/test/build), and GitHub publish. Writes a minimal artifact to `docs/prps/reviews/quick-{timestamp}-review.md` and ends with a `Next steps:` block recommending `$review-fix` (single-pass) or `$review-fix --parallel` (fan-out). Compatible with `--parallel` and `--team`. Mutually exclusive with a PR argument, `--approve`, and `--request-changes`. |
+| Flag                | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--approve`         | Force the final decision to APPROVE regardless of findings (still reports all findings)                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `--request-changes` | Force the final decision to REQUEST CHANGES regardless of findings                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `--parallel`        | Fan out the REVIEW phase across 3 **standalone** `code-reviewer` sub-agents (correctness, security, quality) dispatched in parallel and merge findings. Works in Codex, Cursor, and Codex.                                                                                                                                                                                                                                                                                                   |
+| `--team`            | (Codex only) Fan out the REVIEW phase across the same 3 `code-reviewer` reviewers, but dispatched as an **agent team** with up-front `record the task`, shared `the task tracker` observability, inter-reviewer coordination via `send follow-up instructions`, and coordinated shutdown before merge. Heavier dispatch, richer communication.                                                                                                                                                                            |
+| `--worktree`        | (legacy / now default; safe to omit) Check out the PR head branch into an isolated worktree at `~/.claude-worktrees/<repo>-pr-<N>/`. Worktree mode is on by default in PR mode; pass `--no-worktree` to opt out.                                                                                                                                                                                                                                                                                       |
+| `--no-worktree`     | Opt out of worktree isolation in PR mode. Skip worktree creation, artifact commit+push, and cleanup. Files are read directly from the main checkout.                                                                                                                                                                                                                                                                                                                                                   |
+| `--keep-draft`      | Skip the automatic draft→ready promotion in PR mode. Default: PR is promoted to Ready for Review before posting the review.                                                                                                                                                                                                                                                                                                                                                                            |
+| `--keep-worktree`   | Skip removal of the PR worktree after the review is posted. The artifact is still committed and pushed to the PR branch. Default: worktree is removed via `git worktree remove <path>` after a clean review post.                                                                                                                                                                                                                                                                                      |
+| `--quick`           | **Alias for `$quick-review`.** Fast interactive review of uncommitted changes — prints findings inline and asks Apply fixes / Save to file / Discard. Writes only on confirmation. Compatible with `--parallel` and `--team`. Mutually exclusive with a PR argument, `--approve`, and `--request-changes`. This skill validates the combination and then delegates to `$quick-review` with the remaining flags. See that skill's `--yes`, `--save`, and `--severity` options for scripted use. |
 
 Strip these from `$ARGUMENTS` and set `QUICK_MODE=true|false`, `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `NO_WORKTREE_MODE=true|false`, `KEEP_DRAFT=true|false`, and `KEEP_WORKTREE=true|false`. Compute `WORKTREE_MODE=true` unless `--no-worktree` is present (default-on in PR mode; ignored for local mode as before). The remaining text is the mode selector (PR number/URL or blank for local).
 
@@ -148,82 +149,29 @@ The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
 
 #### Path A — Single-Pass Review (default, neither flag set)
 
-Read each changed file in full. Check for:
+Read each changed file in full and apply the **Local / Quick Review —
+Single-Pass Checklist** (Security CRITICAL, Code Quality HIGH, Best Practices
+MEDIUM) and the **Severity Rubric** from:
 
-**Security Issues (CRITICAL):**
-
-- Hardcoded credentials, API keys, tokens
-- SQL injection vulnerabilities
-- XSS vulnerabilities
-- Missing input validation
-- Insecure dependencies
-- Path traversal risks
-
-**Code Quality (HIGH):**
-
-- Functions > 50 lines
-- Files > 800 lines
-- Nesting depth > 4 levels
-- Missing error handling
-- `console.log` statements
-- TODO/FIXME comments
-- Missing JSDoc for public APIs
-
-**Best Practices (MEDIUM):**
-
-- Mutation patterns (use immutable instead)
-- Emoji usage in code/comments
-- Missing tests for new code
-- Accessibility issues (a11y)
+```
+~/.codex/plugins/ycc/shared/references/review-checklist.md
+```
 
 #### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
 
-Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE message with MULTIPLE `Agent` tool calls. Each agent reads all changed files and applies its assigned focus:
+Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **Local / Quick Mode Roster**
+(`correctness-reviewer`, `security-reviewer`, `quality-reviewer`) and
+**Standard Findings Format** from:
 
-| Reviewer               | Focus           | Checklist Items                                                                                                               |
-| ---------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `correctness-reviewer` | Code Quality    | Functions > 50 lines, files > 800 lines, nesting > 4 levels, missing error handling, `console.log`, TODO/FIXME, missing JSDoc |
-| `security-reviewer`    | Security Issues | Hardcoded credentials/keys/tokens, SQL injection, XSS, missing input validation, insecure deps, path traversal                |
-| `quality-reviewer`     | Best Practices  | Mutation patterns, emoji in code/comments, missing tests, accessibility (a11y)                                                |
-
-Each reviewer prompt must include:
-
-1. The list of changed files (`git diff --name-only HEAD`)
-2. Its assigned focus and checklist items (from the table above)
-3. The severity rubric (CRITICAL, HIGH, MEDIUM, LOW)
-4. A directive to return findings in the standard format below
-
-Each reviewer returns findings as:
-
-```markdown
-## Findings
-
-### CRITICAL
-
-- `file.ts:42` — [description]
-  - Suggested fix: [fix]
-
-### HIGH
-
-- ...
-
-### MEDIUM
-
-- ...
-
-### LOW
-
-- ...
+```
+~/.codex/plugins/ycc/shared/references/review-checklist.md
 ```
 
-After all 3 reviewers return, **merge findings**:
-
-1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW)
-2. De-duplicate findings at the same `file:line` (if two reviewers flagged the same issue, keep the more severe one and annotate which reviewers concurred)
-3. Sort within each severity by file path
-4. Attach the reviewer source to each finding (`[correctness]`, `[security]`, `[quality]`) for traceability
-
-Pass the merged findings to Phase 3 (REPORT) as if they came from a single-pass review.
+The reviewer-prompt contract (changed files, focus + checklist items, severity
+rubric, findings format directive) and the **Merge Procedure** are defined
+in that reference. Pass the merged findings to Phase 3 (REPORT) as if they
+came from a single-pass review.
 
 #### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Codex only)
 
@@ -345,55 +293,32 @@ Never approve code with security vulnerabilities.
 
 ## Quick Review Mode
 
-> Triggered by `--quick`. Lightweight review of uncommitted changes — no worktree, no toolchain validation, no GitHub publish. Just findings plus a `Next steps:` block offering `$review-fix`. Writes a minimal artifact to `docs/prps/reviews/quick-{YYYYMMDD-HHMMSS}-review.md` so `$review-fix` can consume it unchanged.
+> Triggered by `--quick`. This mode is now a **thin delegator** to
+> `$quick-review` — the interactive inline-review skill. Phase 0 above
+> has already validated the flag combination; this section hands off.
 
-### Phase 1 — GATHER
+### Delegation
 
-Identical to Local Review Mode Phase 1 (line 151 above). Compute changed files with:
-
-```bash
-git diff --name-only HEAD
-```
-
-If the diff is empty, print `Nothing to review.` and exit. Do NOT write an artifact.
-
-### Phase 2 — REVIEW
-
-Delegate to **Local Review Mode Phase 2** (starting at line 159 above). The same 7-category checklist, severity rubric, Path A (single-pass) / Path B (`--parallel` → 3 standalone sub-agent reviewers) / Path C (`--team` → coordinated agent team) all apply unchanged.
-
-- If `--parallel` → Path B fan-out.
-- If `--team` → Path C (Codex only; compatibility gate already enforced in Phase 0).
-- Otherwise → Path A.
-
-When using Path C in quick mode, use team name `qrev-local-<YYYYMMDD-HHMMSS>` (matching the artifact timestamp). Lifecycle is identical to Local Mode Path C: create an agent group → record the task × 3 → Agent × 3 in one message → monitor via the task tracker → merge → send follow-up instructions shutdown → close the agent group.
-
-### Phase 3 — REPORT
-
-Assign sequential finding IDs (F001, F002, …) with `Status: Open` on every finding. Write the artifact to `docs/prps/reviews/quick-{YYYYMMDD-HHMMSS}-review.md`. The artifact uses the **Review Artifact Format** (defined at the bottom of this skill) with two omissions:
-
-- **No** `## Validation Results` section — quick mode does not run toolchain validation.
-- **No** `## Worktree Setup` section — quick mode never creates a worktree.
-
-All other sections (Header, Summary, Findings with full ID/Status/Category/Suggested fix, Files Reviewed) are identical to Local Mode's output. `$review-fix` parses the result unchanged.
-
-Then print a `Next steps:` block to stdout:
+Invoke the `quick-review` skill via the `Skill` tool. Forward the
+remaining flags — `--parallel` or `--team`, plus anything quick-review
+accepts — but drop the flags this skill owns (`--quick`, `--approve`,
+`--request-changes`, `--no-worktree`, `--keep-draft`, `--keep-worktree`;
+Phase 0 already consumed them).
 
 ```
-Quick review written to: docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md
-Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
-
-Next steps:
-  $review-fix docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md              # apply fixes {recommended_single if 1-2 Open findings}
-  $review-fix docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md --parallel   # fan out fixes {recommended_parallel if 3+ Open across 2+ files}
+Skill: quick-review
+  args: "<stripped flags: --parallel | --team | --yes | --save | --severity <level>>"
 ```
 
-**Recommendation heuristic** (annotate ONE of the two commands with `# ← recommended`):
+Print a single one-line notice before delegating so the user sees what
+happened:
 
-- 0 Open findings → print `No findings. No follow-up needed.` and skip the two `$review-fix` command lines.
-- 1–2 Open findings → recommend the single-pass form.
-- 3+ Open findings spanning 2+ files → recommend the `--parallel` form.
+```
+--quick delegated to $quick-review. Run $quick-review directly for full option surface (--yes, --save, --severity).
+```
 
-Quick mode has **NO** Phase 4/5/6/7/8 — no VALIDATE, DECIDE, PUBLISH, or OUTPUT phases. If you need toolchain validation or a GitHub review posted, re-run without `--quick`.
+After the Skill call returns, exit. Do NOT run Phase 4/5/6/7/8. Do NOT
+write an artifact here — quick-review owns the artifact lifecycle.
 
 ---
 
@@ -460,69 +385,37 @@ The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
 
 #### Path A — Single-Pass Review (default, neither flag set)
 
-Apply the review checklist across 7 categories:
+Apply the **PR Review — Single-Pass Checklist** (7 categories: Correctness,
+Type Safety, Pattern Compliance, Security, Performance, Completeness,
+Maintainability) and the **Severity Rubric** from:
 
-| Category               | What to Check                                                                 |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Correctness**        | Logic errors, off-by-ones, null handling, edge cases, race conditions         |
-| **Type Safety**        | Type mismatches, unsafe casts, `any` usage, missing generics                  |
-| **Pattern Compliance** | Matches project conventions (naming, file structure, error handling, imports) |
-| **Security**           | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS              |
-| **Performance**        | N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads   |
-| **Completeness**       | Missing tests, missing error handling, incomplete migrations, missing docs    |
-| **Maintainability**    | Dead code, magic numbers, deep nesting, unclear naming, missing types         |
+```
+~/.codex/plugins/ycc/shared/references/review-checklist.md
+```
 
 #### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
 
-Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE message with MULTIPLE `Agent` tool calls. Each agent reads all changed files at the PR head revision and applies its assigned category slice:
+Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **PR Mode Roster**
+(`correctness-reviewer`, `security-reviewer`, `quality-reviewer`) and
+**Standard Findings Format** from:
 
-| Reviewer               | Categories                             | What to Check                                                                                                                                                             |
-| ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `correctness-reviewer` | Correctness, Type Safety, Completeness | Logic errors, off-by-ones, null handling, edge cases, race conditions, type mismatches, unsafe casts, `any` usage, missing generics, missing tests, incomplete migrations |
-| `security-reviewer`    | Security, Performance                  | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS, N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads                             |
-| `quality-reviewer`     | Pattern Compliance, Maintainability    | Project conventions (naming, file structure, error handling, imports), dead code, magic numbers, deep nesting, unclear naming, missing types                              |
+```
+~/.codex/plugins/ycc/shared/references/review-checklist.md
+```
 
-Each reviewer prompt must include:
+Each reviewer prompt must additionally include:
 
 1. The PR number, head revision, and the list of changed files
 2. Relevant context from Phase 2 (AGENTS.md rules, PRP artifacts, PR description)
-3. Its assigned categories and what to check (from the table above)
-4. The severity rubric
-5. A directive to return findings in the standard format below
 
-Each reviewer returns findings as:
+The reviewer-prompt contract (focus + categories, severity rubric, findings
+format directive) and the **Merge Procedure** are defined in that reference.
+Pass the merged findings to Phase 4 (VALIDATE) and downstream phases as if
+they came from a single-pass review.
 
-```markdown
-## Findings
-
-### CRITICAL
-
-- `file.ts:42` — [description] [category]
-  - Suggested fix: [fix]
-
-### HIGH
-
-- ...
-
-### MEDIUM
-
-- ...
-
-### LOW
-
-- ...
-```
-
-After all 3 reviewers return, **merge findings**:
-
-1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW)
-2. De-duplicate findings at the same `file:line` (if two reviewers flagged the same issue, keep the more severe one and list both concurring reviewers)
-3. Sort within each severity by file path
-4. Tag each finding with its source reviewer (`[correctness]`, `[security]`, `[quality]`) for traceability
-
-Pass the merged findings to Phase 4 (VALIDATE) and downstream phases as if they came from a single-pass review.
-
-**Note**: Validation commands (Phase 4) still run sequentially in the main skill — parallelization here only applies to the review pass.
+**Note**: Validation commands (Phase 4) still run sequentially in the main
+skill — parallelization here only applies to the review pass.
 
 #### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Codex only)
 

--- a/.codex-plugin/ycc/skills/quick-review/SKILL.md
+++ b/.codex-plugin/ycc/skills/quick-review/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: quick-review
+description: Fast interactive review of uncommitted changes. Prints findings inline
+  (no file written by default), then asks Apply fixes / Save to file / Discard. Writing
+  only happens on confirmation. Hands off to $review-fix on "Apply fixes". Designed
+  for short, low-friction code changes where opening a full $code-review artifact
+  is overkill. Pass `--parallel` to fan out across 3 standalone code-reviewer sub-agents
+  (correctness, security, quality). Pass `--team` (Codex only) for the same fan-out
+  as a coordinated agent team. `--parallel` and `--team` are mutually exclusive. Pass
+  `--yes` to auto-confirm (Apply fixes) or `--save` to auto-confirm (Save to file)
+  for scripted use. Pass `--severity <CRITICAL|HIGH|MEDIUM|LOW>` to forward the minimum
+  severity threshold to $review-fix (default HIGH). Use when the user asks to "quick
+  review", "fast review", "review what I have", "on-the-fly review", or says "/quick-review".
+  `$code-review --quick` delegates here.
+---
+
+# Quick Review
+
+Interactive low-friction review of uncommitted changes. Output is **inline**;
+a review artifact is only written on confirmation.
+
+**Input**: `$ARGUMENTS`
+
+**Core rule**: You will **NOT** write a review artifact until the user
+explicitly selects "Apply fixes" or "Save to file". "Discard" writes nothing.
+
+---
+
+## Phase 0 — Parse flags
+
+Extract flags from `$ARGUMENTS`:
+
+| Flag                 | Effect                                                                                                                                                                                                    |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--parallel`         | Fan out REVIEW across 3 standalone `code-reviewer` sub-agents (correctness, security, quality) and merge findings. Works in Codex, Cursor, and Codex bundles.                                   |
+| `--team`             | (Codex only) Same 3-reviewer fan-out as a coordinated agent team with `create an agent group`, shared `the task tracker`, per-reviewer `record the task`, and coordinated shutdown. Heavier dispatch, richer communication. |
+| `--yes`              | Skip the confirmation prompt in Phase 4 and behave as "Apply fixes". Mutually exclusive with `--save`.                                                                                                    |
+| `--save`             | Skip the confirmation prompt in Phase 4 and behave as "Save to file" (write artifact, print Next steps, exit). Mutually exclusive with `--yes`.                                                           |
+| `--severity <level>` | Forwarded to `$review-fix` during hand-off. Valid: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`. Default: `HIGH`. Ignored on "Save to file" / "Discard".                                                       |
+| `--no-worktree`      | Accepted as a **no-op**. Quick mode never creates a worktree. Emit a note: `--no-worktree has no effect in quick mode.`                                                                                   |
+
+Strip these from `$ARGUMENTS` and set `PARALLEL_MODE`, `AGENT_TEAM_MODE`,
+`AUTO_YES`, `AUTO_SAVE`, and `MIN_SEVERITY` (default `HIGH`). The remaining
+text MUST be empty; if not, abort with:
+
+```
+Error: $quick-review takes no positional argument (only flags).
+```
+
+**Validation**:
+
+- `--parallel` and `--team` mutually exclusive → abort with: `--parallel and --team are mutually exclusive. Pick one.`
+- `--yes` and `--save` mutually exclusive → abort with: `--yes and --save are mutually exclusive. Pick one.`
+- `--team` in a Cursor/Codex bundle (no `create an agent group` tool) → abort with: `--team is not supported in bundle invocations; use --parallel instead.`
+- `--severity` value not one of `CRITICAL|HIGH|MEDIUM|LOW` → abort with: `Invalid --severity value. Use CRITICAL, HIGH, MEDIUM, or LOW.`
+
+---
+
+## Phase 1 — GATHER
+
+```bash
+git diff --name-only HEAD
+```
+
+If the output is empty, print `Nothing to review.` and exit. Do NOT prompt,
+do NOT write anything.
+
+Capture the list of changed files as `CHANGED_FILES` for the REVIEW phase.
+
+---
+
+## Phase 2 — REVIEW
+
+The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
+
+| Flags             | Path                                        |
+| ----------------- | ------------------------------------------- |
+| Neither set       | **Path A** — single-pass review (default)   |
+| `PARALLEL_MODE`   | **Path B** — 3 parallel sub-agent reviewers |
+| `AGENT_TEAM_MODE` | **Path C** — 3-reviewer agent team          |
+
+Findings from all paths stay **in memory** — do not write to disk yet.
+
+### Path A — Single-Pass Review (default)
+
+Read each changed file in full and apply the **Local / Quick Review —
+Single-Pass Checklist** and **Severity Rubric** from:
+
+```
+~/.codex/plugins/ycc/shared/references/review-checklist.md
+```
+
+### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
+
+Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **Local / Quick Mode Roster**
+and **Standard Findings Format** from:
+
+```
+~/.codex/plugins/ycc/shared/references/review-checklist.md
+```
+
+Each reviewer prompt must include:
+
+1. The list of changed files (`git diff --name-only HEAD`)
+2. Its assigned focus and checklist items (from the roster table)
+3. The severity rubric
+4. A directive to return findings in the Standard Findings Format
+
+Apply the **Merge Procedure** defined in the reference to produce a single
+combined findings list for Phase 3.
+
+### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Codex only)
+
+> **MANDATORY — AGENT TEAMS REQUIRED**
+>
+> You MUST follow the agent-team lifecycle. Every `Agent` call MUST include
+> `name=` AND `name=`. See
+> `~/.codex/plugins/ycc/shared/references/agent-team-dispatch.md`.
+
+Roster and category split identical to Path B.
+
+#### C.1 Build the team name
+
+Team name: `qrev-local-<YYYYMMDD-HHMMSS>`. Generate the timestamp once at the
+start of Phase 2 and reuse it if the user later selects "Save to file" or
+"Apply fixes" (for artifact filename consistency).
+
+#### C.2 Create the team
+
+```
+create an agent group: name="qrev-local-<timestamp>", description="Quick review team for uncommitted local changes"
+```
+
+On failure, abort.
+
+#### C.3 Register subtasks
+
+Create 3 tasks in the shared task list (flat graph — reviewers are independent):
+
+```
+record the task: subject="correctness-reviewer: code-quality review of uncommitted changes", description="<full reviewer prompt>"
+record the task: subject="security-reviewer: security review of uncommitted changes",        description="<full reviewer prompt>"
+record the task: subject="quality-reviewer: best-practices review of uncommitted changes",   description="<full reviewer prompt>"
+```
+
+If any `record the task` fails → `close the agent group`, abort.
+
+#### C.4 Spawn the 3 reviewers
+
+Single message, three `Agent` calls. Every call MUST include `team_name`, `name`
+(matching the `record the task` subject prefix), `subagent_type="code-reviewer"`,
+description, and a prompt equivalent to Path B's reviewer prompt plus a note
+that the teammate shares a task list with two siblings (name them) and may
+`send follow-up instructions` them on overlaps, and must call `update the task tracker` to mark its task
+complete before returning.
+
+#### C.5 Monitor and collect results
+
+Use `the task tracker` until all 3 tasks are `completed`. Failure policy:
+
+- All 3 error → `close the agent group`, abort with a clear error.
+- 1 or 2 error → record "partial review — {role} did not complete" and proceed
+  with the remaining findings. Note the gap when printing inline.
+
+#### C.6 Shutdown and cleanup
+
+```
+send follow-up instructions(to="correctness-reviewer", message={type:"shutdown_request"})
+send follow-up instructions(to="security-reviewer",    message={type:"shutdown_request"})
+send follow-up instructions(to="quality-reviewer",     message={type:"shutdown_request"})
+close the agent group
+```
+
+Always `close the agent group` — even on abort or partial failure.
+
+#### C.7 Merge findings
+
+Apply the reference's Merge Procedure and pass the combined findings to Phase 3.
+
+---
+
+## Phase 3 — REPORT (inline)
+
+Assign sequential finding IDs (`F001`, `F002`, …) ordered by severity
+(CRITICAL first) then by file path. Every finding gets `Status: Open`.
+
+Compute the finding counts by severity: `C`, `H`, `M`, `L`.
+
+**Print** the review to stdout in the Review Artifact Format, **without**
+writing a file. The printed block looks like:
+
+```markdown
+# Quick Review — Uncommitted Changes
+
+**Reviewed**: <ISO date>
+**Mode**: Quick (inline)
+**Author**: local
+**Branch**: <current-branch>
+**Decision**: (pending user confirmation)
+
+## Summary
+
+<1–2 sentence overall assessment>
+
+## Findings
+
+### CRITICAL
+
+- **[F001]** `file:line` — <description>
+  - **Status**: Open
+  - **Category**: <Security | Correctness | Code Quality | Best Practices>
+  - **Suggested fix**: <concrete fix>
+
+### HIGH
+
+- **[F002]** ...
+  - **Status**: Open
+  - ...
+
+### MEDIUM
+
+- **[F003]** ...
+  - **Status**: Open
+  - ...
+
+### LOW
+
+- **[F004]** ...
+  - **Status**: Open
+  - ...
+
+## Files Reviewed
+
+- `file1.ts` (Modified)
+- `file2.ts` (Added)
+```
+
+**Omissions** (vs. the standard Review Artifact Format): no
+`## Worktree Setup` section (quick mode never creates a worktree) and no
+`## Validation Results` section (quick mode does not run toolchain checks).
+
+After the artifact block, print a one-line summary:
+
+```
+Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
+```
+
+If the count is zero across all severities, skip Phase 4 entirely. Print
+`No findings. Nothing to do.` and exit.
+
+Otherwise continue to Phase 4.
+
+---
+
+## Phase 4 — DECIDE (confirmation)
+
+If `AUTO_YES=true` → skip this phase, proceed directly to Phase 5 as if the
+user selected "Apply fixes".
+
+If `AUTO_SAVE=true` → skip this phase, proceed directly to Phase 5 as if the
+user selected "Save to file".
+
+Otherwise, ask the user with `ask the user`:
+
+```
+question: "What should I do with this review?"
+header:   "Review action"
+options:
+  - label: "Apply fixes"
+    description: "Write the review artifact to docs/prps/reviews/ and hand off to $review-fix (recommended)"
+  - label: "Save to file"
+    description: "Write the review artifact to docs/prps/reviews/ and stop — you can run $review-fix later"
+  - label: "Discard"
+    description: "Write nothing, exit"
+```
+
+Mark "Apply fixes" with `(Recommended)` in its label when
+`critical_count + high_count > 0`; otherwise leave it unmarked.
+
+**Text-mode fallback** (if `ask the user` is unavailable — Cursor/Codex
+bundles without that tool): print the three choices explicitly and WAIT for
+the user's next message. Parse their reply case-insensitively:
+
+- `yes` / `apply` / `apply fixes` / `fix` → "Apply fixes"
+- `save` / `save to file` / `write` / `file` → "Save to file"
+- `no` / `discard` / `cancel` / `skip` → "Discard"
+- Anything else → re-prompt once, then default to `Discard` if still ambiguous.
+
+---
+
+## Phase 5 — HAND-OFF
+
+Branch on the user's selection (or the auto-confirm flag).
+
+### Selection: "Discard"
+
+Print `Discarded. No artifact written.` and exit. Do NOT write any file.
+
+### Selection: "Save to file"
+
+Write the artifact to disk using the Phase 3 content plus the canonical
+header block:
+
+```bash
+mkdir -p docs/prps/reviews
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)    # reuse the Path C timestamp if set
+REVIEW_FILE="docs/prps/reviews/quick-${TIMESTAMP}-review.md"
+```
+
+Write the same artifact content that was printed in Phase 3, but set
+`**Decision**: COMMENT` in the header (since a review was produced but no
+GitHub decision is being posted).
+
+Print the Next steps block to stdout:
+
+```
+Quick review written to: docs/prps/reviews/quick-<TIMESTAMP>-review.md
+Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
+
+Next steps:
+  $review-fix docs/prps/reviews/quick-<TIMESTAMP>-review.md              # apply fixes {recommended_single if 1-2 Open findings}
+  $review-fix docs/prps/reviews/quick-<TIMESTAMP>-review.md --parallel   # fan out fixes {recommended_parallel if 3+ Open across 2+ files}
+```
+
+Annotate ONE of the two commands with `# ← recommended`:
+
+- 1–2 Open findings → recommend the single-pass form.
+- 3+ Open findings spanning 2+ files → recommend the `--parallel` form.
+- Otherwise default to the single-pass form.
+
+Exit.
+
+### Selection: "Apply fixes"
+
+Step 1 — write the artifact to disk (same as "Save to file" above) so
+`$review-fix` can parse and update it in place.
+
+Step 2 — invoke the `review-fix` skill inline via the `Skill` tool:
+
+- `skill`: `"review-fix"`
+- `args`: `"<REVIEW_FILE> [--parallel] [--severity <level>]"` — always pass the
+  explicit review path. Forward `--parallel` if `PARALLEL_MODE=true`. Forward
+  `--severity <level>` when `MIN_SEVERITY != HIGH` (HIGH is the default on
+  review-fix so omitting it produces the same behavior).
+
+Step 3 — after the Skill call returns, print a one-line confirmation:
+
+```
+Fixes complete. Review artifact updated in place: docs/prps/reviews/quick-<TIMESTAMP>-review.md
+```
+
+Step 4 — exit.
+
+**Note**: `--team` from quick-review is NOT forwarded to `$review-fix`
+automatically. The review-phase fan-out is about finding issues quickly;
+the fix phase has its own decision. If the user wants team-mode fixes they
+can re-run `$review-fix <path> --team` themselves.
+
+---
+
+## Important Notes
+
+- **No artifact until confirmation**: "Discard" MUST write nothing. "Save to
+  file" and "Apply fixes" both write once, to the same canonical path.
+- **Idempotent filename**: the `quick-{YYYYMMDD-HHMMSS}-review.md` pattern
+  produces a new file per invocation — no overwrites.
+- **Parity with `$code-review`**: the artifact format and finding schema
+  are identical, so `$review-fix` consumes it unchanged.
+- **Not a replacement for `$code-review`**: if you need toolchain
+  validation (typecheck/lint/test/build), a `## Validation Results` block,
+  worktree isolation, or a GitHub review posted, use `$code-review`
+  without `--quick`.
+
+---
+
+## Integration with ycc
+
+- `$code-review --quick` delegates to this skill.
+- `$review-fix` consumes the written artifact.
+- `$prp-commit` or `$git-workflow` can commit the fixes afterward.

--- a/.cursor-plugin/skills/_shared/references/review-checklist.md
+++ b/.cursor-plugin/skills/_shared/references/review-checklist.md
@@ -1,0 +1,168 @@
+# Review Checklist (Shared Reference)
+
+> Canonical review checklist, severity rubric, parallel-reviewer roster, and
+> standard findings format. Consumed by `code-review` (local + PR modes)
+> and `quick-review`. Skills that delegate here MUST NOT duplicate the
+> content below — reference this file instead.
+
+---
+
+## Severity Rubric
+
+| Severity     | Meaning                                     | Action                  |
+| ------------ | ------------------------------------------- | ----------------------- |
+| **CRITICAL** | Security vulnerability or data loss risk    | Must fix before merge   |
+| **HIGH**     | Bug or logic error likely to cause issues   | Should fix before merge |
+| **MEDIUM**   | Code quality issue or missing best practice | Fix recommended         |
+| **LOW**      | Style nit or minor suggestion               | Optional                |
+
+Findings are grouped by severity in the artifact under `### CRITICAL`,
+`### HIGH`, `### MEDIUM`, `### LOW`, in that order.
+
+---
+
+## Local / Quick Review — Single-Pass Checklist (Path A)
+
+Applied to uncommitted changes on `HEAD`. Read each changed file in full.
+
+**Security Issues (CRITICAL):**
+
+- Hardcoded credentials, API keys, tokens
+- SQL injection vulnerabilities
+- XSS vulnerabilities
+- Missing input validation
+- Insecure dependencies
+- Path traversal risks
+
+**Code Quality (HIGH):**
+
+- Functions > 50 lines
+- Files > 800 lines
+- Nesting depth > 4 levels
+- Missing error handling
+- `console.log` statements
+- TODO/FIXME comments
+- Missing JSDoc for public APIs
+
+**Best Practices (MEDIUM):**
+
+- Mutation patterns (use immutable instead)
+- Emoji usage in code/comments
+- Missing tests for new code
+- Accessibility issues (a11y)
+
+---
+
+## PR Review — Single-Pass Checklist (Path A, 7 Categories)
+
+Applied to PR head-revision file contents. Each category is independent —
+a single finding may touch several.
+
+| Category               | What to Check                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| **Correctness**        | Logic errors, off-by-ones, null handling, edge cases, race conditions         |
+| **Type Safety**        | Type mismatches, unsafe casts, `any` usage, missing generics                  |
+| **Pattern Compliance** | Matches project conventions (naming, file structure, error handling, imports) |
+| **Security**           | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS              |
+| **Performance**        | N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads   |
+| **Completeness**       | Missing tests, missing error handling, incomplete migrations, missing docs    |
+| **Maintainability**    | Dead code, magic numbers, deep nesting, unclear naming, missing types         |
+
+---
+
+## Parallel Reviewer Roster (Path B / Path C)
+
+Three standalone `code-reviewer` sub-agents (Path B) or agent-team teammates
+(Path C). The **focus split** differs between local/quick and PR modes because
+local mode has a narrower category set.
+
+### Local / Quick Mode Roster
+
+| Reviewer               | Focus           | Checklist Items                                                                                                               |
+| ---------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `correctness-reviewer` | Code Quality    | Functions > 50 lines, files > 800 lines, nesting > 4 levels, missing error handling, `console.log`, TODO/FIXME, missing JSDoc |
+| `security-reviewer`    | Security Issues | Hardcoded credentials/keys/tokens, SQL injection, XSS, missing input validation, insecure deps, path traversal                |
+| `quality-reviewer`     | Best Practices  | Mutation patterns, emoji in code/comments, missing tests, accessibility (a11y)                                                |
+
+### PR Mode Roster
+
+| Reviewer               | Categories                             | What to Check                                                                                                                                                             |
+| ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `correctness-reviewer` | Correctness, Type Safety, Completeness | Logic errors, off-by-ones, null handling, edge cases, race conditions, type mismatches, unsafe casts, `any` usage, missing generics, missing tests, incomplete migrations |
+| `security-reviewer`    | Security, Performance                  | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS, N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads                             |
+| `quality-reviewer`     | Pattern Compliance, Maintainability    | Project conventions (naming, file structure, error handling, imports), dead code, magic numbers, deep nesting, unclear naming, missing types                              |
+
+Each reviewer prompt MUST include:
+
+1. The list of changed files (mode-specific: `git diff --name-only HEAD` for
+   local/quick; PR number + head revision + changed-file list for PR).
+2. Relevant context (CLAUDE.md rules, PRP artifacts, PR description) — PR mode only.
+3. Its assigned focus / categories and what to check (from the appropriate table
+   above).
+4. The severity rubric.
+5. A directive to return findings in the **Standard Findings Format** below.
+
+---
+
+## Standard Findings Format (Reviewer Output)
+
+Each parallel reviewer returns findings in this shape (pre-merge, before
+finding-ID assignment):
+
+```markdown
+## Findings
+
+### CRITICAL
+
+- `file.ts:42` — [description] [category]
+  - Suggested fix: [fix]
+
+### HIGH
+
+- ...
+
+### MEDIUM
+
+- ...
+
+### LOW
+
+- ...
+```
+
+The `[category]` tag applies to PR mode; local/quick mode may omit it (the focus
+split already implies a category).
+
+---
+
+## Merge Procedure (Path B / Path C)
+
+After all 3 reviewers return:
+
+1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW).
+2. De-duplicate findings at the same `file:line` (if two reviewers flagged the
+   same issue, keep the more severe one and annotate which reviewers concurred).
+3. Sort within each severity by file path.
+4. Attach the reviewer source to each finding (`[correctness]`, `[security]`,
+   `[quality]`) for traceability.
+
+Pass the merged findings to the REPORT phase as if they came from a single-pass
+review.
+
+---
+
+## Finding Artifact Fields
+
+After merging, each finding is promoted to an artifact-format block with these
+fields. The `[F###]` ID is assigned sequentially ordered by severity (CRITICAL
+first), then by file path. Status is always `Open` on first write.
+
+```markdown
+- **[F001]** `file:line` — description
+  - **Status**: Open
+  - **Category**: <category>
+  - **Suggested fix**: <fix>
+```
+
+See `/code-review` → "Review Artifact Format" for the full artifact schema
+(Header, Summary, Findings, Worktree Setup, Validation Results, Files Reviewed).

--- a/.cursor-plugin/skills/code-review/SKILL.md
+++ b/.cursor-plugin/skills/code-review/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: code-review
-description: Dual-mode code review — local uncommitted changes OR a GitHub pull request. Both modes now write a machine-parseable review artifact (Local → docs/prps/reviews/local-{timestamp}-review.md, PR → docs/prps/reviews/pr-{N}-review.md) with sequential finding IDs (F001, F002, ...) and Status fields (Open/Fixed/Failed) so /review-fix can consume and update them in place. Local mode runs a full security + quality pass on the diff. PR mode fetches the PR, reads each changed file in full, builds context from CLAUDE.md and PRP artifacts, applies a 7-category review checklist, runs validation commands (type-check/lint/test/build) for detected stacks, assigns severity, and posts the review to GitHub via gh. Pass `--parallel` to fan out the REVIEW phase across 3 standalone code-reviewer sub-agents (correctness, security, quality) and merge findings. Pass `--team` (Claude Code only) to run the same 3-reviewer fan-out as a coordinated agent team with shared TaskList, per-reviewer task tracking, and inter-reviewer communication via SendMessage. `--parallel` and `--team` are mutually exclusive. Worktree mode is on by default in PR mode — pass `--no-worktree` to opt out. Pass `--keep-draft` to skip automatic draft→ready promotion. Pass `--keep-worktree` to skip worktree removal after the review is posted. Use when the user asks to "review code", "review PR", "check uncommitted changes", "review pr N", "parallel review", "team review", or says "/code-review". Adapted from PRPs-agentic-eng by Wirasm.
+description: Dual-mode code review — local uncommitted changes OR a GitHub pull request. Both modes write a machine-parseable review artifact (Local → docs/prps/reviews/local-{timestamp}-review.md, PR → docs/prps/reviews/pr-{N}-review.md) with sequential finding IDs (F001, F002, ...) and Status fields (Open/Fixed/Failed) so /review-fix can consume and update them in place. Local mode runs a full security + quality pass on the diff. PR mode fetches the PR, reads each changed file in full, builds context from CLAUDE.md and PRP artifacts, applies a 7-category review checklist, runs validation commands (type-check/lint/test/build) for detected stacks, assigns severity, and posts the review to GitHub via gh. For fast, inline, interactive reviews of short uncommitted changes (no file written unless confirmed), use `/quick-review` directly — `--quick` here is kept as a thin alias that delegates. Pass `--parallel` to fan out the REVIEW phase across 3 standalone code-reviewer sub-agents (correctness, security, quality) and merge findings. Pass `--team` (Claude Code only) to run the same 3-reviewer fan-out as a coordinated agent team with shared TaskList, per-reviewer task tracking, and inter-reviewer communication via SendMessage. `--parallel` and `--team` are mutually exclusive. Worktree mode is on by default in PR mode — pass `--no-worktree` to opt out. Pass `--keep-draft` to skip automatic draft→ready promotion. Pass `--keep-worktree` to skip worktree removal after the review is posted. Use when the user asks to "review code", "review PR", "check uncommitted changes", "review pr N", "parallel review", "team review", or says "/code-review". Adapted from PRPs-agentic-eng by Wirasm.
 argument-hint: '[--approve | --request-changes] [--parallel | --team] [--no-worktree] [--keep-draft] [--keep-worktree] [pr-number | pr-url | blank for local review]'
 allowed-tools:
   - Read
   - Grep
   - Glob
   - Write
+  - Skill
   - Agent
   - TeamCreate
   - TeamDelete
@@ -47,17 +48,17 @@ allowed-tools:
 
 Before selecting mode, extract flags from `$ARGUMENTS`:
 
-| Flag                | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--approve`         | Force the final decision to APPROVE regardless of findings (still reports all findings)                                                                                                                                                                                                                                                                                                                                                                                     |
-| `--request-changes` | Force the final decision to REQUEST CHANGES regardless of findings                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `--parallel`        | Fan out the REVIEW phase across 3 **standalone** `code-reviewer` sub-agents (correctness, security, quality) dispatched in parallel and merge findings. Works in Claude Code, Cursor, and Codex.                                                                                                                                                                                                                                                                        |
-| `--team`            | (Claude Code only) Fan out the REVIEW phase across the same 3 `code-reviewer` reviewers, but dispatched as an **agent team** with up-front `TaskCreate`, shared `TaskList` observability, inter-reviewer coordination via `SendMessage`, and coordinated shutdown before merge. Heavier dispatch, richer communication.                                                                                                                                                 |
-| `--worktree`        | (legacy / now default; safe to omit) Check out the PR head branch into an isolated worktree at `~/.claude-worktrees/<repo>-pr-<N>/`. Worktree mode is on by default in PR mode; pass `--no-worktree` to opt out.                                                                                                                                                                                                                                                            |
-| `--no-worktree`     | Opt out of worktree isolation in PR mode. Skip worktree creation, artifact commit+push, and cleanup. Files are read directly from the main checkout.                                                                                                                                                                                                                                                                                                                        |
-| `--keep-draft`      | Skip the automatic draft→ready promotion in PR mode. Default: PR is promoted to Ready for Review before posting the review.                                                                                                                                                                                                                                                                                                                                                 |
-| `--keep-worktree`   | Skip removal of the PR worktree after the review is posted. The artifact is still committed and pushed to the PR branch. Default: worktree is removed via `git worktree remove <path>` after a clean review post.                                                                                                                                                                                                                                                           |
-| `--quick`           | Fast on-the-fly review of uncommitted changes. Skips worktree setup, toolchain validation (typecheck/lint/test/build), and GitHub publish. Writes a minimal artifact to `docs/prps/reviews/quick-{timestamp}-review.md` and ends with a `Next steps:` block recommending `/review-fix` (single-pass) or `/review-fix --parallel` (fan-out). Compatible with `--parallel` and `--team`. Mutually exclusive with a PR argument, `--approve`, and `--request-changes`. |
+| Flag                | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--approve`         | Force the final decision to APPROVE regardless of findings (still reports all findings)                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `--request-changes` | Force the final decision to REQUEST CHANGES regardless of findings                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `--parallel`        | Fan out the REVIEW phase across 3 **standalone** `code-reviewer` sub-agents (correctness, security, quality) dispatched in parallel and merge findings. Works in Claude Code, Cursor, and Codex.                                                                                                                                                                                                                                                                                                   |
+| `--team`            | (Claude Code only) Fan out the REVIEW phase across the same 3 `code-reviewer` reviewers, but dispatched as an **agent team** with up-front `TaskCreate`, shared `TaskList` observability, inter-reviewer coordination via `SendMessage`, and coordinated shutdown before merge. Heavier dispatch, richer communication.                                                                                                                                                                            |
+| `--worktree`        | (legacy / now default; safe to omit) Check out the PR head branch into an isolated worktree at `~/.claude-worktrees/<repo>-pr-<N>/`. Worktree mode is on by default in PR mode; pass `--no-worktree` to opt out.                                                                                                                                                                                                                                                                                       |
+| `--no-worktree`     | Opt out of worktree isolation in PR mode. Skip worktree creation, artifact commit+push, and cleanup. Files are read directly from the main checkout.                                                                                                                                                                                                                                                                                                                                                   |
+| `--keep-draft`      | Skip the automatic draft→ready promotion in PR mode. Default: PR is promoted to Ready for Review before posting the review.                                                                                                                                                                                                                                                                                                                                                                            |
+| `--keep-worktree`   | Skip removal of the PR worktree after the review is posted. The artifact is still committed and pushed to the PR branch. Default: worktree is removed via `git worktree remove <path>` after a clean review post.                                                                                                                                                                                                                                                                                      |
+| `--quick`           | **Alias for `/quick-review`.** Fast interactive review of uncommitted changes — prints findings inline and asks Apply fixes / Save to file / Discard. Writes only on confirmation. Compatible with `--parallel` and `--team`. Mutually exclusive with a PR argument, `--approve`, and `--request-changes`. This skill validates the combination and then delegates to `/quick-review` with the remaining flags. See that skill's `--yes`, `--save`, and `--severity` options for scripted use. |
 
 Strip these from `$ARGUMENTS` and set `QUICK_MODE=true|false`, `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `NO_WORKTREE_MODE=true|false`, `KEEP_DRAFT=true|false`, and `KEEP_WORKTREE=true|false`. Compute `WORKTREE_MODE=true` unless `--no-worktree` is present (default-on in PR mode; ignored for local mode as before). The remaining text is the mode selector (PR number/URL or blank for local).
 
@@ -171,82 +172,29 @@ The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
 
 #### Path A — Single-Pass Review (default, neither flag set)
 
-Read each changed file in full. Check for:
+Read each changed file in full and apply the **Local / Quick Review —
+Single-Pass Checklist** (Security CRITICAL, Code Quality HIGH, Best Practices
+MEDIUM) and the **Severity Rubric** from:
 
-**Security Issues (CRITICAL):**
-
-- Hardcoded credentials, API keys, tokens
-- SQL injection vulnerabilities
-- XSS vulnerabilities
-- Missing input validation
-- Insecure dependencies
-- Path traversal risks
-
-**Code Quality (HIGH):**
-
-- Functions > 50 lines
-- Files > 800 lines
-- Nesting depth > 4 levels
-- Missing error handling
-- `console.log` statements
-- TODO/FIXME comments
-- Missing JSDoc for public APIs
-
-**Best Practices (MEDIUM):**
-
-- Mutation patterns (use immutable instead)
-- Emoji usage in code/comments
-- Missing tests for new code
-- Accessibility issues (a11y)
+```
+${CURSOR_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
+```
 
 #### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
 
-Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE message with MULTIPLE `Agent` tool calls. Each agent reads all changed files and applies its assigned focus:
+Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **Local / Quick Mode Roster**
+(`correctness-reviewer`, `security-reviewer`, `quality-reviewer`) and
+**Standard Findings Format** from:
 
-| Reviewer               | Focus           | Checklist Items                                                                                                               |
-| ---------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `correctness-reviewer` | Code Quality    | Functions > 50 lines, files > 800 lines, nesting > 4 levels, missing error handling, `console.log`, TODO/FIXME, missing JSDoc |
-| `security-reviewer`    | Security Issues | Hardcoded credentials/keys/tokens, SQL injection, XSS, missing input validation, insecure deps, path traversal                |
-| `quality-reviewer`     | Best Practices  | Mutation patterns, emoji in code/comments, missing tests, accessibility (a11y)                                                |
-
-Each reviewer prompt must include:
-
-1. The list of changed files (`git diff --name-only HEAD`)
-2. Its assigned focus and checklist items (from the table above)
-3. The severity rubric (CRITICAL, HIGH, MEDIUM, LOW)
-4. A directive to return findings in the standard format below
-
-Each reviewer returns findings as:
-
-```markdown
-## Findings
-
-### CRITICAL
-
-- `file.ts:42` — [description]
-  - Suggested fix: [fix]
-
-### HIGH
-
-- ...
-
-### MEDIUM
-
-- ...
-
-### LOW
-
-- ...
+```
+${CURSOR_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
 ```
 
-After all 3 reviewers return, **merge findings**:
-
-1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW)
-2. De-duplicate findings at the same `file:line` (if two reviewers flagged the same issue, keep the more severe one and annotate which reviewers concurred)
-3. Sort within each severity by file path
-4. Attach the reviewer source to each finding (`[correctness]`, `[security]`, `[quality]`) for traceability
-
-Pass the merged findings to Phase 3 (REPORT) as if they came from a single-pass review.
+The reviewer-prompt contract (changed files, focus + checklist items, severity
+rubric, findings format directive) and the **Merge Procedure** are defined
+in that reference. Pass the merged findings to Phase 3 (REPORT) as if they
+came from a single-pass review.
 
 #### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Claude Code only)
 
@@ -368,55 +316,32 @@ Never approve code with security vulnerabilities.
 
 ## Quick Review Mode
 
-> Triggered by `--quick`. Lightweight review of uncommitted changes — no worktree, no toolchain validation, no GitHub publish. Just findings plus a `Next steps:` block offering `/review-fix`. Writes a minimal artifact to `docs/prps/reviews/quick-{YYYYMMDD-HHMMSS}-review.md` so `/review-fix` can consume it unchanged.
+> Triggered by `--quick`. This mode is now a **thin delegator** to
+> `/quick-review` — the interactive inline-review skill. Phase 0 above
+> has already validated the flag combination; this section hands off.
 
-### Phase 1 — GATHER
+### Delegation
 
-Identical to Local Review Mode Phase 1 (line 151 above). Compute changed files with:
-
-```bash
-git diff --name-only HEAD
-```
-
-If the diff is empty, print `Nothing to review.` and exit. Do NOT write an artifact.
-
-### Phase 2 — REVIEW
-
-Delegate to **Local Review Mode Phase 2** (starting at line 159 above). The same 7-category checklist, severity rubric, Path A (single-pass) / Path B (`--parallel` → 3 standalone sub-agent reviewers) / Path C (`--team` → coordinated agent team) all apply unchanged.
-
-- If `--parallel` → Path B fan-out.
-- If `--team` → Path C (Claude Code only; compatibility gate already enforced in Phase 0).
-- Otherwise → Path A.
-
-When using Path C in quick mode, use team name `qrev-local-<YYYYMMDD-HHMMSS>` (matching the artifact timestamp). Lifecycle is identical to Local Mode Path C: TeamCreate → TaskCreate × 3 → Agent × 3 in one message → monitor via TaskList → merge → SendMessage shutdown → TeamDelete.
-
-### Phase 3 — REPORT
-
-Assign sequential finding IDs (F001, F002, …) with `Status: Open` on every finding. Write the artifact to `docs/prps/reviews/quick-{YYYYMMDD-HHMMSS}-review.md`. The artifact uses the **Review Artifact Format** (defined at the bottom of this skill) with two omissions:
-
-- **No** `## Validation Results` section — quick mode does not run toolchain validation.
-- **No** `## Worktree Setup` section — quick mode never creates a worktree.
-
-All other sections (Header, Summary, Findings with full ID/Status/Category/Suggested fix, Files Reviewed) are identical to Local Mode's output. `/review-fix` parses the result unchanged.
-
-Then print a `Next steps:` block to stdout:
+Invoke the `quick-review` skill via the `Skill` tool. Forward the
+remaining flags — `--parallel` or `--team`, plus anything quick-review
+accepts — but drop the flags this skill owns (`--quick`, `--approve`,
+`--request-changes`, `--no-worktree`, `--keep-draft`, `--keep-worktree`;
+Phase 0 already consumed them).
 
 ```
-Quick review written to: docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md
-Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
-
-Next steps:
-  /review-fix docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md              # apply fixes {recommended_single if 1-2 Open findings}
-  /review-fix docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md --parallel   # fan out fixes {recommended_parallel if 3+ Open across 2+ files}
+Skill: quick-review
+  args: "<stripped flags: --parallel | --team | --yes | --save | --severity <level>>"
 ```
 
-**Recommendation heuristic** (annotate ONE of the two commands with `# ← recommended`):
+Print a single one-line notice before delegating so the user sees what
+happened:
 
-- 0 Open findings → print `No findings. No follow-up needed.` and skip the two `/review-fix` command lines.
-- 1–2 Open findings → recommend the single-pass form.
-- 3+ Open findings spanning 2+ files → recommend the `--parallel` form.
+```
+--quick delegated to /quick-review. Run /quick-review directly for full option surface (--yes, --save, --severity).
+```
 
-Quick mode has **NO** Phase 4/5/6/7/8 — no VALIDATE, DECIDE, PUBLISH, or OUTPUT phases. If you need toolchain validation or a GitHub review posted, re-run without `--quick`.
+After the Skill call returns, exit. Do NOT run Phase 4/5/6/7/8. Do NOT
+write an artifact here — quick-review owns the artifact lifecycle.
 
 ---
 
@@ -483,69 +408,37 @@ The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
 
 #### Path A — Single-Pass Review (default, neither flag set)
 
-Apply the review checklist across 7 categories:
+Apply the **PR Review — Single-Pass Checklist** (7 categories: Correctness,
+Type Safety, Pattern Compliance, Security, Performance, Completeness,
+Maintainability) and the **Severity Rubric** from:
 
-| Category               | What to Check                                                                 |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Correctness**        | Logic errors, off-by-ones, null handling, edge cases, race conditions         |
-| **Type Safety**        | Type mismatches, unsafe casts, `any` usage, missing generics                  |
-| **Pattern Compliance** | Matches project conventions (naming, file structure, error handling, imports) |
-| **Security**           | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS              |
-| **Performance**        | N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads   |
-| **Completeness**       | Missing tests, missing error handling, incomplete migrations, missing docs    |
-| **Maintainability**    | Dead code, magic numbers, deep nesting, unclear naming, missing types         |
+```
+${CURSOR_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
+```
 
 #### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
 
-Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE message with MULTIPLE `Agent` tool calls. Each agent reads all changed files at the PR head revision and applies its assigned category slice:
+Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **PR Mode Roster**
+(`correctness-reviewer`, `security-reviewer`, `quality-reviewer`) and
+**Standard Findings Format** from:
 
-| Reviewer               | Categories                             | What to Check                                                                                                                                                             |
-| ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `correctness-reviewer` | Correctness, Type Safety, Completeness | Logic errors, off-by-ones, null handling, edge cases, race conditions, type mismatches, unsafe casts, `any` usage, missing generics, missing tests, incomplete migrations |
-| `security-reviewer`    | Security, Performance                  | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS, N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads                             |
-| `quality-reviewer`     | Pattern Compliance, Maintainability    | Project conventions (naming, file structure, error handling, imports), dead code, magic numbers, deep nesting, unclear naming, missing types                              |
+```
+${CURSOR_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
+```
 
-Each reviewer prompt must include:
+Each reviewer prompt must additionally include:
 
 1. The PR number, head revision, and the list of changed files
 2. Relevant context from Phase 2 (CLAUDE.md rules, PRP artifacts, PR description)
-3. Its assigned categories and what to check (from the table above)
-4. The severity rubric
-5. A directive to return findings in the standard format below
 
-Each reviewer returns findings as:
+The reviewer-prompt contract (focus + categories, severity rubric, findings
+format directive) and the **Merge Procedure** are defined in that reference.
+Pass the merged findings to Phase 4 (VALIDATE) and downstream phases as if
+they came from a single-pass review.
 
-```markdown
-## Findings
-
-### CRITICAL
-
-- `file.ts:42` — [description] [category]
-  - Suggested fix: [fix]
-
-### HIGH
-
-- ...
-
-### MEDIUM
-
-- ...
-
-### LOW
-
-- ...
-```
-
-After all 3 reviewers return, **merge findings**:
-
-1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW)
-2. De-duplicate findings at the same `file:line` (if two reviewers flagged the same issue, keep the more severe one and list both concurring reviewers)
-3. Sort within each severity by file path
-4. Tag each finding with its source reviewer (`[correctness]`, `[security]`, `[quality]`) for traceability
-
-Pass the merged findings to Phase 4 (VALIDATE) and downstream phases as if they came from a single-pass review.
-
-**Note**: Validation commands (Phase 4) still run sequentially in the main skill — parallelization here only applies to the review pass.
+**Note**: Validation commands (Phase 4) still run sequentially in the main
+skill — parallelization here only applies to the review pass.
 
 #### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Claude Code only)
 

--- a/.cursor-plugin/skills/quick-review/SKILL.md
+++ b/.cursor-plugin/skills/quick-review/SKILL.md
@@ -1,0 +1,393 @@
+---
+name: quick-review
+description: Fast interactive review of uncommitted changes. Prints findings inline (no file written by default), then asks Apply fixes / Save to file / Discard. Writing only happens on confirmation. Hands off to /review-fix on "Apply fixes". Designed for short, low-friction code changes where opening a full /code-review artifact is overkill. Pass `--parallel` to fan out across 3 standalone code-reviewer sub-agents (correctness, security, quality). Pass `--team` (Claude Code only) for the same fan-out as a coordinated agent team. `--parallel` and `--team` are mutually exclusive. Pass `--yes` to auto-confirm (Apply fixes) or `--save` to auto-confirm (Save to file) for scripted use. Pass `--severity <CRITICAL|HIGH|MEDIUM|LOW>` to forward the minimum severity threshold to /review-fix (default HIGH). Use when the user asks to "quick review", "fast review", "review what I have", "on-the-fly review", or says "/quick-review". `/code-review --quick` delegates here.
+argument-hint: '[--parallel | --team] [--yes | --save] [--severity <level>] [--no-worktree]'
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - Edit
+  - Skill
+  - Agent
+  - AskUserQuestion
+  - TeamCreate
+  - TeamDelete
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - TaskGet
+  - SendMessage
+  - Bash(git:*)
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - Bash(test:*)
+  - Bash(mkdir:*)
+  - Bash(date:*)
+---
+
+# Quick Review
+
+Interactive low-friction review of uncommitted changes. Output is **inline**;
+a review artifact is only written on confirmation.
+
+**Input**: `$ARGUMENTS`
+
+**Core rule**: You will **NOT** write a review artifact until the user
+explicitly selects "Apply fixes" or "Save to file". "Discard" writes nothing.
+
+---
+
+## Phase 0 — Parse flags
+
+Extract flags from `$ARGUMENTS`:
+
+| Flag                 | Effect                                                                                                                                                                                                    |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--parallel`         | Fan out REVIEW across 3 standalone `code-reviewer` sub-agents (correctness, security, quality) and merge findings. Works in Claude Code, Cursor, and Codex bundles.                                   |
+| `--team`             | (Claude Code only) Same 3-reviewer fan-out as a coordinated agent team with `TeamCreate`, shared `TaskList`, per-reviewer `TaskCreate`, and coordinated shutdown. Heavier dispatch, richer communication. |
+| `--yes`              | Skip the confirmation prompt in Phase 4 and behave as "Apply fixes". Mutually exclusive with `--save`.                                                                                                    |
+| `--save`             | Skip the confirmation prompt in Phase 4 and behave as "Save to file" (write artifact, print Next steps, exit). Mutually exclusive with `--yes`.                                                           |
+| `--severity <level>` | Forwarded to `/review-fix` during hand-off. Valid: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`. Default: `HIGH`. Ignored on "Save to file" / "Discard".                                                       |
+| `--no-worktree`      | Accepted as a **no-op**. Quick mode never creates a worktree. Emit a note: `--no-worktree has no effect in quick mode.`                                                                                   |
+
+Strip these from `$ARGUMENTS` and set `PARALLEL_MODE`, `AGENT_TEAM_MODE`,
+`AUTO_YES`, `AUTO_SAVE`, and `MIN_SEVERITY` (default `HIGH`). The remaining
+text MUST be empty; if not, abort with:
+
+```
+Error: /quick-review takes no positional argument (only flags).
+```
+
+**Validation**:
+
+- `--parallel` and `--team` mutually exclusive → abort with: `--parallel and --team are mutually exclusive. Pick one.`
+- `--yes` and `--save` mutually exclusive → abort with: `--yes and --save are mutually exclusive. Pick one.`
+- `--team` in a Cursor/Codex bundle (no `TeamCreate` tool) → abort with: `--team is not supported in bundle invocations; use --parallel instead.`
+- `--severity` value not one of `CRITICAL|HIGH|MEDIUM|LOW` → abort with: `Invalid --severity value. Use CRITICAL, HIGH, MEDIUM, or LOW.`
+
+---
+
+## Phase 1 — GATHER
+
+```bash
+git diff --name-only HEAD
+```
+
+If the output is empty, print `Nothing to review.` and exit. Do NOT prompt,
+do NOT write anything.
+
+Capture the list of changed files as `CHANGED_FILES` for the REVIEW phase.
+
+---
+
+## Phase 2 — REVIEW
+
+The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
+
+| Flags             | Path                                        |
+| ----------------- | ------------------------------------------- |
+| Neither set       | **Path A** — single-pass review (default)   |
+| `PARALLEL_MODE`   | **Path B** — 3 parallel sub-agent reviewers |
+| `AGENT_TEAM_MODE` | **Path C** — 3-reviewer agent team          |
+
+Findings from all paths stay **in memory** — do not write to disk yet.
+
+### Path A — Single-Pass Review (default)
+
+Read each changed file in full and apply the **Local / Quick Review —
+Single-Pass Checklist** and **Severity Rubric** from:
+
+```
+${CURSOR_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
+```
+
+### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
+
+Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **Local / Quick Mode Roster**
+and **Standard Findings Format** from:
+
+```
+${CURSOR_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
+```
+
+Each reviewer prompt must include:
+
+1. The list of changed files (`git diff --name-only HEAD`)
+2. Its assigned focus and checklist items (from the roster table)
+3. The severity rubric
+4. A directive to return findings in the Standard Findings Format
+
+Apply the **Merge Procedure** defined in the reference to produce a single
+combined findings list for Phase 3.
+
+### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Claude Code only)
+
+> **MANDATORY — AGENT TEAMS REQUIRED**
+>
+> You MUST follow the agent-team lifecycle. Every `Agent` call MUST include
+> `team_name=` AND `name=`. See
+> `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/agent-team-dispatch.md`.
+
+Roster and category split identical to Path B.
+
+#### C.1 Build the team name
+
+Team name: `qrev-local-<YYYYMMDD-HHMMSS>`. Generate the timestamp once at the
+start of Phase 2 and reuse it if the user later selects "Save to file" or
+"Apply fixes" (for artifact filename consistency).
+
+#### C.2 Create the team
+
+```
+TeamCreate: team_name="qrev-local-<timestamp>", description="Quick review team for uncommitted local changes"
+```
+
+On failure, abort.
+
+#### C.3 Register subtasks
+
+Create 3 tasks in the shared task list (flat graph — reviewers are independent):
+
+```
+TaskCreate: subject="correctness-reviewer: code-quality review of uncommitted changes", description="<full reviewer prompt>"
+TaskCreate: subject="security-reviewer: security review of uncommitted changes",        description="<full reviewer prompt>"
+TaskCreate: subject="quality-reviewer: best-practices review of uncommitted changes",   description="<full reviewer prompt>"
+```
+
+If any `TaskCreate` fails → `TeamDelete`, abort.
+
+#### C.4 Spawn the 3 reviewers
+
+Single message, three `Agent` calls. Every call MUST include `team_name`, `name`
+(matching the `TaskCreate` subject prefix), `subagent_type="code-reviewer"`,
+description, and a prompt equivalent to Path B's reviewer prompt plus a note
+that the teammate shares a task list with two siblings (name them) and may
+`SendMessage` them on overlaps, and must call `TaskUpdate` to mark its task
+complete before returning.
+
+#### C.5 Monitor and collect results
+
+Use `TaskList` until all 3 tasks are `completed`. Failure policy:
+
+- All 3 error → `TeamDelete`, abort with a clear error.
+- 1 or 2 error → record "partial review — {role} did not complete" and proceed
+  with the remaining findings. Note the gap when printing inline.
+
+#### C.6 Shutdown and cleanup
+
+```
+SendMessage(to="correctness-reviewer", message={type:"shutdown_request"})
+SendMessage(to="security-reviewer",    message={type:"shutdown_request"})
+SendMessage(to="quality-reviewer",     message={type:"shutdown_request"})
+TeamDelete
+```
+
+Always `TeamDelete` — even on abort or partial failure.
+
+#### C.7 Merge findings
+
+Apply the reference's Merge Procedure and pass the combined findings to Phase 3.
+
+---
+
+## Phase 3 — REPORT (inline)
+
+Assign sequential finding IDs (`F001`, `F002`, …) ordered by severity
+(CRITICAL first) then by file path. Every finding gets `Status: Open`.
+
+Compute the finding counts by severity: `C`, `H`, `M`, `L`.
+
+**Print** the review to stdout in the Review Artifact Format, **without**
+writing a file. The printed block looks like:
+
+```markdown
+# Quick Review — Uncommitted Changes
+
+**Reviewed**: <ISO date>
+**Mode**: Quick (inline)
+**Author**: local
+**Branch**: <current-branch>
+**Decision**: (pending user confirmation)
+
+## Summary
+
+<1–2 sentence overall assessment>
+
+## Findings
+
+### CRITICAL
+
+- **[F001]** `file:line` — <description>
+  - **Status**: Open
+  - **Category**: <Security | Correctness | Code Quality | Best Practices>
+  - **Suggested fix**: <concrete fix>
+
+### HIGH
+
+- **[F002]** ...
+  - **Status**: Open
+  - ...
+
+### MEDIUM
+
+- **[F003]** ...
+  - **Status**: Open
+  - ...
+
+### LOW
+
+- **[F004]** ...
+  - **Status**: Open
+  - ...
+
+## Files Reviewed
+
+- `file1.ts` (Modified)
+- `file2.ts` (Added)
+```
+
+**Omissions** (vs. the standard Review Artifact Format): no
+`## Worktree Setup` section (quick mode never creates a worktree) and no
+`## Validation Results` section (quick mode does not run toolchain checks).
+
+After the artifact block, print a one-line summary:
+
+```
+Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
+```
+
+If the count is zero across all severities, skip Phase 4 entirely. Print
+`No findings. Nothing to do.` and exit.
+
+Otherwise continue to Phase 4.
+
+---
+
+## Phase 4 — DECIDE (confirmation)
+
+If `AUTO_YES=true` → skip this phase, proceed directly to Phase 5 as if the
+user selected "Apply fixes".
+
+If `AUTO_SAVE=true` → skip this phase, proceed directly to Phase 5 as if the
+user selected "Save to file".
+
+Otherwise, ask the user with `AskUserQuestion`:
+
+```
+question: "What should I do with this review?"
+header:   "Review action"
+options:
+  - label: "Apply fixes"
+    description: "Write the review artifact to docs/prps/reviews/ and hand off to /review-fix (recommended)"
+  - label: "Save to file"
+    description: "Write the review artifact to docs/prps/reviews/ and stop — you can run /review-fix later"
+  - label: "Discard"
+    description: "Write nothing, exit"
+```
+
+Mark "Apply fixes" with `(Recommended)` in its label when
+`critical_count + high_count > 0`; otherwise leave it unmarked.
+
+**Text-mode fallback** (if `AskUserQuestion` is unavailable — Cursor/Codex
+bundles without that tool): print the three choices explicitly and WAIT for
+the user's next message. Parse their reply case-insensitively:
+
+- `yes` / `apply` / `apply fixes` / `fix` → "Apply fixes"
+- `save` / `save to file` / `write` / `file` → "Save to file"
+- `no` / `discard` / `cancel` / `skip` → "Discard"
+- Anything else → re-prompt once, then default to `Discard` if still ambiguous.
+
+---
+
+## Phase 5 — HAND-OFF
+
+Branch on the user's selection (or the auto-confirm flag).
+
+### Selection: "Discard"
+
+Print `Discarded. No artifact written.` and exit. Do NOT write any file.
+
+### Selection: "Save to file"
+
+Write the artifact to disk using the Phase 3 content plus the canonical
+header block:
+
+```bash
+mkdir -p docs/prps/reviews
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)    # reuse the Path C timestamp if set
+REVIEW_FILE="docs/prps/reviews/quick-${TIMESTAMP}-review.md"
+```
+
+Write the same artifact content that was printed in Phase 3, but set
+`**Decision**: COMMENT` in the header (since a review was produced but no
+GitHub decision is being posted).
+
+Print the Next steps block to stdout:
+
+```
+Quick review written to: docs/prps/reviews/quick-<TIMESTAMP>-review.md
+Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
+
+Next steps:
+  /review-fix docs/prps/reviews/quick-<TIMESTAMP>-review.md              # apply fixes {recommended_single if 1-2 Open findings}
+  /review-fix docs/prps/reviews/quick-<TIMESTAMP>-review.md --parallel   # fan out fixes {recommended_parallel if 3+ Open across 2+ files}
+```
+
+Annotate ONE of the two commands with `# ← recommended`:
+
+- 1–2 Open findings → recommend the single-pass form.
+- 3+ Open findings spanning 2+ files → recommend the `--parallel` form.
+- Otherwise default to the single-pass form.
+
+Exit.
+
+### Selection: "Apply fixes"
+
+Step 1 — write the artifact to disk (same as "Save to file" above) so
+`/review-fix` can parse and update it in place.
+
+Step 2 — invoke the `review-fix` skill inline via the `Skill` tool:
+
+- `skill`: `"review-fix"`
+- `args`: `"<REVIEW_FILE> [--parallel] [--severity <level>]"` — always pass the
+  explicit review path. Forward `--parallel` if `PARALLEL_MODE=true`. Forward
+  `--severity <level>` when `MIN_SEVERITY != HIGH` (HIGH is the default on
+  review-fix so omitting it produces the same behavior).
+
+Step 3 — after the Skill call returns, print a one-line confirmation:
+
+```
+Fixes complete. Review artifact updated in place: docs/prps/reviews/quick-<TIMESTAMP>-review.md
+```
+
+Step 4 — exit.
+
+**Note**: `--team` from quick-review is NOT forwarded to `/review-fix`
+automatically. The review-phase fan-out is about finding issues quickly;
+the fix phase has its own decision. If the user wants team-mode fixes they
+can re-run `/review-fix <path> --team` themselves.
+
+---
+
+## Important Notes
+
+- **No artifact until confirmation**: "Discard" MUST write nothing. "Save to
+  file" and "Apply fixes" both write once, to the same canonical path.
+- **Idempotent filename**: the `quick-{YYYYMMDD-HHMMSS}-review.md` pattern
+  produces a new file per invocation — no overwrites.
+- **Parity with `/code-review`**: the artifact format and finding schema
+  are identical, so `/review-fix` consumes it unchanged.
+- **Not a replacement for `/code-review`**: if you need toolchain
+  validation (typecheck/lint/test/build), a `## Validation Results` block,
+  worktree isolation, or a GitHub review posted, use `/code-review`
+  without `--quick`.
+
+---
+
+## Integration with ycc
+
+- `/code-review --quick` delegates to this skill.
+- `/review-fix` consumes the written artifact.
+- `/prp-commit` or `/git-workflow` can commit the fixes afterward.

--- a/.opencode-plugin/commands/code-review.md
+++ b/.opencode-plugin/commands/code-review.md
@@ -7,13 +7,13 @@ description: 'Code review — local uncommitted changes or a GitHub PR (pass PR 
   agent team with shared the todo tracker and per-reviewer task tracking. Worktree
   mode is on by default in PR mode — pass --no-worktree to opt out. Pass --keep-draft
   to skip automatic draft→ready promotion. Pass --keep-worktree to skip worktree removal
-  after the review is posted. Pass --quick for a lightweight on-the-fly review of
-  uncommitted changes (no worktree, no validation commands, no gh publish; writes
-  a minimal artifact to docs/prps/reviews/quick-{timestamp}-review.md and ends with
-  a Next steps hint for /review-fix). Compatible with --parallel and --team; mutually
-  exclusive with a PR argument, --approve, and --request-changes. Usage: [--quick]
-  [--approve | --request-changes] [--parallel | --team] [--no-worktree] [--keep-draft]
-  [--keep-worktree] [pr-number | pr-url | blank for local review]'
+  after the review is posted. Pass --quick as a thin alias for /quick-review — interactive
+  inline review (no file written unless confirmed), prompts for Apply fixes / Save
+  to file / Discard. Compatible with --parallel and --team; mutually exclusive with
+  a PR argument, --approve, and --request-changes. For direct access to --yes, --save,
+  and --severity, invoke /quick-review instead. Usage: [--quick] [--approve | --request-changes]
+  [--parallel | --team] [--no-worktree] [--keep-draft] [--keep-worktree] [pr-number
+  | pr-url | blank for local review]'
 ---
 
 # Code Review Command
@@ -27,7 +27,7 @@ Run a code review in either local or PR mode.
 
 **Flags**:
 
-- `--quick` — Fast on-the-fly review of uncommitted changes. Skips worktree setup, toolchain validation (typecheck/lint/test/build), and GitHub publish. Writes a minimal artifact to `docs/prps/reviews/quick-{timestamp}-review.md` (consumable by `/review-fix`) and ends with a `Next steps:` block recommending `/review-fix` (single-pass) or `/review-fix --parallel` (fan-out) based on finding volume. Compatible with `--parallel` and `--team`; mutually exclusive with a PR argument, `--approve`, and `--request-changes`.
+- `--quick` — **Alias for `/quick-review`.** Interactive inline review of uncommitted changes — prints findings and prompts **Apply fixes** / **Save to file** / **Discard**. No artifact is written unless you confirm. On "Apply fixes", hands off to `/review-fix` automatically. Compatible with `--parallel` and `--team`; mutually exclusive with a PR argument, `--approve`, and `--request-changes`. For direct access to `--yes`, `--save`, and `--severity`, invoke `/quick-review` instead.
 
 - `--approve` — Force the final decision to APPROVE (still reports all findings)
 - `--request-changes` — Force the final decision to REQUEST CHANGES

--- a/.opencode-plugin/commands/quick-review.md
+++ b/.opencode-plugin/commands/quick-review.md
@@ -1,0 +1,63 @@
+---
+description: 'Fast interactive review of uncommitted changes — findings print inline;
+  Apply fixes / Save to file / Discard on confirmation. Writes nothing by default.
+  Hands off to /review-fix on "Apply fixes". Pass --parallel or --team for 3-reviewer
+  fan-out. Pass --yes or --save to skip the prompt (scripted use). Pass --severity
+  <CRITICAL|HIGH|MEDIUM|LOW> to forward the minimum-severity threshold to /review-fix
+  (default HIGH). Usage: [--parallel | --team] [--yes | --save] [--severity <level>]
+  [--no-worktree]'
+---
+
+# Quick Review Command
+
+Run a fast, inline, interactive review of uncommitted changes.
+
+**Load and follow the `quick-review` skill, passing through `$ARGUMENTS`.**
+
+Unlike `/code-review`, this skill:
+
+- Prints findings **inline** — no artifact is written by default
+- Asks **Apply fixes / Save to file / Discard** after the review
+- Writes a review artifact **only on confirmation**
+- Hands off to `/review-fix` automatically when you pick "Apply fixes"
+
+Designed for short, low-friction code changes where opening a full `/code-review` artifact is overkill.
+
+**Flags**:
+
+- `--parallel` — Fan out the REVIEW phase across 3 standalone `code-reviewer` sub-agents (correctness, security, quality) in parallel. Works in opencode, Cursor, and Codex bundles.
+
+- `--team` — (Claude Code only) Same 3-reviewer fan-out as `--parallel`, dispatched as a coordinated agent team with `spawn coordinated subagents`, shared `the todo tracker`, per-reviewer task tracking, and coordinated shutdown before merge. Cursor and Codex bundles lack the team tools — use `--parallel` there instead.
+
+- `--yes` — Skip the confirmation prompt and auto-confirm "Apply fixes". Useful for scripted flows. Mutually exclusive with `--save`.
+
+- `--save` — Skip the confirmation prompt and auto-confirm "Save to file" (writes the artifact and exits; does not run `/review-fix`). Mutually exclusive with `--yes`.
+
+- `--severity <CRITICAL|HIGH|MEDIUM|LOW>` — Minimum severity threshold forwarded to `/review-fix` during hand-off. Default: `HIGH`. Ignored on "Save to file" and "Discard".
+
+- `--no-worktree` — Accepted as a **no-op**. Quick mode never creates a worktree.
+
+`--parallel` and `--team` are **mutually exclusive** — pick one. Same for `--yes` and `--save`.
+
+```
+Usage: /quick-review [--parallel | --team] [--yes | --save] [--severity <level>] [--no-worktree]
+
+Examples:
+  /quick-review                               # inline review, prompt for confirmation
+  /quick-review --parallel                    # 3 parallel sub-agent reviewers, prompt for confirmation
+  /quick-review --team                        # 3-reviewer agent team (Claude Code only), prompt for confirmation
+  /quick-review --yes                         # auto-confirm: write artifact + invoke /review-fix
+  /quick-review --save                        # auto-confirm: write artifact + exit (run /review-fix later)
+  /quick-review --yes --severity MEDIUM       # auto-confirm and lower the fix threshold
+  /quick-review --parallel --yes              # parallel review + auto-apply fixes
+```
+
+The skill will:
+
+1. `git diff --name-only HEAD` — abort if nothing is changed
+2. REVIEW — single-pass, `--parallel`, or `--team` dispatch
+3. Print findings **inline** in Review Artifact Format (no file written yet)
+4. Ask: **Apply fixes** / **Save to file** / **Discard** (or act on `--yes` / `--save`)
+5. On confirmation → write `docs/prps/reviews/quick-{timestamp}-review.md`; on **Apply fixes**, also invoke `/review-fix` inline
+
+`/code-review --quick` delegates here. Use this command directly to access `--yes`, `--save`, and `--severity`.

--- a/.opencode-plugin/shared/references/review-checklist.md
+++ b/.opencode-plugin/shared/references/review-checklist.md
@@ -1,0 +1,168 @@
+# Review Checklist (Shared Reference)
+
+> Canonical review checklist, severity rubric, parallel-reviewer roster, and
+> standard findings format. Consumed by `code-review` (local + PR modes)
+> and `quick-review`. Skills that delegate here MUST NOT duplicate the
+> content below — reference this file instead.
+
+---
+
+## Severity Rubric
+
+| Severity     | Meaning                                     | Action                  |
+| ------------ | ------------------------------------------- | ----------------------- |
+| **CRITICAL** | Security vulnerability or data loss risk    | Must fix before merge   |
+| **HIGH**     | Bug or logic error likely to cause issues   | Should fix before merge |
+| **MEDIUM**   | Code quality issue or missing best practice | Fix recommended         |
+| **LOW**      | Style nit or minor suggestion               | Optional                |
+
+Findings are grouped by severity in the artifact under `### CRITICAL`,
+`### HIGH`, `### MEDIUM`, `### LOW`, in that order.
+
+---
+
+## Local / Quick Review — Single-Pass Checklist (Path A)
+
+Applied to uncommitted changes on `HEAD`. Read each changed file in full.
+
+**Security Issues (CRITICAL):**
+
+- Hardcoded credentials, API keys, tokens
+- SQL injection vulnerabilities
+- XSS vulnerabilities
+- Missing input validation
+- Insecure dependencies
+- Path traversal risks
+
+**Code Quality (HIGH):**
+
+- Functions > 50 lines
+- Files > 800 lines
+- Nesting depth > 4 levels
+- Missing error handling
+- `console.log` statements
+- TODO/FIXME comments
+- Missing JSDoc for public APIs
+
+**Best Practices (MEDIUM):**
+
+- Mutation patterns (use immutable instead)
+- Emoji usage in code/comments
+- Missing tests for new code
+- Accessibility issues (a11y)
+
+---
+
+## PR Review — Single-Pass Checklist (Path A, 7 Categories)
+
+Applied to PR head-revision file contents. Each category is independent —
+a single finding may touch several.
+
+| Category               | What to Check                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| **Correctness**        | Logic errors, off-by-ones, null handling, edge cases, race conditions         |
+| **Type Safety**        | Type mismatches, unsafe casts, `any` usage, missing generics                  |
+| **Pattern Compliance** | Matches project conventions (naming, file structure, error handling, imports) |
+| **Security**           | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS              |
+| **Performance**        | N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads   |
+| **Completeness**       | Missing tests, missing error handling, incomplete migrations, missing docs    |
+| **Maintainability**    | Dead code, magic numbers, deep nesting, unclear naming, missing types         |
+
+---
+
+## Parallel Reviewer Roster (Path B / Path C)
+
+Three standalone `code-reviewer` sub-agents (Path B) or agent-team teammates
+(Path C). The **focus split** differs between local/quick and PR modes because
+local mode has a narrower category set.
+
+### Local / Quick Mode Roster
+
+| Reviewer               | Focus           | Checklist Items                                                                                                               |
+| ---------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `correctness-reviewer` | Code Quality    | Functions > 50 lines, files > 800 lines, nesting > 4 levels, missing error handling, `console.log`, TODO/FIXME, missing JSDoc |
+| `security-reviewer`    | Security Issues | Hardcoded credentials/keys/tokens, SQL injection, XSS, missing input validation, insecure deps, path traversal                |
+| `quality-reviewer`     | Best Practices  | Mutation patterns, emoji in code/comments, missing tests, accessibility (a11y)                                                |
+
+### PR Mode Roster
+
+| Reviewer               | Categories                             | What to Check                                                                                                                                                             |
+| ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `correctness-reviewer` | Correctness, Type Safety, Completeness | Logic errors, off-by-ones, null handling, edge cases, race conditions, type mismatches, unsafe casts, `any` usage, missing generics, missing tests, incomplete migrations |
+| `security-reviewer`    | Security, Performance                  | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS, N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads                             |
+| `quality-reviewer`     | Pattern Compliance, Maintainability    | Project conventions (naming, file structure, error handling, imports), dead code, magic numbers, deep nesting, unclear naming, missing types                              |
+
+Each reviewer prompt MUST include:
+
+1. The list of changed files (mode-specific: `git diff --name-only HEAD` for
+   local/quick; PR number + head revision + changed-file list for PR).
+2. Relevant context (AGENTS.md rules, PRP artifacts, PR description) — PR mode only.
+3. Its assigned focus / categories and what to check (from the appropriate table
+   above).
+4. The severity rubric.
+5. A directive to return findings in the **Standard Findings Format** below.
+
+---
+
+## Standard Findings Format (Reviewer Output)
+
+Each parallel reviewer returns findings in this shape (pre-merge, before
+finding-ID assignment):
+
+```markdown
+## Findings
+
+### CRITICAL
+
+- `file.ts:42` — [description] [category]
+  - Suggested fix: [fix]
+
+### HIGH
+
+- ...
+
+### MEDIUM
+
+- ...
+
+### LOW
+
+- ...
+```
+
+The `[category]` tag applies to PR mode; local/quick mode may omit it (the focus
+split already implies a category).
+
+---
+
+## Merge Procedure (Path B / Path C)
+
+After all 3 reviewers return:
+
+1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW).
+2. De-duplicate findings at the same `file:line` (if two reviewers flagged the
+   same issue, keep the more severe one and annotate which reviewers concurred).
+3. Sort within each severity by file path.
+4. Attach the reviewer source to each finding (`[correctness]`, `[security]`,
+   `[quality]`) for traceability.
+
+Pass the merged findings to the REPORT phase as if they came from a single-pass
+review.
+
+---
+
+## Finding Artifact Fields
+
+After merging, each finding is promoted to an artifact-format block with these
+fields. The `[F###]` ID is assigned sequentially ordered by severity (CRITICAL
+first), then by file path. Status is always `Open` on first write.
+
+```markdown
+- **[F001]** `file:line` — description
+  - **Status**: Open
+  - **Category**: <category>
+  - **Suggested fix**: <fix>
+```
+
+See `/code-review` → "Review Artifact Format" for the full artifact schema
+(Header, Summary, Findings, Worktree Setup, Validation Results, Files Reviewed).

--- a/.opencode-plugin/skills/code-review/SKILL.md
+++ b/.opencode-plugin/skills/code-review/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: code-review
 description: Dual-mode code review — local uncommitted changes OR a GitHub pull request.
-  Both modes now write a machine-parseable review artifact (Local → docs/prps/reviews/local-{timestamp}-review.md,
+  Both modes write a machine-parseable review artifact (Local → docs/prps/reviews/local-{timestamp}-review.md,
   PR → docs/prps/reviews/pr-{N}-review.md) with sequential finding IDs (F001, F002,
   ...) and Status fields (Open/Fixed/Failed) so /review-fix can consume and update
   them in place. Local mode runs a full security + quality pass on the diff. PR mode
   fetches the PR, reads each changed file in full, builds context from AGENTS.md and
   PRP artifacts, applies a 7-category review checklist, runs validation commands (type-check/lint/test/build)
-  for detected stacks, assigns severity, and posts the review to GitHub via gh. Pass
-  `--parallel` to fan out the REVIEW phase across 3 standalone code-reviewer sub-agents
-  (correctness, security, quality) and merge findings.
+  for detected stacks, assigns severity, and posts the review to GitHub via gh. For
+  fast, inline, interactive reviews of short uncommitted changes (no file written
+  unless confirmed), use `/quick-review` directly — `--quick` here is kept as a thin
+  alias that delegates.
 ---
 
 # Code Review
@@ -24,17 +25,17 @@ description: Dual-mode code review — local uncommitted changes OR a GitHub pul
 
 Before selecting mode, extract flags from `$ARGUMENTS`:
 
-| Flag                | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--approve`         | Force the final decision to APPROVE regardless of findings (still reports all findings)                                                                                                                                                                                                                                                                                                                                                                                     |
-| `--request-changes` | Force the final decision to REQUEST CHANGES regardless of findings                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `--parallel`        | Fan out the REVIEW phase across 3 **standalone** `code-reviewer` sub-agents (correctness, security, quality) dispatched in parallel and merge findings. Works in opencode, Cursor, and Codex.                                                                                                                                                                                                                                                                        |
-| `--team`            | (Claude Code only) Fan out the REVIEW phase across the same 3 `code-reviewer` reviewers, but dispatched as an **agent team** with up-front `track the task`, shared `the todo tracker` observability, inter-reviewer coordination via `send follow-up instructions`, and coordinated shutdown before merge. Heavier dispatch, richer communication.                                                                                                                                                 |
-| `--worktree`        | (legacy / now default; safe to omit) Check out the PR head branch into an isolated worktree at `~/.claude-worktrees/<repo>-pr-<N>/`. Worktree mode is on by default in PR mode; pass `--no-worktree` to opt out.                                                                                                                                                                                                                                                            |
-| `--no-worktree`     | Opt out of worktree isolation in PR mode. Skip worktree creation, artifact commit+push, and cleanup. Files are read directly from the main checkout.                                                                                                                                                                                                                                                                                                                        |
-| `--keep-draft`      | Skip the automatic draft→ready promotion in PR mode. Default: PR is promoted to Ready for Review before posting the review.                                                                                                                                                                                                                                                                                                                                                 |
-| `--keep-worktree`   | Skip removal of the PR worktree after the review is posted. The artifact is still committed and pushed to the PR branch. Default: worktree is removed via `git worktree remove <path>` after a clean review post.                                                                                                                                                                                                                                                           |
-| `--quick`           | Fast on-the-fly review of uncommitted changes. Skips worktree setup, toolchain validation (typecheck/lint/test/build), and GitHub publish. Writes a minimal artifact to `docs/prps/reviews/quick-{timestamp}-review.md` and ends with a `Next steps:` block recommending `/review-fix` (single-pass) or `/review-fix --parallel` (fan-out). Compatible with `--parallel` and `--team`. Mutually exclusive with a PR argument, `--approve`, and `--request-changes`. |
+| Flag                | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--approve`         | Force the final decision to APPROVE regardless of findings (still reports all findings)                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `--request-changes` | Force the final decision to REQUEST CHANGES regardless of findings                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `--parallel`        | Fan out the REVIEW phase across 3 **standalone** `code-reviewer` sub-agents (correctness, security, quality) dispatched in parallel and merge findings. Works in opencode, Cursor, and Codex.                                                                                                                                                                                                                                                                                                   |
+| `--team`            | (Claude Code only) Fan out the REVIEW phase across the same 3 `code-reviewer` reviewers, but dispatched as an **agent team** with up-front `track the task`, shared `the todo tracker` observability, inter-reviewer coordination via `send follow-up instructions`, and coordinated shutdown before merge. Heavier dispatch, richer communication.                                                                                                                                                                            |
+| `--worktree`        | (legacy / now default; safe to omit) Check out the PR head branch into an isolated worktree at `~/.claude-worktrees/<repo>-pr-<N>/`. Worktree mode is on by default in PR mode; pass `--no-worktree` to opt out.                                                                                                                                                                                                                                                                                       |
+| `--no-worktree`     | Opt out of worktree isolation in PR mode. Skip worktree creation, artifact commit+push, and cleanup. Files are read directly from the main checkout.                                                                                                                                                                                                                                                                                                                                                   |
+| `--keep-draft`      | Skip the automatic draft→ready promotion in PR mode. Default: PR is promoted to Ready for Review before posting the review.                                                                                                                                                                                                                                                                                                                                                                            |
+| `--keep-worktree`   | Skip removal of the PR worktree after the review is posted. The artifact is still committed and pushed to the PR branch. Default: worktree is removed via `git worktree remove <path>` after a clean review post.                                                                                                                                                                                                                                                                                      |
+| `--quick`           | **Alias for `/quick-review`.** Fast interactive review of uncommitted changes — prints findings inline and asks Apply fixes / Save to file / Discard. Writes only on confirmation. Compatible with `--parallel` and `--team`. Mutually exclusive with a PR argument, `--approve`, and `--request-changes`. This skill validates the combination and then delegates to `/quick-review` with the remaining flags. See that skill's `--yes`, `--save`, and `--severity` options for scripted use. |
 
 Strip these from `$ARGUMENTS` and set `QUICK_MODE=true|false`, `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `NO_WORKTREE_MODE=true|false`, `KEEP_DRAFT=true|false`, and `KEEP_WORKTREE=true|false`. Compute `WORKTREE_MODE=true` unless `--no-worktree` is present (default-on in PR mode; ignored for local mode as before). The remaining text is the mode selector (PR number/URL or blank for local).
 
@@ -148,82 +149,29 @@ The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
 
 #### Path A — Single-Pass Review (default, neither flag set)
 
-Read each changed file in full. Check for:
+Read each changed file in full and apply the **Local / Quick Review —
+Single-Pass Checklist** (Security CRITICAL, Code Quality HIGH, Best Practices
+MEDIUM) and the **Severity Rubric** from:
 
-**Security Issues (CRITICAL):**
-
-- Hardcoded credentials, API keys, tokens
-- SQL injection vulnerabilities
-- XSS vulnerabilities
-- Missing input validation
-- Insecure dependencies
-- Path traversal risks
-
-**Code Quality (HIGH):**
-
-- Functions > 50 lines
-- Files > 800 lines
-- Nesting depth > 4 levels
-- Missing error handling
-- `console.log` statements
-- TODO/FIXME comments
-- Missing JSDoc for public APIs
-
-**Best Practices (MEDIUM):**
-
-- Mutation patterns (use immutable instead)
-- Emoji usage in code/comments
-- Missing tests for new code
-- Accessibility issues (a11y)
+```
+~/.config/opencode/shared/references/review-checklist.md
+```
 
 #### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
 
-Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE message with MULTIPLE `Agent` tool calls. Each agent reads all changed files and applies its assigned focus:
+Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **Local / Quick Mode Roster**
+(`correctness-reviewer`, `security-reviewer`, `quality-reviewer`) and
+**Standard Findings Format** from:
 
-| Reviewer               | Focus           | Checklist Items                                                                                                               |
-| ---------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `correctness-reviewer` | Code Quality    | Functions > 50 lines, files > 800 lines, nesting > 4 levels, missing error handling, `console.log`, TODO/FIXME, missing JSDoc |
-| `security-reviewer`    | Security Issues | Hardcoded credentials/keys/tokens, SQL injection, XSS, missing input validation, insecure deps, path traversal                |
-| `quality-reviewer`     | Best Practices  | Mutation patterns, emoji in code/comments, missing tests, accessibility (a11y)                                                |
-
-Each reviewer prompt must include:
-
-1. The list of changed files (`git diff --name-only HEAD`)
-2. Its assigned focus and checklist items (from the table above)
-3. The severity rubric (CRITICAL, HIGH, MEDIUM, LOW)
-4. A directive to return findings in the standard format below
-
-Each reviewer returns findings as:
-
-```markdown
-## Findings
-
-### CRITICAL
-
-- `file.ts:42` — [description]
-  - Suggested fix: [fix]
-
-### HIGH
-
-- ...
-
-### MEDIUM
-
-- ...
-
-### LOW
-
-- ...
+```
+~/.config/opencode/shared/references/review-checklist.md
 ```
 
-After all 3 reviewers return, **merge findings**:
-
-1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW)
-2. De-duplicate findings at the same `file:line` (if two reviewers flagged the same issue, keep the more severe one and annotate which reviewers concurred)
-3. Sort within each severity by file path
-4. Attach the reviewer source to each finding (`[correctness]`, `[security]`, `[quality]`) for traceability
-
-Pass the merged findings to Phase 3 (REPORT) as if they came from a single-pass review.
+The reviewer-prompt contract (changed files, focus + checklist items, severity
+rubric, findings format directive) and the **Merge Procedure** are defined
+in that reference. Pass the merged findings to Phase 3 (REPORT) as if they
+came from a single-pass review.
 
 #### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Claude Code only)
 
@@ -345,55 +293,32 @@ Never approve code with security vulnerabilities.
 
 ## Quick Review Mode
 
-> Triggered by `--quick`. Lightweight review of uncommitted changes — no worktree, no toolchain validation, no GitHub publish. Just findings plus a `Next steps:` block offering `/review-fix`. Writes a minimal artifact to `docs/prps/reviews/quick-{YYYYMMDD-HHMMSS}-review.md` so `/review-fix` can consume it unchanged.
+> Triggered by `--quick`. This mode is now a **thin delegator** to
+> `/quick-review` — the interactive inline-review skill. Phase 0 above
+> has already validated the flag combination; this section hands off.
 
-### Phase 1 — GATHER
+### Delegation
 
-Identical to Local Review Mode Phase 1 (line 151 above). Compute changed files with:
-
-```bash
-git diff --name-only HEAD
-```
-
-If the diff is empty, print `Nothing to review.` and exit. Do NOT write an artifact.
-
-### Phase 2 — REVIEW
-
-Delegate to **Local Review Mode Phase 2** (starting at line 159 above). The same 7-category checklist, severity rubric, Path A (single-pass) / Path B (`--parallel` → 3 standalone sub-agent reviewers) / Path C (`--team` → coordinated agent team) all apply unchanged.
-
-- If `--parallel` → Path B fan-out.
-- If `--team` → Path C (Claude Code only; compatibility gate already enforced in Phase 0).
-- Otherwise → Path A.
-
-When using Path C in quick mode, use team name `qrev-local-<YYYYMMDD-HHMMSS>` (matching the artifact timestamp). Lifecycle is identical to Local Mode Path C: spawn coordinated subagents → track the task × 3 → Agent × 3 in one message → monitor via the todo tracker → merge → send follow-up instructions shutdown → end the coordinated run.
-
-### Phase 3 — REPORT
-
-Assign sequential finding IDs (F001, F002, …) with `Status: Open` on every finding. Write the artifact to `docs/prps/reviews/quick-{YYYYMMDD-HHMMSS}-review.md`. The artifact uses the **Review Artifact Format** (defined at the bottom of this skill) with two omissions:
-
-- **No** `## Validation Results` section — quick mode does not run toolchain validation.
-- **No** `## Worktree Setup` section — quick mode never creates a worktree.
-
-All other sections (Header, Summary, Findings with full ID/Status/Category/Suggested fix, Files Reviewed) are identical to Local Mode's output. `/review-fix` parses the result unchanged.
-
-Then print a `Next steps:` block to stdout:
+Invoke the `quick-review` skill via the `Skill` tool. Forward the
+remaining flags — `--parallel` or `--team`, plus anything quick-review
+accepts — but drop the flags this skill owns (`--quick`, `--approve`,
+`--request-changes`, `--no-worktree`, `--keep-draft`, `--keep-worktree`;
+Phase 0 already consumed them).
 
 ```
-Quick review written to: docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md
-Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
-
-Next steps:
-  /review-fix docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md              # apply fixes {recommended_single if 1-2 Open findings}
-  /review-fix docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md --parallel   # fan out fixes {recommended_parallel if 3+ Open across 2+ files}
+Skill: quick-review
+  args: "<stripped flags: --parallel | --team | --yes | --save | --severity <level>>"
 ```
 
-**Recommendation heuristic** (annotate ONE of the two commands with `# ← recommended`):
+Print a single one-line notice before delegating so the user sees what
+happened:
 
-- 0 Open findings → print `No findings. No follow-up needed.` and skip the two `/review-fix` command lines.
-- 1–2 Open findings → recommend the single-pass form.
-- 3+ Open findings spanning 2+ files → recommend the `--parallel` form.
+```
+--quick delegated to /quick-review. Run /quick-review directly for full option surface (--yes, --save, --severity).
+```
 
-Quick mode has **NO** Phase 4/5/6/7/8 — no VALIDATE, DECIDE, PUBLISH, or OUTPUT phases. If you need toolchain validation or a GitHub review posted, re-run without `--quick`.
+After the Skill call returns, exit. Do NOT run Phase 4/5/6/7/8. Do NOT
+write an artifact here — quick-review owns the artifact lifecycle.
 
 ---
 
@@ -460,69 +385,37 @@ The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
 
 #### Path A — Single-Pass Review (default, neither flag set)
 
-Apply the review checklist across 7 categories:
+Apply the **PR Review — Single-Pass Checklist** (7 categories: Correctness,
+Type Safety, Pattern Compliance, Security, Performance, Completeness,
+Maintainability) and the **Severity Rubric** from:
 
-| Category               | What to Check                                                                 |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Correctness**        | Logic errors, off-by-ones, null handling, edge cases, race conditions         |
-| **Type Safety**        | Type mismatches, unsafe casts, `any` usage, missing generics                  |
-| **Pattern Compliance** | Matches project conventions (naming, file structure, error handling, imports) |
-| **Security**           | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS              |
-| **Performance**        | N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads   |
-| **Completeness**       | Missing tests, missing error handling, incomplete migrations, missing docs    |
-| **Maintainability**    | Dead code, magic numbers, deep nesting, unclear naming, missing types         |
+```
+~/.config/opencode/shared/references/review-checklist.md
+```
 
 #### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
 
-Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE message with MULTIPLE `Agent` tool calls. Each agent reads all changed files at the PR head revision and applies its assigned category slice:
+Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **PR Mode Roster**
+(`correctness-reviewer`, `security-reviewer`, `quality-reviewer`) and
+**Standard Findings Format** from:
 
-| Reviewer               | Categories                             | What to Check                                                                                                                                                             |
-| ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `correctness-reviewer` | Correctness, Type Safety, Completeness | Logic errors, off-by-ones, null handling, edge cases, race conditions, type mismatches, unsafe casts, `any` usage, missing generics, missing tests, incomplete migrations |
-| `security-reviewer`    | Security, Performance                  | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS, N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads                             |
-| `quality-reviewer`     | Pattern Compliance, Maintainability    | Project conventions (naming, file structure, error handling, imports), dead code, magic numbers, deep nesting, unclear naming, missing types                              |
+```
+~/.config/opencode/shared/references/review-checklist.md
+```
 
-Each reviewer prompt must include:
+Each reviewer prompt must additionally include:
 
 1. The PR number, head revision, and the list of changed files
 2. Relevant context from Phase 2 (AGENTS.md rules, PRP artifacts, PR description)
-3. Its assigned categories and what to check (from the table above)
-4. The severity rubric
-5. A directive to return findings in the standard format below
 
-Each reviewer returns findings as:
+The reviewer-prompt contract (focus + categories, severity rubric, findings
+format directive) and the **Merge Procedure** are defined in that reference.
+Pass the merged findings to Phase 4 (VALIDATE) and downstream phases as if
+they came from a single-pass review.
 
-```markdown
-## Findings
-
-### CRITICAL
-
-- `file.ts:42` — [description] [category]
-  - Suggested fix: [fix]
-
-### HIGH
-
-- ...
-
-### MEDIUM
-
-- ...
-
-### LOW
-
-- ...
-```
-
-After all 3 reviewers return, **merge findings**:
-
-1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW)
-2. De-duplicate findings at the same `file:line` (if two reviewers flagged the same issue, keep the more severe one and list both concurring reviewers)
-3. Sort within each severity by file path
-4. Tag each finding with its source reviewer (`[correctness]`, `[security]`, `[quality]`) for traceability
-
-Pass the merged findings to Phase 4 (VALIDATE) and downstream phases as if they came from a single-pass review.
-
-**Note**: Validation commands (Phase 4) still run sequentially in the main skill — parallelization here only applies to the review pass.
+**Note**: Validation commands (Phase 4) still run sequentially in the main
+skill — parallelization here only applies to the review pass.
 
 #### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Claude Code only)
 

--- a/.opencode-plugin/skills/quick-review/SKILL.md
+++ b/.opencode-plugin/skills/quick-review/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: quick-review
+description: Fast interactive review of uncommitted changes. Prints findings inline
+  (no file written by default), then asks Apply fixes / Save to file / Discard. Writing
+  only happens on confirmation. Hands off to /review-fix on "Apply fixes". Designed
+  for short, low-friction code changes where opening a full /code-review artifact
+  is overkill. Pass `--parallel` to fan out across 3 standalone code-reviewer sub-agents
+  (correctness, security, quality). Pass `--team` (Claude Code only) for the same
+  fan-out as a coordinated agent team. `--parallel` and `--team` are mutually exclusive.
+  Pass `--yes` to auto-confirm (Apply fixes) or `--save` to auto-confirm (Save to
+  file) for scripted use. Pass `--severity <CRITICAL|HIGH|MEDIUM|LOW>` to forward
+  the minimum severity threshold to /review-fix (default HIGH). Use when the user
+  asks to "quick review", "fast review", "review what I have", "on-the-fly review",
+  or says "/quick-review". `/code-review --quick` delegates here.
+---
+
+# Quick Review
+
+Interactive low-friction review of uncommitted changes. Output is **inline**;
+a review artifact is only written on confirmation.
+
+**Input**: `$ARGUMENTS`
+
+**Core rule**: You will **NOT** write a review artifact until the user
+explicitly selects "Apply fixes" or "Save to file". "Discard" writes nothing.
+
+---
+
+## Phase 0 — Parse flags
+
+Extract flags from `$ARGUMENTS`:
+
+| Flag                 | Effect                                                                                                                                                                                                    |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--parallel`         | Fan out REVIEW across 3 standalone `code-reviewer` sub-agents (correctness, security, quality) and merge findings. Works in opencode, Cursor, and Codex bundles.                                   |
+| `--team`             | (Claude Code only) Same 3-reviewer fan-out as a coordinated agent team with `spawn coordinated subagents`, shared `the todo tracker`, per-reviewer `track the task`, and coordinated shutdown. Heavier dispatch, richer communication. |
+| `--yes`              | Skip the confirmation prompt in Phase 4 and behave as "Apply fixes". Mutually exclusive with `--save`.                                                                                                    |
+| `--save`             | Skip the confirmation prompt in Phase 4 and behave as "Save to file" (write artifact, print Next steps, exit). Mutually exclusive with `--yes`.                                                           |
+| `--severity <level>` | Forwarded to `/review-fix` during hand-off. Valid: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`. Default: `HIGH`. Ignored on "Save to file" / "Discard".                                                       |
+| `--no-worktree`      | Accepted as a **no-op**. Quick mode never creates a worktree. Emit a note: `--no-worktree has no effect in quick mode.`                                                                                   |
+
+Strip these from `$ARGUMENTS` and set `PARALLEL_MODE`, `AGENT_TEAM_MODE`,
+`AUTO_YES`, `AUTO_SAVE`, and `MIN_SEVERITY` (default `HIGH`). The remaining
+text MUST be empty; if not, abort with:
+
+```
+Error: /quick-review takes no positional argument (only flags).
+```
+
+**Validation**:
+
+- `--parallel` and `--team` mutually exclusive → abort with: `--parallel and --team are mutually exclusive. Pick one.`
+- `--yes` and `--save` mutually exclusive → abort with: `--yes and --save are mutually exclusive. Pick one.`
+- `--team` in a Cursor/Codex bundle (no `spawn coordinated subagents` tool) → abort with: `--team is not supported in bundle invocations; use --parallel instead.`
+- `--severity` value not one of `CRITICAL|HIGH|MEDIUM|LOW` → abort with: `Invalid --severity value. Use CRITICAL, HIGH, MEDIUM, or LOW.`
+
+---
+
+## Phase 1 — GATHER
+
+```bash
+git diff --name-only HEAD
+```
+
+If the output is empty, print `Nothing to review.` and exit. Do NOT prompt,
+do NOT write anything.
+
+Capture the list of changed files as `CHANGED_FILES` for the REVIEW phase.
+
+---
+
+## Phase 2 — REVIEW
+
+The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
+
+| Flags             | Path                                        |
+| ----------------- | ------------------------------------------- |
+| Neither set       | **Path A** — single-pass review (default)   |
+| `PARALLEL_MODE`   | **Path B** — 3 parallel sub-agent reviewers |
+| `AGENT_TEAM_MODE` | **Path C** — 3-reviewer agent team          |
+
+Findings from all paths stay **in memory** — do not write to disk yet.
+
+### Path A — Single-Pass Review (default)
+
+Read each changed file in full and apply the **Local / Quick Review —
+Single-Pass Checklist** and **Severity Rubric** from:
+
+```
+~/.config/opencode/shared/references/review-checklist.md
+```
+
+### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
+
+Dispatch **3 standalone `code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **Local / Quick Mode Roster**
+and **Standard Findings Format** from:
+
+```
+~/.config/opencode/shared/references/review-checklist.md
+```
+
+Each reviewer prompt must include:
+
+1. The list of changed files (`git diff --name-only HEAD`)
+2. Its assigned focus and checklist items (from the roster table)
+3. The severity rubric
+4. A directive to return findings in the Standard Findings Format
+
+Apply the **Merge Procedure** defined in the reference to produce a single
+combined findings list for Phase 3.
+
+### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Claude Code only)
+
+> **MANDATORY — AGENT TEAMS REQUIRED**
+>
+> You MUST follow the agent-team lifecycle. Every `Agent` call MUST include
+> `team_name=` AND `name=`. See
+> `~/.config/opencode/shared/references/agent-team-dispatch.md`.
+
+Roster and category split identical to Path B.
+
+#### C.1 Build the team name
+
+Team name: `qrev-local-<YYYYMMDD-HHMMSS>`. Generate the timestamp once at the
+start of Phase 2 and reuse it if the user later selects "Save to file" or
+"Apply fixes" (for artifact filename consistency).
+
+#### C.2 Create the team
+
+```
+spawn coordinated subagents: team_name="qrev-local-<timestamp>", description="Quick review team for uncommitted local changes"
+```
+
+On failure, abort.
+
+#### C.3 Register subtasks
+
+Create 3 tasks in the shared task list (flat graph — reviewers are independent):
+
+```
+track the task: subject="correctness-reviewer: code-quality review of uncommitted changes", description="<full reviewer prompt>"
+track the task: subject="security-reviewer: security review of uncommitted changes",        description="<full reviewer prompt>"
+track the task: subject="quality-reviewer: best-practices review of uncommitted changes",   description="<full reviewer prompt>"
+```
+
+If any `track the task` fails → `end the coordinated run`, abort.
+
+#### C.4 Spawn the 3 reviewers
+
+Single message, three `Agent` calls. Every call MUST include `team_name`, `name`
+(matching the `track the task` subject prefix), `subagent_type="code-reviewer"`,
+description, and a prompt equivalent to Path B's reviewer prompt plus a note
+that the teammate shares a task list with two siblings (name them) and may
+`send follow-up instructions` them on overlaps, and must call `update the todo tracker` to mark its task
+complete before returning.
+
+#### C.5 Monitor and collect results
+
+Use `the todo tracker` until all 3 tasks are `completed`. Failure policy:
+
+- All 3 error → `end the coordinated run`, abort with a clear error.
+- 1 or 2 error → record "partial review — {role} did not complete" and proceed
+  with the remaining findings. Note the gap when printing inline.
+
+#### C.6 Shutdown and cleanup
+
+```
+send follow-up instructions(to="correctness-reviewer", message={type:"shutdown_request"})
+send follow-up instructions(to="security-reviewer",    message={type:"shutdown_request"})
+send follow-up instructions(to="quality-reviewer",     message={type:"shutdown_request"})
+end the coordinated run
+```
+
+Always `end the coordinated run` — even on abort or partial failure.
+
+#### C.7 Merge findings
+
+Apply the reference's Merge Procedure and pass the combined findings to Phase 3.
+
+---
+
+## Phase 3 — REPORT (inline)
+
+Assign sequential finding IDs (`F001`, `F002`, …) ordered by severity
+(CRITICAL first) then by file path. Every finding gets `Status: Open`.
+
+Compute the finding counts by severity: `C`, `H`, `M`, `L`.
+
+**Print** the review to stdout in the Review Artifact Format, **without**
+writing a file. The printed block looks like:
+
+```markdown
+# Quick Review — Uncommitted Changes
+
+**Reviewed**: <ISO date>
+**Mode**: Quick (inline)
+**Author**: local
+**Branch**: <current-branch>
+**Decision**: (pending user confirmation)
+
+## Summary
+
+<1–2 sentence overall assessment>
+
+## Findings
+
+### CRITICAL
+
+- **[F001]** `file:line` — <description>
+  - **Status**: Open
+  - **Category**: <Security | Correctness | Code Quality | Best Practices>
+  - **Suggested fix**: <concrete fix>
+
+### HIGH
+
+- **[F002]** ...
+  - **Status**: Open
+  - ...
+
+### MEDIUM
+
+- **[F003]** ...
+  - **Status**: Open
+  - ...
+
+### LOW
+
+- **[F004]** ...
+  - **Status**: Open
+  - ...
+
+## Files Reviewed
+
+- `file1.ts` (Modified)
+- `file2.ts` (Added)
+```
+
+**Omissions** (vs. the standard Review Artifact Format): no
+`## Worktree Setup` section (quick mode never creates a worktree) and no
+`## Validation Results` section (quick mode does not run toolchain checks).
+
+After the artifact block, print a one-line summary:
+
+```
+Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
+```
+
+If the count is zero across all severities, skip Phase 4 entirely. Print
+`No findings. Nothing to do.` and exit.
+
+Otherwise continue to Phase 4.
+
+---
+
+## Phase 4 — DECIDE (confirmation)
+
+If `AUTO_YES=true` → skip this phase, proceed directly to Phase 5 as if the
+user selected "Apply fixes".
+
+If `AUTO_SAVE=true` → skip this phase, proceed directly to Phase 5 as if the
+user selected "Save to file".
+
+Otherwise, ask the user with `ask the user`:
+
+```
+question: "What should I do with this review?"
+header:   "Review action"
+options:
+  - label: "Apply fixes"
+    description: "Write the review artifact to docs/prps/reviews/ and hand off to /review-fix (recommended)"
+  - label: "Save to file"
+    description: "Write the review artifact to docs/prps/reviews/ and stop — you can run /review-fix later"
+  - label: "Discard"
+    description: "Write nothing, exit"
+```
+
+Mark "Apply fixes" with `(Recommended)` in its label when
+`critical_count + high_count > 0`; otherwise leave it unmarked.
+
+**Text-mode fallback** (if `ask the user` is unavailable — Cursor/Codex
+bundles without that tool): print the three choices explicitly and WAIT for
+the user's next message. Parse their reply case-insensitively:
+
+- `yes` / `apply` / `apply fixes` / `fix` → "Apply fixes"
+- `save` / `save to file` / `write` / `file` → "Save to file"
+- `no` / `discard` / `cancel` / `skip` → "Discard"
+- Anything else → re-prompt once, then default to `Discard` if still ambiguous.
+
+---
+
+## Phase 5 — HAND-OFF
+
+Branch on the user's selection (or the auto-confirm flag).
+
+### Selection: "Discard"
+
+Print `Discarded. No artifact written.` and exit. Do NOT write any file.
+
+### Selection: "Save to file"
+
+Write the artifact to disk using the Phase 3 content plus the canonical
+header block:
+
+```bash
+mkdir -p docs/prps/reviews
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)    # reuse the Path C timestamp if set
+REVIEW_FILE="docs/prps/reviews/quick-${TIMESTAMP}-review.md"
+```
+
+Write the same artifact content that was printed in Phase 3, but set
+`**Decision**: COMMENT` in the header (since a review was produced but no
+GitHub decision is being posted).
+
+Print the Next steps block to stdout:
+
+```
+Quick review written to: docs/prps/reviews/quick-<TIMESTAMP>-review.md
+Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
+
+Next steps:
+  /review-fix docs/prps/reviews/quick-<TIMESTAMP>-review.md              # apply fixes {recommended_single if 1-2 Open findings}
+  /review-fix docs/prps/reviews/quick-<TIMESTAMP>-review.md --parallel   # fan out fixes {recommended_parallel if 3+ Open across 2+ files}
+```
+
+Annotate ONE of the two commands with `# ← recommended`:
+
+- 1–2 Open findings → recommend the single-pass form.
+- 3+ Open findings spanning 2+ files → recommend the `--parallel` form.
+- Otherwise default to the single-pass form.
+
+Exit.
+
+### Selection: "Apply fixes"
+
+Step 1 — write the artifact to disk (same as "Save to file" above) so
+`/review-fix` can parse and update it in place.
+
+Step 2 — invoke the `review-fix` skill inline via the `Skill` tool:
+
+- `skill`: `"review-fix"`
+- `args`: `"<REVIEW_FILE> [--parallel] [--severity <level>]"` — always pass the
+  explicit review path. Forward `--parallel` if `PARALLEL_MODE=true`. Forward
+  `--severity <level>` when `MIN_SEVERITY != HIGH` (HIGH is the default on
+  review-fix so omitting it produces the same behavior).
+
+Step 3 — after the Skill call returns, print a one-line confirmation:
+
+```
+Fixes complete. Review artifact updated in place: docs/prps/reviews/quick-<TIMESTAMP>-review.md
+```
+
+Step 4 — exit.
+
+**Note**: `--team` from quick-review is NOT forwarded to `/review-fix`
+automatically. The review-phase fan-out is about finding issues quickly;
+the fix phase has its own decision. If the user wants team-mode fixes they
+can re-run `/review-fix <path> --team` themselves.
+
+---
+
+## Important Notes
+
+- **No artifact until confirmation**: "Discard" MUST write nothing. "Save to
+  file" and "Apply fixes" both write once, to the same canonical path.
+- **Idempotent filename**: the `quick-{YYYYMMDD-HHMMSS}-review.md` pattern
+  produces a new file per invocation — no overwrites.
+- **Parity with `/code-review`**: the artifact format and finding schema
+  are identical, so `/review-fix` consumes it unchanged.
+- **Not a replacement for `/code-review`**: if you need toolchain
+  validation (typecheck/lint/test/build), a `## Validation Results` block,
+  worktree isolation, or a GitHub review posted, use `/code-review`
+  without `--quick`.
+
+---
+
+## Integration with ycc
+
+- `/code-review --quick` delegates to this skill.
+- `/review-fix` consumes the written artifact.
+- `/prp-commit` or `/git-workflow` can commit the fixes afterward.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A single Claude Code plugin (`ycc`) bundling workflow orchestration, parallel pl
 
 <!-- BEGIN:GENERATED-COUNTS -->
 
-The source plugin ships **44 skills**, **43 slash commands** (most skills have a matching command), and **52 agents**.
+The source plugin ships **45 skills**, **44 slash commands** (most skills have a matching command), and **52 agents**.
 
 <!-- END:GENERATED-COUNTS -->
 
@@ -48,6 +48,7 @@ The source plugin ships **44 skills**, **43 slash commands** (most skills have a
 | `/ycc:prp-spec`            | Generate a lightweight feature spec for the PRP workflow — single-pass with optional codebase/market grounding.                                                                         |
 | `/ycc:python-patterns`     | Idiomatic Python patterns, PEP 8 conventions, type hints, dataclasses, context managers, decorators, and best practices for building robust, maintainable Python applications.          |
 | `/ycc:python-testing`      | Python testing patterns using pytest — TDD methodology, fixtures (function/module/session scopes), parametrization, markers, mocking with unittest.mock, async tests with pytest-asy... |
+| `/ycc:quick-review`        | Fast interactive review of uncommitted changes — findings print inline; Apply fixes / Save to file / Discard on confirmation.                                                           |
 | `/ycc:releaser`            | Prepare and cut a GitHub release for any project — detects toolchain, drafts changelog, plans platform/arch artifacts, optionally generates or audits release CI.                       |
 | `/ycc:research-to-issues`  | Convert research, feature specs, and implementation plans into structured GitHub issues with tracking hierarchy, labels, and priority.                                                  |
 | `/ycc:resume-session`      | Load the most recent session file from ~/.claude/session-data/ and resume work with full context.                                                                                       |

--- a/docs/inventory.json
+++ b/docs/inventory.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "code-review",
-      "description": "Dual-mode code review \u2014 local uncommitted changes OR a GitHub pull request. Both modes now write a machine-parseable review artifact (Local \u2192 docs/prps/reviews/local-{timestamp}-review.md, PR \u2192 docs/prps/reviews/pr-{N}-review.md) with sequential finding IDs (F001, F002, ...) and Status fields (Open/Fixed/Failed) so /ycc:review-fix can consume and update them in place. Local mode runs a full security + quality pass on the diff. PR mode fetches the PR, reads each changed file in full, builds context from CLAUDE.md and PRP artifacts, applies a 7-category review checklist, runs validation commands (type-check/lint/test/build) for detected stacks, assigns severity, and posts the review to GitHub via gh. Pass `--parallel` to fan out the REVIEW phase across 3 standalone ycc:code-reviewer sub-agents (correctness, security, quality) and merge findings. Pass `--team` (Claude Code only) to run the same 3-reviewer fan-out as a coordinated agent team with shared TaskList, per-reviewer task tracking, and inter-reviewer communication via SendMessage. `--parallel` and `--team` are mutually exclusive. Worktree mode is on by default in PR mode \u2014 pass `--no-worktree` to opt out. Pass `--keep-draft` to skip automatic draft\u2192ready promotion. Pass `--keep-worktree` to skip worktree removal after the review is posted. Use when the user asks to \"review code\", \"review PR\", \"check uncommitted changes\", \"review pr N\", \"parallel review\", \"team review\", or says \"/code-review\". Adapted from PRPs-agentic-eng by Wirasm."
+      "description": "Dual-mode code review \u2014 local uncommitted changes OR a GitHub pull request. Both modes write a machine-parseable review artifact (Local \u2192 docs/prps/reviews/local-{timestamp}-review.md, PR \u2192 docs/prps/reviews/pr-{N}-review.md) with sequential finding IDs (F001, F002, ...) and Status fields (Open/Fixed/Failed) so /ycc:review-fix can consume and update them in place. Local mode runs a full security + quality pass on the diff. PR mode fetches the PR, reads each changed file in full, builds context from CLAUDE.md and PRP artifacts, applies a 7-category review checklist, runs validation commands (type-check/lint/test/build) for detected stacks, assigns severity, and posts the review to GitHub via gh. For fast, inline, interactive reviews of short uncommitted changes (no file written unless confirmed), use `/ycc:quick-review` directly \u2014 `--quick` here is kept as a thin alias that delegates. Pass `--parallel` to fan out the REVIEW phase across 3 standalone ycc:code-reviewer sub-agents (correctness, security, quality) and merge findings. Pass `--team` (Claude Code only) to run the same 3-reviewer fan-out as a coordinated agent team with shared TaskList, per-reviewer task tracking, and inter-reviewer communication via SendMessage. `--parallel` and `--team` are mutually exclusive. Worktree mode is on by default in PR mode \u2014 pass `--no-worktree` to opt out. Pass `--keep-draft` to skip automatic draft\u2192ready promotion. Pass `--keep-worktree` to skip worktree removal after the review is posted. Use when the user asks to \"review code\", \"review PR\", \"check uncommitted changes\", \"review pr N\", \"parallel review\", \"team review\", or says \"/code-review\". Adapted from PRPs-agentic-eng by Wirasm."
     },
     {
       "name": "compatibility-audit",
@@ -133,6 +133,10 @@
       "description": "Python testing patterns using pytest \u2014 TDD methodology, fixtures (function/module/session scopes), parametrization, markers, mocking with unittest.mock, async tests with pytest-asyncio, tmp_path, conftest.py organization, and coverage targets. Use when the user is writing Python tests, adding test coverage to Python code, asks about pytest, @pytest.fixture, @pytest.mark.parametrize, @patch / Mock / MagicMock / autospec, pytest-asyncio, conftest.py, tmp_path / tmpdir, pytest --cov, or wants TDD guidance for a Python project."
     },
     {
+      "name": "quick-review",
+      "description": "Fast interactive review of uncommitted changes. Prints findings inline (no file written by default), then asks Apply fixes / Save to file / Discard. Writing only happens on confirmation. Hands off to /ycc:review-fix on \"Apply fixes\". Designed for short, low-friction code changes where opening a full /ycc:code-review artifact is overkill. Pass `--parallel` to fan out across 3 standalone ycc:code-reviewer sub-agents (correctness, security, quality). Pass `--team` (Claude Code only) for the same fan-out as a coordinated agent team. `--parallel` and `--team` are mutually exclusive. Pass `--yes` to auto-confirm (Apply fixes) or `--save` to auto-confirm (Save to file) for scripted use. Pass `--severity <CRITICAL|HIGH|MEDIUM|LOW>` to forward the minimum severity threshold to /ycc:review-fix (default HIGH). Use when the user asks to \"quick review\", \"fast review\", \"review what I have\", \"on-the-fly review\", or says \"/quick-review\". `/ycc:code-review --quick` delegates here."
+    },
+    {
       "name": "releaser",
       "description": "This skill should be used when the user asks to \"prepare a release\", \"cut a release\", \"tag a release\", \"create a GitHub release\", \"draft release notes\", \"set up release CI\", \"add a release workflow\", or \"audit release pipeline\" for any project. Detects language/toolchain, drafts a changelog, plans platform/arch artifacts, optionally generates or audits GitHub Actions release CI, and emits the exact commands the user runs to tag and publish. Never auto-commits, pushes, or publishes. Generic external-project counterpart to `ycc:bundle-release` (which is scoped to this repo's ycc bundle)."
     },
@@ -200,7 +204,7 @@
     },
     {
       "name": "code-review",
-      "description": "Code review \u2014 local uncommitted changes or a GitHub PR (pass PR number/URL for PR mode). Runs security + quality checks, executes validation commands, writes an artifact, and posts the review. Pass --parallel to fan out the review phase across 3 specialized reviewer agents (correctness, security, quality) and merge findings. Pass --team (Claude Code only) to run the same 3-reviewer fan-out as a coordinated agent team with shared TaskList and per-reviewer task tracking. Worktree mode is on by default in PR mode \u2014 pass --no-worktree to opt out. Pass --keep-draft to skip automatic draft\u2192ready promotion. Pass --keep-worktree to skip worktree removal after the review is posted. Pass --quick for a lightweight on-the-fly review of uncommitted changes (no worktree, no validation commands, no gh publish; writes a minimal artifact to docs/prps/reviews/quick-{timestamp}-review.md and ends with a Next steps hint for /ycc:review-fix). Compatible with --parallel and --team; mutually exclusive with a PR argument, --approve, and --request-changes."
+      "description": "Code review \u2014 local uncommitted changes or a GitHub PR (pass PR number/URL for PR mode). Runs security + quality checks, executes validation commands, writes an artifact, and posts the review. Pass --parallel to fan out the review phase across 3 specialized reviewer agents (correctness, security, quality) and merge findings. Pass --team (Claude Code only) to run the same 3-reviewer fan-out as a coordinated agent team with shared TaskList and per-reviewer task tracking. Worktree mode is on by default in PR mode \u2014 pass --no-worktree to opt out. Pass --keep-draft to skip automatic draft\u2192ready promotion. Pass --keep-worktree to skip worktree removal after the review is posted. Pass --quick as a thin alias for /ycc:quick-review \u2014 interactive inline review (no file written unless confirmed), prompts for Apply fixes / Save to file / Discard. Compatible with --parallel and --team; mutually exclusive with a PR argument, --approve, and --request-changes. For direct access to --yes, --save, and --severity, invoke /ycc:quick-review instead."
     },
     {
       "name": "compatibility-audit",
@@ -305,6 +309,10 @@
     {
       "name": "python-testing",
       "description": "Python testing patterns using pytest \u2014 TDD methodology, fixtures (function/module/session scopes), parametrization, markers, mocking with unittest.mock, async tests with pytest-asyncio, tmp_path, conftest.py organization, and coverage targets. Use when the user is writing Python tests, adding test coverage to Python code, asks about pytest, @pytest.fixture, @pytest.mark.parametrize, @patch / Mock / MagicMock / autospec, pytest-asyncio, conftest.py, tmp_path / tmpdir, pytest --cov, or wants TDD guidance for a Python project."
+    },
+    {
+      "name": "quick-review",
+      "description": "Fast interactive review of uncommitted changes \u2014 findings print inline; Apply fixes / Save to file / Discard on confirmation. Writes nothing by default. Hands off to /ycc:review-fix on \"Apply fixes\". Pass --parallel or --team for 3-reviewer fan-out. Pass --yes or --save to skip the prompt (scripted use). Pass --severity <CRITICAL|HIGH|MEDIUM|LOW> to forward the minimum-severity threshold to /ycc:review-fix (default HIGH)."
     },
     {
       "name": "releaser",
@@ -562,8 +570,8 @@
     }
   ],
   "counts": {
-    "skills": 44,
-    "commands": 43,
+    "skills": 45,
+    "commands": 44,
     "agents": 52
   },
   "parity": {

--- a/ycc/commands/code-review.md
+++ b/ycc/commands/code-review.md
@@ -1,11 +1,12 @@
 ---
-description: Code review — local uncommitted changes or a GitHub PR (pass PR number/URL for PR mode). Runs security + quality checks, executes validation commands, writes an artifact, and posts the review. Pass --parallel to fan out the review phase across 3 specialized reviewer agents (correctness, security, quality) and merge findings. Pass --team (Claude Code only) to run the same 3-reviewer fan-out as a coordinated agent team with shared TaskList and per-reviewer task tracking. Worktree mode is on by default in PR mode — pass --no-worktree to opt out. Pass --keep-draft to skip automatic draft→ready promotion. Pass --keep-worktree to skip worktree removal after the review is posted. Pass --quick for a lightweight on-the-fly review of uncommitted changes (no worktree, no validation commands, no gh publish; writes a minimal artifact to docs/prps/reviews/quick-{timestamp}-review.md and ends with a Next steps hint for /ycc:review-fix). Compatible with --parallel and --team; mutually exclusive with a PR argument, --approve, and --request-changes.
+description: Code review — local uncommitted changes or a GitHub PR (pass PR number/URL for PR mode). Runs security + quality checks, executes validation commands, writes an artifact, and posts the review. Pass --parallel to fan out the review phase across 3 specialized reviewer agents (correctness, security, quality) and merge findings. Pass --team (Claude Code only) to run the same 3-reviewer fan-out as a coordinated agent team with shared TaskList and per-reviewer task tracking. Worktree mode is on by default in PR mode — pass --no-worktree to opt out. Pass --keep-draft to skip automatic draft→ready promotion. Pass --keep-worktree to skip worktree removal after the review is posted. Pass --quick as a thin alias for /ycc:quick-review — interactive inline review (no file written unless confirmed), prompts for Apply fixes / Save to file / Discard. Compatible with --parallel and --team; mutually exclusive with a PR argument, --approve, and --request-changes. For direct access to --yes, --save, and --severity, invoke /ycc:quick-review instead.
 argument-hint: '[--quick] [--approve | --request-changes] [--parallel | --team] [--no-worktree] [--keep-draft] [--keep-worktree] [pr-number | pr-url | blank for local review]'
 allowed-tools:
   - Read
   - Grep
   - Glob
   - Write
+  - Skill
   - Agent
   - TeamCreate
   - TeamDelete
@@ -45,7 +46,7 @@ Run a code review in either local or PR mode.
 
 **Flags**:
 
-- `--quick` — Fast on-the-fly review of uncommitted changes. Skips worktree setup, toolchain validation (typecheck/lint/test/build), and GitHub publish. Writes a minimal artifact to `docs/prps/reviews/quick-{timestamp}-review.md` (consumable by `/ycc:review-fix`) and ends with a `Next steps:` block recommending `/ycc:review-fix` (single-pass) or `/ycc:review-fix --parallel` (fan-out) based on finding volume. Compatible with `--parallel` and `--team`; mutually exclusive with a PR argument, `--approve`, and `--request-changes`.
+- `--quick` — **Alias for `/ycc:quick-review`.** Interactive inline review of uncommitted changes — prints findings and prompts **Apply fixes** / **Save to file** / **Discard**. No artifact is written unless you confirm. On "Apply fixes", hands off to `/ycc:review-fix` automatically. Compatible with `--parallel` and `--team`; mutually exclusive with a PR argument, `--approve`, and `--request-changes`. For direct access to `--yes`, `--save`, and `--severity`, invoke `/ycc:quick-review` instead.
 
 - `--approve` — Force the final decision to APPROVE (still reports all findings)
 - `--request-changes` — Force the final decision to REQUEST CHANGES

--- a/ycc/commands/quick-review.md
+++ b/ycc/commands/quick-review.md
@@ -1,0 +1,80 @@
+---
+description: Fast interactive review of uncommitted changes — findings print inline; Apply fixes / Save to file / Discard on confirmation. Writes nothing by default. Hands off to /ycc:review-fix on "Apply fixes". Pass --parallel or --team for 3-reviewer fan-out. Pass --yes or --save to skip the prompt (scripted use). Pass --severity <CRITICAL|HIGH|MEDIUM|LOW> to forward the minimum-severity threshold to /ycc:review-fix (default HIGH).
+argument-hint: '[--parallel | --team] [--yes | --save] [--severity <level>] [--no-worktree]'
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - Edit
+  - Skill
+  - Agent
+  - AskUserQuestion
+  - TeamCreate
+  - TeamDelete
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - TaskGet
+  - SendMessage
+  - Bash(git:*)
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - Bash(test:*)
+  - Bash(mkdir:*)
+  - Bash(date:*)
+---
+
+# Quick Review Command
+
+Run a fast, inline, interactive review of uncommitted changes.
+
+**Load and follow the `ycc:quick-review` skill, passing through `$ARGUMENTS`.**
+
+Unlike `/ycc:code-review`, this skill:
+
+- Prints findings **inline** — no artifact is written by default
+- Asks **Apply fixes / Save to file / Discard** after the review
+- Writes a review artifact **only on confirmation**
+- Hands off to `/ycc:review-fix` automatically when you pick "Apply fixes"
+
+Designed for short, low-friction code changes where opening a full `/ycc:code-review` artifact is overkill.
+
+**Flags**:
+
+- `--parallel` — Fan out the REVIEW phase across 3 standalone `ycc:code-reviewer` sub-agents (correctness, security, quality) in parallel. Works in Claude Code, Cursor, and Codex bundles.
+
+- `--team` — (Claude Code only) Same 3-reviewer fan-out as `--parallel`, dispatched as a coordinated agent team with `TeamCreate`, shared `TaskList`, per-reviewer task tracking, and coordinated shutdown before merge. Cursor and Codex bundles lack the team tools — use `--parallel` there instead.
+
+- `--yes` — Skip the confirmation prompt and auto-confirm "Apply fixes". Useful for scripted flows. Mutually exclusive with `--save`.
+
+- `--save` — Skip the confirmation prompt and auto-confirm "Save to file" (writes the artifact and exits; does not run `/ycc:review-fix`). Mutually exclusive with `--yes`.
+
+- `--severity <CRITICAL|HIGH|MEDIUM|LOW>` — Minimum severity threshold forwarded to `/ycc:review-fix` during hand-off. Default: `HIGH`. Ignored on "Save to file" and "Discard".
+
+- `--no-worktree` — Accepted as a **no-op**. Quick mode never creates a worktree.
+
+`--parallel` and `--team` are **mutually exclusive** — pick one. Same for `--yes` and `--save`.
+
+```
+Usage: /ycc:quick-review [--parallel | --team] [--yes | --save] [--severity <level>] [--no-worktree]
+
+Examples:
+  /ycc:quick-review                               # inline review, prompt for confirmation
+  /ycc:quick-review --parallel                    # 3 parallel sub-agent reviewers, prompt for confirmation
+  /ycc:quick-review --team                        # 3-reviewer agent team (Claude Code only), prompt for confirmation
+  /ycc:quick-review --yes                         # auto-confirm: write artifact + invoke /ycc:review-fix
+  /ycc:quick-review --save                        # auto-confirm: write artifact + exit (run /ycc:review-fix later)
+  /ycc:quick-review --yes --severity MEDIUM       # auto-confirm and lower the fix threshold
+  /ycc:quick-review --parallel --yes              # parallel review + auto-apply fixes
+```
+
+The skill will:
+
+1. `git diff --name-only HEAD` — abort if nothing is changed
+2. REVIEW — single-pass, `--parallel`, or `--team` dispatch
+3. Print findings **inline** in Review Artifact Format (no file written yet)
+4. Ask: **Apply fixes** / **Save to file** / **Discard** (or act on `--yes` / `--save`)
+5. On confirmation → write `docs/prps/reviews/quick-{timestamp}-review.md`; on **Apply fixes**, also invoke `/ycc:review-fix` inline
+
+`/ycc:code-review --quick` delegates here. Use this command directly to access `--yes`, `--save`, and `--severity`.

--- a/ycc/skills/_shared/references/review-checklist.md
+++ b/ycc/skills/_shared/references/review-checklist.md
@@ -1,0 +1,168 @@
+# Review Checklist (Shared Reference)
+
+> Canonical review checklist, severity rubric, parallel-reviewer roster, and
+> standard findings format. Consumed by `ycc:code-review` (local + PR modes)
+> and `ycc:quick-review`. Skills that delegate here MUST NOT duplicate the
+> content below — reference this file instead.
+
+---
+
+## Severity Rubric
+
+| Severity     | Meaning                                     | Action                  |
+| ------------ | ------------------------------------------- | ----------------------- |
+| **CRITICAL** | Security vulnerability or data loss risk    | Must fix before merge   |
+| **HIGH**     | Bug or logic error likely to cause issues   | Should fix before merge |
+| **MEDIUM**   | Code quality issue or missing best practice | Fix recommended         |
+| **LOW**      | Style nit or minor suggestion               | Optional                |
+
+Findings are grouped by severity in the artifact under `### CRITICAL`,
+`### HIGH`, `### MEDIUM`, `### LOW`, in that order.
+
+---
+
+## Local / Quick Review — Single-Pass Checklist (Path A)
+
+Applied to uncommitted changes on `HEAD`. Read each changed file in full.
+
+**Security Issues (CRITICAL):**
+
+- Hardcoded credentials, API keys, tokens
+- SQL injection vulnerabilities
+- XSS vulnerabilities
+- Missing input validation
+- Insecure dependencies
+- Path traversal risks
+
+**Code Quality (HIGH):**
+
+- Functions > 50 lines
+- Files > 800 lines
+- Nesting depth > 4 levels
+- Missing error handling
+- `console.log` statements
+- TODO/FIXME comments
+- Missing JSDoc for public APIs
+
+**Best Practices (MEDIUM):**
+
+- Mutation patterns (use immutable instead)
+- Emoji usage in code/comments
+- Missing tests for new code
+- Accessibility issues (a11y)
+
+---
+
+## PR Review — Single-Pass Checklist (Path A, 7 Categories)
+
+Applied to PR head-revision file contents. Each category is independent —
+a single finding may touch several.
+
+| Category               | What to Check                                                                 |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| **Correctness**        | Logic errors, off-by-ones, null handling, edge cases, race conditions         |
+| **Type Safety**        | Type mismatches, unsafe casts, `any` usage, missing generics                  |
+| **Pattern Compliance** | Matches project conventions (naming, file structure, error handling, imports) |
+| **Security**           | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS              |
+| **Performance**        | N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads   |
+| **Completeness**       | Missing tests, missing error handling, incomplete migrations, missing docs    |
+| **Maintainability**    | Dead code, magic numbers, deep nesting, unclear naming, missing types         |
+
+---
+
+## Parallel Reviewer Roster (Path B / Path C)
+
+Three standalone `ycc:code-reviewer` sub-agents (Path B) or agent-team teammates
+(Path C). The **focus split** differs between local/quick and PR modes because
+local mode has a narrower category set.
+
+### Local / Quick Mode Roster
+
+| Reviewer               | Focus           | Checklist Items                                                                                                               |
+| ---------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `correctness-reviewer` | Code Quality    | Functions > 50 lines, files > 800 lines, nesting > 4 levels, missing error handling, `console.log`, TODO/FIXME, missing JSDoc |
+| `security-reviewer`    | Security Issues | Hardcoded credentials/keys/tokens, SQL injection, XSS, missing input validation, insecure deps, path traversal                |
+| `quality-reviewer`     | Best Practices  | Mutation patterns, emoji in code/comments, missing tests, accessibility (a11y)                                                |
+
+### PR Mode Roster
+
+| Reviewer               | Categories                             | What to Check                                                                                                                                                             |
+| ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `correctness-reviewer` | Correctness, Type Safety, Completeness | Logic errors, off-by-ones, null handling, edge cases, race conditions, type mismatches, unsafe casts, `any` usage, missing generics, missing tests, incomplete migrations |
+| `security-reviewer`    | Security, Performance                  | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS, N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads                             |
+| `quality-reviewer`     | Pattern Compliance, Maintainability    | Project conventions (naming, file structure, error handling, imports), dead code, magic numbers, deep nesting, unclear naming, missing types                              |
+
+Each reviewer prompt MUST include:
+
+1. The list of changed files (mode-specific: `git diff --name-only HEAD` for
+   local/quick; PR number + head revision + changed-file list for PR).
+2. Relevant context (CLAUDE.md rules, PRP artifacts, PR description) — PR mode only.
+3. Its assigned focus / categories and what to check (from the appropriate table
+   above).
+4. The severity rubric.
+5. A directive to return findings in the **Standard Findings Format** below.
+
+---
+
+## Standard Findings Format (Reviewer Output)
+
+Each parallel reviewer returns findings in this shape (pre-merge, before
+finding-ID assignment):
+
+```markdown
+## Findings
+
+### CRITICAL
+
+- `file.ts:42` — [description] [category]
+  - Suggested fix: [fix]
+
+### HIGH
+
+- ...
+
+### MEDIUM
+
+- ...
+
+### LOW
+
+- ...
+```
+
+The `[category]` tag applies to PR mode; local/quick mode may omit it (the focus
+split already implies a category).
+
+---
+
+## Merge Procedure (Path B / Path C)
+
+After all 3 reviewers return:
+
+1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW).
+2. De-duplicate findings at the same `file:line` (if two reviewers flagged the
+   same issue, keep the more severe one and annotate which reviewers concurred).
+3. Sort within each severity by file path.
+4. Attach the reviewer source to each finding (`[correctness]`, `[security]`,
+   `[quality]`) for traceability.
+
+Pass the merged findings to the REPORT phase as if they came from a single-pass
+review.
+
+---
+
+## Finding Artifact Fields
+
+After merging, each finding is promoted to an artifact-format block with these
+fields. The `[F###]` ID is assigned sequentially ordered by severity (CRITICAL
+first), then by file path. Status is always `Open` on first write.
+
+```markdown
+- **[F001]** `file:line` — description
+  - **Status**: Open
+  - **Category**: <category>
+  - **Suggested fix**: <fix>
+```
+
+See `/ycc:code-review` → "Review Artifact Format" for the full artifact schema
+(Header, Summary, Findings, Worktree Setup, Validation Results, Files Reviewed).

--- a/ycc/skills/code-review/SKILL.md
+++ b/ycc/skills/code-review/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: code-review
-description: Dual-mode code review — local uncommitted changes OR a GitHub pull request. Both modes now write a machine-parseable review artifact (Local → docs/prps/reviews/local-{timestamp}-review.md, PR → docs/prps/reviews/pr-{N}-review.md) with sequential finding IDs (F001, F002, ...) and Status fields (Open/Fixed/Failed) so /ycc:review-fix can consume and update them in place. Local mode runs a full security + quality pass on the diff. PR mode fetches the PR, reads each changed file in full, builds context from CLAUDE.md and PRP artifacts, applies a 7-category review checklist, runs validation commands (type-check/lint/test/build) for detected stacks, assigns severity, and posts the review to GitHub via gh. Pass `--parallel` to fan out the REVIEW phase across 3 standalone ycc:code-reviewer sub-agents (correctness, security, quality) and merge findings. Pass `--team` (Claude Code only) to run the same 3-reviewer fan-out as a coordinated agent team with shared TaskList, per-reviewer task tracking, and inter-reviewer communication via SendMessage. `--parallel` and `--team` are mutually exclusive. Worktree mode is on by default in PR mode — pass `--no-worktree` to opt out. Pass `--keep-draft` to skip automatic draft→ready promotion. Pass `--keep-worktree` to skip worktree removal after the review is posted. Use when the user asks to "review code", "review PR", "check uncommitted changes", "review pr N", "parallel review", "team review", or says "/code-review". Adapted from PRPs-agentic-eng by Wirasm.
+description: Dual-mode code review — local uncommitted changes OR a GitHub pull request. Both modes write a machine-parseable review artifact (Local → docs/prps/reviews/local-{timestamp}-review.md, PR → docs/prps/reviews/pr-{N}-review.md) with sequential finding IDs (F001, F002, ...) and Status fields (Open/Fixed/Failed) so /ycc:review-fix can consume and update them in place. Local mode runs a full security + quality pass on the diff. PR mode fetches the PR, reads each changed file in full, builds context from CLAUDE.md and PRP artifacts, applies a 7-category review checklist, runs validation commands (type-check/lint/test/build) for detected stacks, assigns severity, and posts the review to GitHub via gh. For fast, inline, interactive reviews of short uncommitted changes (no file written unless confirmed), use `/ycc:quick-review` directly — `--quick` here is kept as a thin alias that delegates. Pass `--parallel` to fan out the REVIEW phase across 3 standalone ycc:code-reviewer sub-agents (correctness, security, quality) and merge findings. Pass `--team` (Claude Code only) to run the same 3-reviewer fan-out as a coordinated agent team with shared TaskList, per-reviewer task tracking, and inter-reviewer communication via SendMessage. `--parallel` and `--team` are mutually exclusive. Worktree mode is on by default in PR mode — pass `--no-worktree` to opt out. Pass `--keep-draft` to skip automatic draft→ready promotion. Pass `--keep-worktree` to skip worktree removal after the review is posted. Use when the user asks to "review code", "review PR", "check uncommitted changes", "review pr N", "parallel review", "team review", or says "/code-review". Adapted from PRPs-agentic-eng by Wirasm.
 argument-hint: '[--approve | --request-changes] [--parallel | --team] [--no-worktree] [--keep-draft] [--keep-worktree] [pr-number | pr-url | blank for local review]'
 allowed-tools:
   - Read
   - Grep
   - Glob
   - Write
+  - Skill
   - Agent
   - TeamCreate
   - TeamDelete
@@ -47,17 +48,17 @@ allowed-tools:
 
 Before selecting mode, extract flags from `$ARGUMENTS`:
 
-| Flag                | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--approve`         | Force the final decision to APPROVE regardless of findings (still reports all findings)                                                                                                                                                                                                                                                                                                                                                                                     |
-| `--request-changes` | Force the final decision to REQUEST CHANGES regardless of findings                                                                                                                                                                                                                                                                                                                                                                                                          |
-| `--parallel`        | Fan out the REVIEW phase across 3 **standalone** `ycc:code-reviewer` sub-agents (correctness, security, quality) dispatched in parallel and merge findings. Works in Claude Code, Cursor, and Codex.                                                                                                                                                                                                                                                                        |
-| `--team`            | (Claude Code only) Fan out the REVIEW phase across the same 3 `ycc:code-reviewer` reviewers, but dispatched as an **agent team** with up-front `TaskCreate`, shared `TaskList` observability, inter-reviewer coordination via `SendMessage`, and coordinated shutdown before merge. Heavier dispatch, richer communication.                                                                                                                                                 |
-| `--worktree`        | (legacy / now default; safe to omit) Check out the PR head branch into an isolated worktree at `~/.claude-worktrees/<repo>-pr-<N>/`. Worktree mode is on by default in PR mode; pass `--no-worktree` to opt out.                                                                                                                                                                                                                                                            |
-| `--no-worktree`     | Opt out of worktree isolation in PR mode. Skip worktree creation, artifact commit+push, and cleanup. Files are read directly from the main checkout.                                                                                                                                                                                                                                                                                                                        |
-| `--keep-draft`      | Skip the automatic draft→ready promotion in PR mode. Default: PR is promoted to Ready for Review before posting the review.                                                                                                                                                                                                                                                                                                                                                 |
-| `--keep-worktree`   | Skip removal of the PR worktree after the review is posted. The artifact is still committed and pushed to the PR branch. Default: worktree is removed via `git worktree remove <path>` after a clean review post.                                                                                                                                                                                                                                                           |
-| `--quick`           | Fast on-the-fly review of uncommitted changes. Skips worktree setup, toolchain validation (typecheck/lint/test/build), and GitHub publish. Writes a minimal artifact to `docs/prps/reviews/quick-{timestamp}-review.md` and ends with a `Next steps:` block recommending `/ycc:review-fix` (single-pass) or `/ycc:review-fix --parallel` (fan-out). Compatible with `--parallel` and `--team`. Mutually exclusive with a PR argument, `--approve`, and `--request-changes`. |
+| Flag                | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--approve`         | Force the final decision to APPROVE regardless of findings (still reports all findings)                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `--request-changes` | Force the final decision to REQUEST CHANGES regardless of findings                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `--parallel`        | Fan out the REVIEW phase across 3 **standalone** `ycc:code-reviewer` sub-agents (correctness, security, quality) dispatched in parallel and merge findings. Works in Claude Code, Cursor, and Codex.                                                                                                                                                                                                                                                                                                   |
+| `--team`            | (Claude Code only) Fan out the REVIEW phase across the same 3 `ycc:code-reviewer` reviewers, but dispatched as an **agent team** with up-front `TaskCreate`, shared `TaskList` observability, inter-reviewer coordination via `SendMessage`, and coordinated shutdown before merge. Heavier dispatch, richer communication.                                                                                                                                                                            |
+| `--worktree`        | (legacy / now default; safe to omit) Check out the PR head branch into an isolated worktree at `~/.claude-worktrees/<repo>-pr-<N>/`. Worktree mode is on by default in PR mode; pass `--no-worktree` to opt out.                                                                                                                                                                                                                                                                                       |
+| `--no-worktree`     | Opt out of worktree isolation in PR mode. Skip worktree creation, artifact commit+push, and cleanup. Files are read directly from the main checkout.                                                                                                                                                                                                                                                                                                                                                   |
+| `--keep-draft`      | Skip the automatic draft→ready promotion in PR mode. Default: PR is promoted to Ready for Review before posting the review.                                                                                                                                                                                                                                                                                                                                                                            |
+| `--keep-worktree`   | Skip removal of the PR worktree after the review is posted. The artifact is still committed and pushed to the PR branch. Default: worktree is removed via `git worktree remove <path>` after a clean review post.                                                                                                                                                                                                                                                                                      |
+| `--quick`           | **Alias for `/ycc:quick-review`.** Fast interactive review of uncommitted changes — prints findings inline and asks Apply fixes / Save to file / Discard. Writes only on confirmation. Compatible with `--parallel` and `--team`. Mutually exclusive with a PR argument, `--approve`, and `--request-changes`. This skill validates the combination and then delegates to `/ycc:quick-review` with the remaining flags. See that skill's `--yes`, `--save`, and `--severity` options for scripted use. |
 
 Strip these from `$ARGUMENTS` and set `QUICK_MODE=true|false`, `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `NO_WORKTREE_MODE=true|false`, `KEEP_DRAFT=true|false`, and `KEEP_WORKTREE=true|false`. Compute `WORKTREE_MODE=true` unless `--no-worktree` is present (default-on in PR mode; ignored for local mode as before). The remaining text is the mode selector (PR number/URL or blank for local).
 
@@ -171,82 +172,29 @@ The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
 
 #### Path A — Single-Pass Review (default, neither flag set)
 
-Read each changed file in full. Check for:
+Read each changed file in full and apply the **Local / Quick Review —
+Single-Pass Checklist** (Security CRITICAL, Code Quality HIGH, Best Practices
+MEDIUM) and the **Severity Rubric** from:
 
-**Security Issues (CRITICAL):**
-
-- Hardcoded credentials, API keys, tokens
-- SQL injection vulnerabilities
-- XSS vulnerabilities
-- Missing input validation
-- Insecure dependencies
-- Path traversal risks
-
-**Code Quality (HIGH):**
-
-- Functions > 50 lines
-- Files > 800 lines
-- Nesting depth > 4 levels
-- Missing error handling
-- `console.log` statements
-- TODO/FIXME comments
-- Missing JSDoc for public APIs
-
-**Best Practices (MEDIUM):**
-
-- Mutation patterns (use immutable instead)
-- Emoji usage in code/comments
-- Missing tests for new code
-- Accessibility issues (a11y)
+```
+${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
+```
 
 #### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
 
-Dispatch **3 standalone `ycc:code-reviewer` sub-agents in parallel** in a SINGLE message with MULTIPLE `Agent` tool calls. Each agent reads all changed files and applies its assigned focus:
+Dispatch **3 standalone `ycc:code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **Local / Quick Mode Roster**
+(`correctness-reviewer`, `security-reviewer`, `quality-reviewer`) and
+**Standard Findings Format** from:
 
-| Reviewer               | Focus           | Checklist Items                                                                                                               |
-| ---------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `correctness-reviewer` | Code Quality    | Functions > 50 lines, files > 800 lines, nesting > 4 levels, missing error handling, `console.log`, TODO/FIXME, missing JSDoc |
-| `security-reviewer`    | Security Issues | Hardcoded credentials/keys/tokens, SQL injection, XSS, missing input validation, insecure deps, path traversal                |
-| `quality-reviewer`     | Best Practices  | Mutation patterns, emoji in code/comments, missing tests, accessibility (a11y)                                                |
-
-Each reviewer prompt must include:
-
-1. The list of changed files (`git diff --name-only HEAD`)
-2. Its assigned focus and checklist items (from the table above)
-3. The severity rubric (CRITICAL, HIGH, MEDIUM, LOW)
-4. A directive to return findings in the standard format below
-
-Each reviewer returns findings as:
-
-```markdown
-## Findings
-
-### CRITICAL
-
-- `file.ts:42` — [description]
-  - Suggested fix: [fix]
-
-### HIGH
-
-- ...
-
-### MEDIUM
-
-- ...
-
-### LOW
-
-- ...
+```
+${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
 ```
 
-After all 3 reviewers return, **merge findings**:
-
-1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW)
-2. De-duplicate findings at the same `file:line` (if two reviewers flagged the same issue, keep the more severe one and annotate which reviewers concurred)
-3. Sort within each severity by file path
-4. Attach the reviewer source to each finding (`[correctness]`, `[security]`, `[quality]`) for traceability
-
-Pass the merged findings to Phase 3 (REPORT) as if they came from a single-pass review.
+The reviewer-prompt contract (changed files, focus + checklist items, severity
+rubric, findings format directive) and the **Merge Procedure** are defined
+in that reference. Pass the merged findings to Phase 3 (REPORT) as if they
+came from a single-pass review.
 
 #### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Claude Code only)
 
@@ -368,55 +316,32 @@ Never approve code with security vulnerabilities.
 
 ## Quick Review Mode
 
-> Triggered by `--quick`. Lightweight review of uncommitted changes — no worktree, no toolchain validation, no GitHub publish. Just findings plus a `Next steps:` block offering `/ycc:review-fix`. Writes a minimal artifact to `docs/prps/reviews/quick-{YYYYMMDD-HHMMSS}-review.md` so `/ycc:review-fix` can consume it unchanged.
+> Triggered by `--quick`. This mode is now a **thin delegator** to
+> `/ycc:quick-review` — the interactive inline-review skill. Phase 0 above
+> has already validated the flag combination; this section hands off.
 
-### Phase 1 — GATHER
+### Delegation
 
-Identical to Local Review Mode Phase 1 (line 151 above). Compute changed files with:
-
-```bash
-git diff --name-only HEAD
-```
-
-If the diff is empty, print `Nothing to review.` and exit. Do NOT write an artifact.
-
-### Phase 2 — REVIEW
-
-Delegate to **Local Review Mode Phase 2** (starting at line 159 above). The same 7-category checklist, severity rubric, Path A (single-pass) / Path B (`--parallel` → 3 standalone sub-agent reviewers) / Path C (`--team` → coordinated agent team) all apply unchanged.
-
-- If `--parallel` → Path B fan-out.
-- If `--team` → Path C (Claude Code only; compatibility gate already enforced in Phase 0).
-- Otherwise → Path A.
-
-When using Path C in quick mode, use team name `qrev-local-<YYYYMMDD-HHMMSS>` (matching the artifact timestamp). Lifecycle is identical to Local Mode Path C: TeamCreate → TaskCreate × 3 → Agent × 3 in one message → monitor via TaskList → merge → SendMessage shutdown → TeamDelete.
-
-### Phase 3 — REPORT
-
-Assign sequential finding IDs (F001, F002, …) with `Status: Open` on every finding. Write the artifact to `docs/prps/reviews/quick-{YYYYMMDD-HHMMSS}-review.md`. The artifact uses the **Review Artifact Format** (defined at the bottom of this skill) with two omissions:
-
-- **No** `## Validation Results` section — quick mode does not run toolchain validation.
-- **No** `## Worktree Setup` section — quick mode never creates a worktree.
-
-All other sections (Header, Summary, Findings with full ID/Status/Category/Suggested fix, Files Reviewed) are identical to Local Mode's output. `/ycc:review-fix` parses the result unchanged.
-
-Then print a `Next steps:` block to stdout:
+Invoke the `ycc:quick-review` skill via the `Skill` tool. Forward the
+remaining flags — `--parallel` or `--team`, plus anything quick-review
+accepts — but drop the flags this skill owns (`--quick`, `--approve`,
+`--request-changes`, `--no-worktree`, `--keep-draft`, `--keep-worktree`;
+Phase 0 already consumed them).
 
 ```
-Quick review written to: docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md
-Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
-
-Next steps:
-  /ycc:review-fix docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md              # apply fixes {recommended_single if 1-2 Open findings}
-  /ycc:review-fix docs/prps/reviews/quick-YYYYMMDD-HHMMSS-review.md --parallel   # fan out fixes {recommended_parallel if 3+ Open across 2+ files}
+Skill: ycc:quick-review
+  args: "<stripped flags: --parallel | --team | --yes | --save | --severity <level>>"
 ```
 
-**Recommendation heuristic** (annotate ONE of the two commands with `# ← recommended`):
+Print a single one-line notice before delegating so the user sees what
+happened:
 
-- 0 Open findings → print `No findings. No follow-up needed.` and skip the two `/ycc:review-fix` command lines.
-- 1–2 Open findings → recommend the single-pass form.
-- 3+ Open findings spanning 2+ files → recommend the `--parallel` form.
+```
+--quick delegated to /ycc:quick-review. Run /ycc:quick-review directly for full option surface (--yes, --save, --severity).
+```
 
-Quick mode has **NO** Phase 4/5/6/7/8 — no VALIDATE, DECIDE, PUBLISH, or OUTPUT phases. If you need toolchain validation or a GitHub review posted, re-run without `--quick`.
+After the Skill call returns, exit. Do NOT run Phase 4/5/6/7/8. Do NOT
+write an artifact here — quick-review owns the artifact lifecycle.
 
 ---
 
@@ -483,69 +408,37 @@ The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
 
 #### Path A — Single-Pass Review (default, neither flag set)
 
-Apply the review checklist across 7 categories:
+Apply the **PR Review — Single-Pass Checklist** (7 categories: Correctness,
+Type Safety, Pattern Compliance, Security, Performance, Completeness,
+Maintainability) and the **Severity Rubric** from:
 
-| Category               | What to Check                                                                 |
-| ---------------------- | ----------------------------------------------------------------------------- |
-| **Correctness**        | Logic errors, off-by-ones, null handling, edge cases, race conditions         |
-| **Type Safety**        | Type mismatches, unsafe casts, `any` usage, missing generics                  |
-| **Pattern Compliance** | Matches project conventions (naming, file structure, error handling, imports) |
-| **Security**           | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS              |
-| **Performance**        | N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads   |
-| **Completeness**       | Missing tests, missing error handling, incomplete migrations, missing docs    |
-| **Maintainability**    | Dead code, magic numbers, deep nesting, unclear naming, missing types         |
+```
+${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
+```
 
 #### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
 
-Dispatch **3 standalone `ycc:code-reviewer` sub-agents in parallel** in a SINGLE message with MULTIPLE `Agent` tool calls. Each agent reads all changed files at the PR head revision and applies its assigned category slice:
+Dispatch **3 standalone `ycc:code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **PR Mode Roster**
+(`correctness-reviewer`, `security-reviewer`, `quality-reviewer`) and
+**Standard Findings Format** from:
 
-| Reviewer               | Categories                             | What to Check                                                                                                                                                             |
-| ---------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `correctness-reviewer` | Correctness, Type Safety, Completeness | Logic errors, off-by-ones, null handling, edge cases, race conditions, type mismatches, unsafe casts, `any` usage, missing generics, missing tests, incomplete migrations |
-| `security-reviewer`    | Security, Performance                  | Injection, auth gaps, secret exposure, SSRF, path traversal, XSS, N+1 queries, missing indexes, unbounded loops, memory leaks, large payloads                             |
-| `quality-reviewer`     | Pattern Compliance, Maintainability    | Project conventions (naming, file structure, error handling, imports), dead code, magic numbers, deep nesting, unclear naming, missing types                              |
+```
+${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
+```
 
-Each reviewer prompt must include:
+Each reviewer prompt must additionally include:
 
 1. The PR number, head revision, and the list of changed files
 2. Relevant context from Phase 2 (CLAUDE.md rules, PRP artifacts, PR description)
-3. Its assigned categories and what to check (from the table above)
-4. The severity rubric
-5. A directive to return findings in the standard format below
 
-Each reviewer returns findings as:
+The reviewer-prompt contract (focus + categories, severity rubric, findings
+format directive) and the **Merge Procedure** are defined in that reference.
+Pass the merged findings to Phase 4 (VALIDATE) and downstream phases as if
+they came from a single-pass review.
 
-```markdown
-## Findings
-
-### CRITICAL
-
-- `file.ts:42` — [description] [category]
-  - Suggested fix: [fix]
-
-### HIGH
-
-- ...
-
-### MEDIUM
-
-- ...
-
-### LOW
-
-- ...
-```
-
-After all 3 reviewers return, **merge findings**:
-
-1. Combine by severity (CRITICAL first, then HIGH, MEDIUM, LOW)
-2. De-duplicate findings at the same `file:line` (if two reviewers flagged the same issue, keep the more severe one and list both concurring reviewers)
-3. Sort within each severity by file path
-4. Tag each finding with its source reviewer (`[correctness]`, `[security]`, `[quality]`) for traceability
-
-Pass the merged findings to Phase 4 (VALIDATE) and downstream phases as if they came from a single-pass review.
-
-**Note**: Validation commands (Phase 4) still run sequentially in the main skill — parallelization here only applies to the review pass.
+**Note**: Validation commands (Phase 4) still run sequentially in the main
+skill — parallelization here only applies to the review pass.
 
 #### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Claude Code only)
 

--- a/ycc/skills/quick-review/SKILL.md
+++ b/ycc/skills/quick-review/SKILL.md
@@ -1,0 +1,393 @@
+---
+name: quick-review
+description: Fast interactive review of uncommitted changes. Prints findings inline (no file written by default), then asks Apply fixes / Save to file / Discard. Writing only happens on confirmation. Hands off to /ycc:review-fix on "Apply fixes". Designed for short, low-friction code changes where opening a full /ycc:code-review artifact is overkill. Pass `--parallel` to fan out across 3 standalone ycc:code-reviewer sub-agents (correctness, security, quality). Pass `--team` (Claude Code only) for the same fan-out as a coordinated agent team. `--parallel` and `--team` are mutually exclusive. Pass `--yes` to auto-confirm (Apply fixes) or `--save` to auto-confirm (Save to file) for scripted use. Pass `--severity <CRITICAL|HIGH|MEDIUM|LOW>` to forward the minimum severity threshold to /ycc:review-fix (default HIGH). Use when the user asks to "quick review", "fast review", "review what I have", "on-the-fly review", or says "/quick-review". `/ycc:code-review --quick` delegates here.
+argument-hint: '[--parallel | --team] [--yes | --save] [--severity <level>] [--no-worktree]'
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - Edit
+  - Skill
+  - Agent
+  - AskUserQuestion
+  - TeamCreate
+  - TeamDelete
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - TaskGet
+  - SendMessage
+  - Bash(git:*)
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - Bash(test:*)
+  - Bash(mkdir:*)
+  - Bash(date:*)
+---
+
+# Quick Review
+
+Interactive low-friction review of uncommitted changes. Output is **inline**;
+a review artifact is only written on confirmation.
+
+**Input**: `$ARGUMENTS`
+
+**Core rule**: You will **NOT** write a review artifact until the user
+explicitly selects "Apply fixes" or "Save to file". "Discard" writes nothing.
+
+---
+
+## Phase 0 — Parse flags
+
+Extract flags from `$ARGUMENTS`:
+
+| Flag                 | Effect                                                                                                                                                                                                    |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--parallel`         | Fan out REVIEW across 3 standalone `ycc:code-reviewer` sub-agents (correctness, security, quality) and merge findings. Works in Claude Code, Cursor, and Codex bundles.                                   |
+| `--team`             | (Claude Code only) Same 3-reviewer fan-out as a coordinated agent team with `TeamCreate`, shared `TaskList`, per-reviewer `TaskCreate`, and coordinated shutdown. Heavier dispatch, richer communication. |
+| `--yes`              | Skip the confirmation prompt in Phase 4 and behave as "Apply fixes". Mutually exclusive with `--save`.                                                                                                    |
+| `--save`             | Skip the confirmation prompt in Phase 4 and behave as "Save to file" (write artifact, print Next steps, exit). Mutually exclusive with `--yes`.                                                           |
+| `--severity <level>` | Forwarded to `/ycc:review-fix` during hand-off. Valid: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`. Default: `HIGH`. Ignored on "Save to file" / "Discard".                                                       |
+| `--no-worktree`      | Accepted as a **no-op**. Quick mode never creates a worktree. Emit a note: `--no-worktree has no effect in quick mode.`                                                                                   |
+
+Strip these from `$ARGUMENTS` and set `PARALLEL_MODE`, `AGENT_TEAM_MODE`,
+`AUTO_YES`, `AUTO_SAVE`, and `MIN_SEVERITY` (default `HIGH`). The remaining
+text MUST be empty; if not, abort with:
+
+```
+Error: /ycc:quick-review takes no positional argument (only flags).
+```
+
+**Validation**:
+
+- `--parallel` and `--team` mutually exclusive → abort with: `--parallel and --team are mutually exclusive. Pick one.`
+- `--yes` and `--save` mutually exclusive → abort with: `--yes and --save are mutually exclusive. Pick one.`
+- `--team` in a Cursor/Codex bundle (no `TeamCreate` tool) → abort with: `--team is not supported in bundle invocations; use --parallel instead.`
+- `--severity` value not one of `CRITICAL|HIGH|MEDIUM|LOW` → abort with: `Invalid --severity value. Use CRITICAL, HIGH, MEDIUM, or LOW.`
+
+---
+
+## Phase 1 — GATHER
+
+```bash
+git diff --name-only HEAD
+```
+
+If the output is empty, print `Nothing to review.` and exit. Do NOT prompt,
+do NOT write anything.
+
+Capture the list of changed files as `CHANGED_FILES` for the REVIEW phase.
+
+---
+
+## Phase 2 — REVIEW
+
+The shape of this phase depends on `PARALLEL_MODE` and `AGENT_TEAM_MODE`:
+
+| Flags             | Path                                        |
+| ----------------- | ------------------------------------------- |
+| Neither set       | **Path A** — single-pass review (default)   |
+| `PARALLEL_MODE`   | **Path B** — 3 parallel sub-agent reviewers |
+| `AGENT_TEAM_MODE` | **Path C** — 3-reviewer agent team          |
+
+Findings from all paths stay **in memory** — do not write to disk yet.
+
+### Path A — Single-Pass Review (default)
+
+Read each changed file in full and apply the **Local / Quick Review —
+Single-Pass Checklist** and **Severity Rubric** from:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
+```
+
+### Path B — Parallel Sub-Agent Review (`PARALLEL_MODE=true`)
+
+Dispatch **3 standalone `ycc:code-reviewer` sub-agents in parallel** in a SINGLE
+message with MULTIPLE `Agent` tool calls. Use the **Local / Quick Mode Roster**
+and **Standard Findings Format** from:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/review-checklist.md
+```
+
+Each reviewer prompt must include:
+
+1. The list of changed files (`git diff --name-only HEAD`)
+2. Its assigned focus and checklist items (from the roster table)
+3. The severity rubric
+4. A directive to return findings in the Standard Findings Format
+
+Apply the **Merge Procedure** defined in the reference to produce a single
+combined findings list for Phase 3.
+
+### Path C — Agent Team Review (`AGENT_TEAM_MODE=true`, Claude Code only)
+
+> **MANDATORY — AGENT TEAMS REQUIRED**
+>
+> You MUST follow the agent-team lifecycle. Every `Agent` call MUST include
+> `team_name=` AND `name=`. See
+> `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/agent-team-dispatch.md`.
+
+Roster and category split identical to Path B.
+
+#### C.1 Build the team name
+
+Team name: `qrev-local-<YYYYMMDD-HHMMSS>`. Generate the timestamp once at the
+start of Phase 2 and reuse it if the user later selects "Save to file" or
+"Apply fixes" (for artifact filename consistency).
+
+#### C.2 Create the team
+
+```
+TeamCreate: team_name="qrev-local-<timestamp>", description="Quick review team for uncommitted local changes"
+```
+
+On failure, abort.
+
+#### C.3 Register subtasks
+
+Create 3 tasks in the shared task list (flat graph — reviewers are independent):
+
+```
+TaskCreate: subject="correctness-reviewer: code-quality review of uncommitted changes", description="<full reviewer prompt>"
+TaskCreate: subject="security-reviewer: security review of uncommitted changes",        description="<full reviewer prompt>"
+TaskCreate: subject="quality-reviewer: best-practices review of uncommitted changes",   description="<full reviewer prompt>"
+```
+
+If any `TaskCreate` fails → `TeamDelete`, abort.
+
+#### C.4 Spawn the 3 reviewers
+
+Single message, three `Agent` calls. Every call MUST include `team_name`, `name`
+(matching the `TaskCreate` subject prefix), `subagent_type="ycc:code-reviewer"`,
+description, and a prompt equivalent to Path B's reviewer prompt plus a note
+that the teammate shares a task list with two siblings (name them) and may
+`SendMessage` them on overlaps, and must call `TaskUpdate` to mark its task
+complete before returning.
+
+#### C.5 Monitor and collect results
+
+Use `TaskList` until all 3 tasks are `completed`. Failure policy:
+
+- All 3 error → `TeamDelete`, abort with a clear error.
+- 1 or 2 error → record "partial review — {role} did not complete" and proceed
+  with the remaining findings. Note the gap when printing inline.
+
+#### C.6 Shutdown and cleanup
+
+```
+SendMessage(to="correctness-reviewer", message={type:"shutdown_request"})
+SendMessage(to="security-reviewer",    message={type:"shutdown_request"})
+SendMessage(to="quality-reviewer",     message={type:"shutdown_request"})
+TeamDelete
+```
+
+Always `TeamDelete` — even on abort or partial failure.
+
+#### C.7 Merge findings
+
+Apply the reference's Merge Procedure and pass the combined findings to Phase 3.
+
+---
+
+## Phase 3 — REPORT (inline)
+
+Assign sequential finding IDs (`F001`, `F002`, …) ordered by severity
+(CRITICAL first) then by file path. Every finding gets `Status: Open`.
+
+Compute the finding counts by severity: `C`, `H`, `M`, `L`.
+
+**Print** the review to stdout in the Review Artifact Format, **without**
+writing a file. The printed block looks like:
+
+```markdown
+# Quick Review — Uncommitted Changes
+
+**Reviewed**: <ISO date>
+**Mode**: Quick (inline)
+**Author**: local
+**Branch**: <current-branch>
+**Decision**: (pending user confirmation)
+
+## Summary
+
+<1–2 sentence overall assessment>
+
+## Findings
+
+### CRITICAL
+
+- **[F001]** `file:line` — <description>
+  - **Status**: Open
+  - **Category**: <Security | Correctness | Code Quality | Best Practices>
+  - **Suggested fix**: <concrete fix>
+
+### HIGH
+
+- **[F002]** ...
+  - **Status**: Open
+  - ...
+
+### MEDIUM
+
+- **[F003]** ...
+  - **Status**: Open
+  - ...
+
+### LOW
+
+- **[F004]** ...
+  - **Status**: Open
+  - ...
+
+## Files Reviewed
+
+- `file1.ts` (Modified)
+- `file2.ts` (Added)
+```
+
+**Omissions** (vs. the standard Review Artifact Format): no
+`## Worktree Setup` section (quick mode never creates a worktree) and no
+`## Validation Results` section (quick mode does not run toolchain checks).
+
+After the artifact block, print a one-line summary:
+
+```
+Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
+```
+
+If the count is zero across all severities, skip Phase 4 entirely. Print
+`No findings. Nothing to do.` and exit.
+
+Otherwise continue to Phase 4.
+
+---
+
+## Phase 4 — DECIDE (confirmation)
+
+If `AUTO_YES=true` → skip this phase, proceed directly to Phase 5 as if the
+user selected "Apply fixes".
+
+If `AUTO_SAVE=true` → skip this phase, proceed directly to Phase 5 as if the
+user selected "Save to file".
+
+Otherwise, ask the user with `AskUserQuestion`:
+
+```
+question: "What should I do with this review?"
+header:   "Review action"
+options:
+  - label: "Apply fixes"
+    description: "Write the review artifact to docs/prps/reviews/ and hand off to /ycc:review-fix (recommended)"
+  - label: "Save to file"
+    description: "Write the review artifact to docs/prps/reviews/ and stop — you can run /ycc:review-fix later"
+  - label: "Discard"
+    description: "Write nothing, exit"
+```
+
+Mark "Apply fixes" with `(Recommended)` in its label when
+`critical_count + high_count > 0`; otherwise leave it unmarked.
+
+**Text-mode fallback** (if `AskUserQuestion` is unavailable — Cursor/Codex
+bundles without that tool): print the three choices explicitly and WAIT for
+the user's next message. Parse their reply case-insensitively:
+
+- `yes` / `apply` / `apply fixes` / `fix` → "Apply fixes"
+- `save` / `save to file` / `write` / `file` → "Save to file"
+- `no` / `discard` / `cancel` / `skip` → "Discard"
+- Anything else → re-prompt once, then default to `Discard` if still ambiguous.
+
+---
+
+## Phase 5 — HAND-OFF
+
+Branch on the user's selection (or the auto-confirm flag).
+
+### Selection: "Discard"
+
+Print `Discarded. No artifact written.` and exit. Do NOT write any file.
+
+### Selection: "Save to file"
+
+Write the artifact to disk using the Phase 3 content plus the canonical
+header block:
+
+```bash
+mkdir -p docs/prps/reviews
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)    # reuse the Path C timestamp if set
+REVIEW_FILE="docs/prps/reviews/quick-${TIMESTAMP}-review.md"
+```
+
+Write the same artifact content that was printed in Phase 3, but set
+`**Decision**: COMMENT` in the header (since a review was produced but no
+GitHub decision is being posted).
+
+Print the Next steps block to stdout:
+
+```
+Quick review written to: docs/prps/reviews/quick-<TIMESTAMP>-review.md
+Findings: [C] {critical_count}  [H] {high_count}  [M] {medium_count}  [L] {low_count}
+
+Next steps:
+  /ycc:review-fix docs/prps/reviews/quick-<TIMESTAMP>-review.md              # apply fixes {recommended_single if 1-2 Open findings}
+  /ycc:review-fix docs/prps/reviews/quick-<TIMESTAMP>-review.md --parallel   # fan out fixes {recommended_parallel if 3+ Open across 2+ files}
+```
+
+Annotate ONE of the two commands with `# ← recommended`:
+
+- 1–2 Open findings → recommend the single-pass form.
+- 3+ Open findings spanning 2+ files → recommend the `--parallel` form.
+- Otherwise default to the single-pass form.
+
+Exit.
+
+### Selection: "Apply fixes"
+
+Step 1 — write the artifact to disk (same as "Save to file" above) so
+`/ycc:review-fix` can parse and update it in place.
+
+Step 2 — invoke the `ycc:review-fix` skill inline via the `Skill` tool:
+
+- `skill`: `"ycc:review-fix"`
+- `args`: `"<REVIEW_FILE> [--parallel] [--severity <level>]"` — always pass the
+  explicit review path. Forward `--parallel` if `PARALLEL_MODE=true`. Forward
+  `--severity <level>` when `MIN_SEVERITY != HIGH` (HIGH is the default on
+  review-fix so omitting it produces the same behavior).
+
+Step 3 — after the Skill call returns, print a one-line confirmation:
+
+```
+Fixes complete. Review artifact updated in place: docs/prps/reviews/quick-<TIMESTAMP>-review.md
+```
+
+Step 4 — exit.
+
+**Note**: `--team` from quick-review is NOT forwarded to `/ycc:review-fix`
+automatically. The review-phase fan-out is about finding issues quickly;
+the fix phase has its own decision. If the user wants team-mode fixes they
+can re-run `/ycc:review-fix <path> --team` themselves.
+
+---
+
+## Important Notes
+
+- **No artifact until confirmation**: "Discard" MUST write nothing. "Save to
+  file" and "Apply fixes" both write once, to the same canonical path.
+- **Idempotent filename**: the `quick-{YYYYMMDD-HHMMSS}-review.md` pattern
+  produces a new file per invocation — no overwrites.
+- **Parity with `/ycc:code-review`**: the artifact format and finding schema
+  are identical, so `/ycc:review-fix` consumes it unchanged.
+- **Not a replacement for `/ycc:code-review`**: if you need toolchain
+  validation (typecheck/lint/test/build), a `## Validation Results` block,
+  worktree isolation, or a GitHub review posted, use `/ycc:code-review`
+  without `--quick`.
+
+---
+
+## Integration with ycc
+
+- `/ycc:code-review --quick` delegates to this skill.
+- `/ycc:review-fix` consumes the written artifact.
+- `/ycc:prp-commit` or `/ycc:git-workflow` can commit the fixes afterward.


### PR DESCRIPTION
## Summary

Replace `/ycc:code-review --quick`'s file-writing behavior with a new dedicated `ycc:quick-review` skill that prints findings inline and asks **Apply fixes / Save to file / Discard** before any artifact is written. Designed for short, low-friction changes where a full code-review artifact is overkill. On "Apply fixes" it hands off to `/ycc:review-fix` in the same conversation.

`/ycc:code-review --quick` stays as a thin passthrough so existing muscle memory keeps working.

## Changes

- **New skill** `ycc/skills/quick-review/SKILL.md` — inline REVIEW → `AskUserQuestion` prompt → write-on-confirmation or discard. Supports `--parallel`, `--team`, `--yes`, `--save`, `--severity`. Text-mode fallback when `AskUserQuestion` is unavailable.
- **New command wrapper** `ycc/commands/quick-review.md` → `/ycc:quick-review`.
- **New shared reference** `ycc/skills/_shared/references/review-checklist.md` — single source of truth for severity rubric, local/quick checklist, PR 7-category checklist, parallel-reviewer roster, standard findings format, and merge procedure. Both `code-review` and `quick-review` now pull from here.
- **`ycc/skills/code-review/SKILL.md`** — Local Mode Path A/B and PR Mode Path A/B now reference the shared checklist. `## Quick Review Mode` rewritten as a thin delegator to `/ycc:quick-review` via the `Skill` tool. Phase 0 still validates the flag combination (mutex with PR arg, `--approve`, `--request-changes`). SKILL size drops from 1003 → 896 lines. Description updated.
- **`ycc/commands/code-review.md`** — `--quick` flag row and description updated to reflect aliasing; `Skill` added to `allowed-tools`.
- Cursor, Codex, and opencode compatibility bundles regenerated. `docs/inventory.json` updated (45 skills, 44 commands).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Refactor (no functional changes)
- [x] Documentation — shared-reference extraction

## Testing

- [x] `./scripts/validate.sh` passes (all targets: inventory, cursor, codex, opencode, json, formatter bundle, hooks symlink)
- [x] `./scripts/sync.sh` produces clean bundles
- [x] `npm run lint` passes (markdownlint + prettier + ruff + black + shellcheck)
- [x] `python3 -m json.tool` validates `marketplace.json` and `ycc/.claude-plugin/plugin.json`
- [x] `find ycc/skills -name "*.sh" -not -executable` — only pre-existing helpers (not in scope)
- [ ] Live smoke test in a Claude Code session — see Reviewer Notes

### Manual smoke matrix (not yet run — requires live Claude Code session)

1. `/ycc:quick-review` in a dirty repo → findings print inline, no file on disk
2. Answer "Apply fixes" → file appears, `/ycc:review-fix` invoked inline, Status flips to Fixed
3. Answer "Save to file" → file appears, Next steps printed, no fix dispatch
4. Answer "Discard" → no file, no agents dispatched
5. `/ycc:code-review --quick` delegates with a one-line notice
6. `/ycc:quick-review --parallel` → 3-reviewer fan-out
7. `/ycc:code-review --quick --approve` rejected at Phase 0 (mutex still enforced)
8. Empty diff → `Nothing to review.`

## Reviewer Notes

- **The manual smoke matrix above has not been run.** Skill behavior can't be exercised without a live Claude Code session. Worth running before merging to catch any behavioral regressions the static validators can't see.
- **The shared-reference extraction changes the prose rendering** of code-review Path A/B (the inline checklist tables are now a reference pointer). Verify that this is acceptable stylistically — if you want the checklist inline for discoverability, the refactor can be partially reverted while keeping quick-review on its own.
- **Size reduction**: `ycc/skills/code-review/SKILL.md` is down ~10% (1003 → 896 lines). Still over the 500-line soft cap per `CLAUDE.md`, but the quick-mode delegation has extracted the right concern. Further trimming (split PR mode into its own skill?) is out of scope for this PR.
- **`--team` forwarding on "Apply fixes"**: `quick-review --team` does NOT forward `--team` to `/ycc:review-fix`. Rationale is documented in the skill. Re-consider if you'd rather propagate it.
- **Worktree**: `~/.claude-worktrees/claude-plugins-quick-review-interactive` (per repo convention). Safe to remove post-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new `quick-review` command providing interactive inline review of uncommitted changes with user confirmation options: Apply fixes, Save to file, or Discard.

* **Refactor**
  * Updated `--quick` flag to delegate to `quick-review` with interactive confirmation flow instead of automatic artifact creation.

* **Documentation**
  * Established shared review checklist standards, severity rubrics, and reviewer procedures across plugin systems for consistent review practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->