### PR TITLE
fix(skills): wire prepare-feature-branch.sh into --no-worktree paths

### DIFF
--- a/.codex-plugin/ycc/shared/references/branch-prep.md
+++ b/.codex-plugin/ycc/shared/references/branch-prep.md
@@ -1,0 +1,21 @@
+# Branch Prep Helper Contract
+
+Use `prepare-feature-branch.sh` before any worktree setup or implementor-agent dispatch, except in dry-run or plan-only paths that do not touch git. Worktree setup adopts the prepared `feat/<slug>` branch when it exists.
+
+```bash
+FEATURE_BRANCH=$(bash ~/.codex/plugins/ycc/shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+```
+
+The helper echoes the prepared branch name on success.
+
+| Current State                                                                  | Helper Behavior                                                                       |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| On `feat/<slug>`                                                               | Idempotent no-op; echoes branch and exits 0                                           |
+| On `main`/`master`/`trunk`/`develop`, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                             |
+| On `main`/`master`/`trunk`/`develop`, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                          |
+| On another feature branch                                                      | Exits 2; re-run with `--allow-existing-feature-branch` after confirming with the user |
+| On trunk with unrelated dirty files                                            | Exits 1; stop and ask the user to stash or commit first                               |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation.
+
+If it exits 1, stop and have the user clean the tree before dispatching agents.

--- a/.codex-plugin/ycc/shared/scripts/prepare-feature-branch.sh
+++ b/.codex-plugin/ycc/shared/scripts/prepare-feature-branch.sh
@@ -7,12 +7,13 @@
 #
 # Behavior:
 #   - Rejects an unrelated dirty checkout (only plan-artifact paths allowed:
-#     docs/plans/<slug>/*, docs/prps/plans/<slug>*, docs/prps/specs/<slug>*).
+#     docs/plans/<slug>/*, docs/orchestration/<slug>*,
+#     docs/prps/{plans,specs,prds}/<slug>*).
 #   - On feat/<slug>: idempotent no-op.
-#   - On trunk (main/master) and feat/<slug> exists: switch to it.
+#   - On trunk (main/master/trunk/develop) and feat/<slug> exists: switch to it.
 #   - On trunk and feat/<slug> missing: create it.
-#   - On another feature branch + --allow-existing-feature-branch: keep it.
-#   - On another feature branch without the flag: exit 2 (caller asks user).
+#   - On another non-trunk branch + --allow-existing-feature-branch: keep it.
+#   - On another non-trunk branch without the flag: exit 2 (caller asks user).
 #
 # Mirrors setup-worktree.sh stdout/stderr discipline:
 #   - Branch name on stdout (one line).
@@ -21,7 +22,7 @@
 # Exit codes:
 #   0  branch is prepared (name on stdout)
 #   1  hard failure (dirty unrelated tree, git error, missing slug, ...)
-#   2  on a different feature branch and --allow-existing-feature-branch not set
+#   2  on a different non-trunk branch and --allow-existing-feature-branch not set
 
 set -euo pipefail
 
@@ -36,8 +37,7 @@ Usage:
 
 Arguments:
   feature-slug                       Kebab-case feature identifier (e.g. "add-widget")
-  --allow-existing-feature-branch    Reuse the current branch if it already starts
-                                     with feat/ and differs from feat/<feature-slug>
+  --allow-existing-feature-branch    Reuse the current non-trunk branch
 EOF
 }
 
@@ -56,6 +56,16 @@ _info() {
 FEATURE_SLUG=""
 ALLOW_EXISTING_FEATURE_BRANCH=false
 
+set_feature_slug() {
+  if [[ -z "$FEATURE_SLUG" ]]; then
+    FEATURE_SLUG="$1"
+  else
+    _error "unexpected positional argument: $1"
+    usage
+    exit 1
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --allow-existing-feature-branch)
@@ -68,6 +78,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --)
       shift
+      while [[ $# -gt 0 ]]; do
+        set_feature_slug "$1"
+        shift
+      done
       break
       ;;
     -*)
@@ -76,13 +90,7 @@ while [[ $# -gt 0 ]]; do
       exit 1
       ;;
     *)
-      if [[ -z "$FEATURE_SLUG" ]]; then
-        FEATURE_SLUG="$1"
-      else
-        _error "unexpected positional argument: $1"
-        usage
-        exit 1
-      fi
+      set_feature_slug "$1"
       shift
       ;;
   esac
@@ -90,6 +98,12 @@ done
 
 if [[ -z "$FEATURE_SLUG" ]]; then
   _error "feature-slug is required"
+  usage
+  exit 1
+fi
+
+if [[ ! "$FEATURE_SLUG" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+  _error "feature-slug must be kebab-case matching [a-z0-9][a-z0-9-]*"
   usage
   exit 1
 fi
@@ -111,6 +125,12 @@ fi
 
 FEATURE_BRANCH="feat/${FEATURE_SLUG}"
 
+if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
+  _info "already on ${FEATURE_BRANCH}"
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
 # ---------------------------------------------------------------------------
 # Dirty-tree guard
 # ---------------------------------------------------------------------------
@@ -121,6 +141,7 @@ is_plan_artifact() {
   local path="$1"
   case "$path" in
     docs/plans/"${FEATURE_SLUG}"/*) return 0 ;;
+    docs/orchestration/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/plans/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/specs/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/prds/"${FEATURE_SLUG}"*) return 0 ;;
@@ -160,6 +181,10 @@ branch_exists() {
   git show-ref --verify --quiet "refs/heads/$1"
 }
 
+remote_branch_exists() {
+  git show-ref --verify --quiet "refs/remotes/origin/$1"
+}
+
 is_trunk_branch() {
   case "$1" in
     main|master|trunk|develop) return 0 ;;
@@ -167,16 +192,16 @@ is_trunk_branch() {
   esac
 }
 
-if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
-  _info "already on ${FEATURE_BRANCH}"
-  echo "$FEATURE_BRANCH"
-  exit 0
-fi
-
 if is_trunk_branch "$CURRENT_BRANCH"; then
   if branch_exists "$FEATURE_BRANCH"; then
     _info "switching from ${CURRENT_BRANCH} to existing ${FEATURE_BRANCH}"
     git checkout "$FEATURE_BRANCH" >&2
+    if ! git merge-base --is-ancestor "$CURRENT_BRANCH" "$FEATURE_BRANCH"; then
+      _info "warning: ${FEATURE_BRANCH} is not based on current ${CURRENT_BRANCH}; consider rebasing before dispatch"
+    fi
+  elif remote_branch_exists "$FEATURE_BRANCH"; then
+    _info "switching from ${CURRENT_BRANCH} to existing origin/${FEATURE_BRANCH}"
+    git checkout --track "origin/${FEATURE_BRANCH}" >&2
   else
     _info "creating ${FEATURE_BRANCH} from ${CURRENT_BRANCH}"
     git checkout -b "$FEATURE_BRANCH" >&2

--- a/.codex-plugin/ycc/shared/scripts/prepare-feature-branch.sh
+++ b/.codex-plugin/ycc/shared/scripts/prepare-feature-branch.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# prepare-feature-branch.sh — ensure the current checkout is on the feature
+# branch before dispatching implementor agents in --no-worktree mode.
+#
+# Usage:
+#   prepare-feature-branch.sh <feature-slug> [--allow-existing-feature-branch]
+#
+# Behavior:
+#   - Rejects an unrelated dirty checkout (only plan-artifact paths allowed:
+#     docs/plans/<slug>/*, docs/prps/plans/<slug>*, docs/prps/specs/<slug>*).
+#   - On feat/<slug>: idempotent no-op.
+#   - On trunk (main/master) and feat/<slug> exists: switch to it.
+#   - On trunk and feat/<slug> missing: create it.
+#   - On another feature branch + --allow-existing-feature-branch: keep it.
+#   - On another feature branch without the flag: exit 2 (caller asks user).
+#
+# Mirrors setup-worktree.sh stdout/stderr discipline:
+#   - Branch name on stdout (one line).
+#   - All git output and status messages on stderr.
+#
+# Exit codes:
+#   0  branch is prepared (name on stdout)
+#   1  hard failure (dirty unrelated tree, git error, missing slug, ...)
+#   2  on a different feature branch and --allow-existing-feature-branch not set
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  prepare-feature-branch.sh <feature-slug> [--allow-existing-feature-branch]
+
+Arguments:
+  feature-slug                       Kebab-case feature identifier (e.g. "add-widget")
+  --allow-existing-feature-branch    Reuse the current branch if it already starts
+                                     with feat/ and differs from feat/<feature-slug>
+EOF
+}
+
+_error() {
+  echo "prepare-feature-branch.sh: error: $*" >&2
+}
+
+_info() {
+  echo "prepare-feature-branch.sh: $*" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+FEATURE_SLUG=""
+ALLOW_EXISTING_FEATURE_BRANCH=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-existing-feature-branch)
+      ALLOW_EXISTING_FEATURE_BRANCH=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -z "$FEATURE_SLUG" ]]; then
+        FEATURE_SLUG="$1"
+      else
+        _error "unexpected positional argument: $1"
+        usage
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$FEATURE_SLUG" ]]; then
+  _error "feature-slug is required"
+  usage
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Git context
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository"
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ -z "$CURRENT_BRANCH" ]]; then
+  _error "detached HEAD is not supported; check out a branch first"
+  exit 1
+fi
+
+FEATURE_BRANCH="feat/${FEATURE_SLUG}"
+
+# ---------------------------------------------------------------------------
+# Dirty-tree guard
+# ---------------------------------------------------------------------------
+#
+# Allow plan-artifact paths; reject anything else.
+
+is_plan_artifact() {
+  local path="$1"
+  case "$path" in
+    docs/plans/"${FEATURE_SLUG}"/*) return 0 ;;
+    docs/prps/plans/"${FEATURE_SLUG}"*) return 0 ;;
+    docs/prps/specs/"${FEATURE_SLUG}"*) return 0 ;;
+    docs/prps/prds/"${FEATURE_SLUG}"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+UNRELATED_DIRTY=()
+collect_dirty() {
+  # Untracked files (file-level — avoids `?? dir/` collapsed entries from
+  # `git status --porcelain` and `--untracked-files=all`'s memory cost).
+  git ls-files --others --exclude-standard
+  # Modified-but-unstaged tracked files.
+  git diff --name-only
+  # Staged tracked files (added/modified/renamed/deleted).
+  git diff --name-only --cached
+}
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  if ! is_plan_artifact "$path"; then
+    UNRELATED_DIRTY+=("$path")
+  fi
+done < <(collect_dirty | sort -u)
+
+if (( ${#UNRELATED_DIRTY[@]} > 0 )); then
+  _error "working tree has unrelated changes; stash or commit them first:"
+  printf '  %s\n' "${UNRELATED_DIRTY[@]}" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Branch state machine
+# ---------------------------------------------------------------------------
+
+branch_exists() {
+  git show-ref --verify --quiet "refs/heads/$1"
+}
+
+is_trunk_branch() {
+  case "$1" in
+    main|master|trunk|develop) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
+  _info "already on ${FEATURE_BRANCH}"
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
+if is_trunk_branch "$CURRENT_BRANCH"; then
+  if branch_exists "$FEATURE_BRANCH"; then
+    _info "switching from ${CURRENT_BRANCH} to existing ${FEATURE_BRANCH}"
+    git checkout "$FEATURE_BRANCH" >&2
+  else
+    _info "creating ${FEATURE_BRANCH} from ${CURRENT_BRANCH}"
+    git checkout -b "$FEATURE_BRANCH" >&2
+  fi
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
+# Some other branch — already a non-trunk branch, not feat/<slug>.
+if [[ "$ALLOW_EXISTING_FEATURE_BRANCH" == true ]]; then
+  _info "using current branch ${CURRENT_BRANCH} (--allow-existing-feature-branch)"
+  echo "$CURRENT_BRANCH"
+  exit 0
+fi
+
+_error "on branch '${CURRENT_BRANCH}', expected '${FEATURE_BRANCH}' or a trunk branch"
+_error "pass --allow-existing-feature-branch to reuse the current branch, or check out a trunk branch first"
+exit 2

--- a/.codex-plugin/ycc/skills/implement-plan/SKILL.md
+++ b/.codex-plugin/ycc/skills/implement-plan/SKILL.md
@@ -223,7 +223,13 @@ Before creating a worktree or branch, inspect `GIT_STATUS`.
 
 ### Step 6.6: Prepare the execution tree
 
-When `WORKTREE_ACTIVE=true`, create the parent worktree **once** before Batch 1. The worktree owns `FEATURE_BRANCH`; do not check out that branch in the main checkout:
+Prepare the feature branch directly in the current checkout **before** any worktree setup or implementor-agent dispatch. The helper exits non-zero on failure and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`. See `~/.codex/plugins/ycc/shared/references/branch-prep.md` for the helper's behavior and exit-code contract.
+
+```bash
+FEATURE_BRANCH=$(bash ~/.codex/plugins/ycc/shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
+```
+
+When `WORKTREE_ACTIVE=true`, create the parent worktree **once** before Batch 1. The worktree adopts the prepared `FEATURE_BRANCH`:
 
 ```bash
 WT_PARENT_PATH=$(bash ~/.codex/plugins/ycc/shared/scripts/setup-worktree.sh parent "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}")
@@ -237,23 +243,7 @@ Store the echoed path as `WT_PARENT_PATH` (overrides any deduced value).
 All agents in every batch — parallel and sequential — operate directly in this
 single feature worktree. No child worktrees are created.
 
-When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout. Run the shared helper **before dispatching any implementor agents** — without this step, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
-
-```bash
-FEATURE_BRANCH=$(bash ~/.codex/plugins/ycc/shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
-```
-
-The script enforces the branch-decision matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main` (GitHub #TBD).
-
-| Current State                                                            | Helper Behavior                                                                        |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| On `FEATURE_BRANCH`                                                      | Idempotent no-op; echoes `feat/<slug>` and exits 0                                     |
-| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` exists  | `git checkout feat/<slug>`; echoes branch                                              |
-| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` missing | `git checkout -b feat/<slug>`; echoes branch                                           |
-| On another feature branch                                                | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user |
-| On main with unrelated dirty files                                       | Exits 1 — ask user to stash or commit first                                            |
-
-If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup.
 
 After this branch step, all agents in every batch operate in the current checkout. Include `Working directory: ${REPO_ROOT}` in each prompt when `--no-worktree` is active so dispatched agents target the prepared branch consistently.
 

--- a/.codex-plugin/ycc/skills/implement-plan/SKILL.md
+++ b/.codex-plugin/ycc/skills/implement-plan/SKILL.md
@@ -237,15 +237,23 @@ Store the echoed path as `WT_PARENT_PATH` (overrides any deduced value).
 All agents in every batch — parallel and sequential — operate directly in this
 single feature worktree. No child worktrees are created.
 
-When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout:
+When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout. Run the shared helper **before dispatching any implementor agents** — without this step, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
 
-| Current State                                                                | Action                                                      |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| On `FEATURE_BRANCH`                                                          | Use current branch                                          |
-| On another feature branch                                                    | Use current branch only if the user confirms it is intended |
-| On main, clean/plan-only dirty checkout, and `FEATURE_BRANCH` exists         | Switch to it: `git checkout "${FEATURE_BRANCH}"`            |
-| On main, clean/plan-only dirty checkout, and `FEATURE_BRANCH` does not exist | Create it: `git checkout -b "${FEATURE_BRANCH}"`            |
-| On main with unrelated dirty files                                           | **STOP** — ask user to stash or commit first                |
+```bash
+FEATURE_BRANCH=$(bash ~/.codex/plugins/ycc/shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
+```
+
+The script enforces the branch-decision matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main` (GitHub #TBD).
+
+| Current State                                                            | Helper Behavior                                                                        |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| On `FEATURE_BRANCH`                                                      | Idempotent no-op; echoes `feat/<slug>` and exits 0                                     |
+| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` exists  | `git checkout feat/<slug>`; echoes branch                                              |
+| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` missing | `git checkout -b feat/<slug>`; echoes branch                                           |
+| On another feature branch                                                | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user |
+| On main with unrelated dirty files                                       | Exits 1 — ask user to stash or commit first                                            |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
 
 After this branch step, all agents in every batch operate in the current checkout. Include `Working directory: ${REPO_ROOT}` in each prompt when `--no-worktree` is active so dispatched agents target the prepared branch consistently.
 

--- a/.codex-plugin/ycc/skills/orchestrate/SKILL.md
+++ b/.codex-plugin/ycc/skills/orchestrate/SKILL.md
@@ -235,9 +235,17 @@ The decision follows a strict precedence order:
 
 `--worktree` is accepted as a silent no-op and matches the new default; it has no additional effect. Note: this skill does not auto-detect `## Worktree Setup` annotations from a plan (it creates its own decomposition), so the only opt-out is `--no-worktree`.
 
-Skip this phase entirely when `WORKTREE_MODE=false`.
+### When `WORKTREE_MODE=false` (`--no-worktree`)
 
-When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`:
+Skip parent worktree setup, but **always prepare the feature branch** before any agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
+
+```bash
+FEATURE_BRANCH=$(bash ~/.codex/plugins/ycc/shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+```
+
+The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+
+### When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`
 
 Determine the repository name from the current directory (`basename $(git rev-parse --show-toplevel)`). Use the `FEATURE_SLUG` derived during flag parsing.
 

--- a/.codex-plugin/ycc/skills/orchestrate/SKILL.md
+++ b/.codex-plugin/ycc/skills/orchestrate/SKILL.md
@@ -35,7 +35,7 @@ Parse flags first, then treat the remainder as the task description:
 
 Strip flags from `$ARGUMENTS` and set `TEAM_FLAG=true|false`, `DRY_RUN=true|false`, `PLAN_ONLY=true|false`, `SEQUENTIAL=true|false`, `WORKTREE_MODE=true|false`. Join the remaining non-flag tokens into `TASK_DESCRIPTION`.
 
-**Feature slug derivation** (used when `WORKTREE_MODE=true`): sanitize `TASK_DESCRIPTION` to produce `FEATURE_SLUG` — lowercase, replace `[^a-z0-9-]` with `-`, collapse runs of `-`, trim leading/trailing `-`, truncate to 20 characters. Fall back to `untitled` if empty. This is the same sanitization used for team-name context in `agent-team-dispatch.md` §1.
+**Feature slug derivation**: after `TASK_DESCRIPTION` is set, always sanitize it to produce `FEATURE_SLUG` before any `WORKTREE_MODE` branching — lowercase, replace `[^a-z0-9-]` with `-`, collapse runs of `-`, trim leading/trailing `-`, truncate to 20 characters. Fall back to `untitled` if empty. This is the same sanitization used for team-name context in `agent-team-dispatch.md` §1.
 
 If no task description is provided after stripping flags, abort with usage instructions:
 

--- a/.codex-plugin/ycc/skills/orchestrate/SKILL.md
+++ b/.codex-plugin/ycc/skills/orchestrate/SKILL.md
@@ -235,15 +235,17 @@ The decision follows a strict precedence order:
 
 `--worktree` is accepted as a silent no-op and matches the new default; it has no additional effect. Note: this skill does not auto-detect `## Worktree Setup` annotations from a plan (it creates its own decomposition), so the only opt-out is `--no-worktree`.
 
-### When `WORKTREE_MODE=false` (`--no-worktree`)
+### Branch Preparation
 
-Skip parent worktree setup, but **always prepare the feature branch** before any agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
+When `DRY_RUN=false` and `PLAN_ONLY=false`, **always prepare the feature branch** before any worktree setup or agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
 
 ```bash
 FEATURE_BRANCH=$(bash ~/.codex/plugins/ycc/shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
 ```
 
-The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+See `~/.codex/plugins/ycc/shared/references/branch-prep.md` for the helper's behavior and exit-code contract. Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+
+When `WORKTREE_MODE=false` (`--no-worktree`), skip parent worktree setup after branch preparation.
 
 ### When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`
 

--- a/.codex-plugin/ycc/skills/plan/SKILL.md
+++ b/.codex-plugin/ycc/skills/plan/SKILL.md
@@ -559,7 +559,18 @@ If the plan was produced with `--parallel` (has a `Batches` section and `Depends
 
 **Option 1 — In-conversation parallel execution (lightweight)**
 
-Process batches sequentially. Within each batch, dispatch one `implementor` agent per step in a SINGLE message with MULTIPLE `Agent` tool calls. Between batches, run the project's type-check and unit-test commands. On failure, stop and ask the user how to proceed.
+Before dispatching any `implementor` agents, prepare the feature branch so agents do not commit on `main`:
+
+- **`WORKTREE_MODE=true` (default)** — the plan already names the parent worktree at `~/.claude-worktrees/<repo>-<feature>/` (branch `feat/<feature>`). Run `setup-worktree.sh parent <repo> <feature>` once, then dispatch agents with `Working directory: <parent path>`.
+- **`WORKTREE_MODE=false` (`--no-worktree`)** — derive `FEATURE_SLUG` from the user's request using the same sanitization as Path B §B.1 (lowercase, non-`[a-z0-9-]` → `-`, collapse runs, truncate to 20 chars, fallback `untitled`), then run:
+
+  ```bash
+  FEATURE_BRANCH=$(bash ~/.codex/plugins/ycc/shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+  ```
+
+  The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). **Do not skip this step** — it is what prevents implementor agents from committing to `main`.
+
+Then process batches sequentially. Within each batch, dispatch one `implementor` agent per step in a SINGLE message with MULTIPLE `Agent` tool calls. Between batches, run the project's type-check and unit-test commands. On failure, stop and ask the user how to proceed.
 
 This keeps everything in the current conversation — no file artifact needed.
 

--- a/.codex-plugin/ycc/skills/prp-implement/SKILL.md
+++ b/.codex-plugin/ycc/skills/prp-implement/SKILL.md
@@ -177,22 +177,11 @@ git status --porcelain
 Run the shared branch-prep helper **before any agent dispatch** so implementor agents inherit the right branch instead of `main`:
 
 ```bash
-FEATURE_BRANCH=$(bash "~/.codex/plugins/ycc/shared/scripts/prepare-feature-branch.sh" \
+FEATURE_BRANCH=$(bash ~/.codex/plugins/ycc/shared/scripts/prepare-feature-branch.sh \
   "${WT_FEATURE_SLUG}")
 ```
 
-The script enforces the matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`.
-
-| Current State                                                  | Helper Behavior                                                                            |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| On `feat/<slug>`                                               | Idempotent no-op; echoes branch and exits 0                                                |
-| On main/master/trunk, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                                  |
-| On main/master/trunk, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                               |
-| On another feature branch                                      | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user     |
-| On main with unrelated dirty files                             | Exits 1 — stop and ask user to stash or commit first                                       |
-| In a git worktree for this feature                             | Use the worktree (see `WORKTREE_ACTIVE` logic below); the helper still resolves the branch |
-
-If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+The script exits non-zero on failure and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`. See `~/.codex/plugins/ycc/shared/references/branch-prep.md` for the helper's behavior and exit-code contract.
 
 When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so `feat/<slug>` exists locally), then run the worktree setup step below — `setup-worktree.sh parent` will adopt the existing branch.
 

--- a/.codex-plugin/ycc/skills/prp-implement/SKILL.md
+++ b/.codex-plugin/ycc/skills/prp-implement/SKILL.md
@@ -203,7 +203,7 @@ When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so 
 After the branch decision, create the parent worktree **once** before the first batch:
 
 ```bash
-WT_PARENT_PATH=$(bash "~/.codex/plugins/ycc/shared/scripts/setup-worktree.sh" \
+WT_PARENT_PATH=$(bash ~/.codex/plugins/ycc/shared/scripts/setup-worktree.sh \
   parent "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}")
 ```
 
@@ -214,7 +214,7 @@ This creates `~/.claude-worktrees/${WT_REPO_NAME}-${WT_FEATURE_SLUG}/` on branch
 Plan artifacts written by `prp-plan` are pre-commit and live in the **main checkout** when this skill starts. The first thing to do after the worktree exists is **move** them in — never copy, never sync:
 
 ```bash
-PLAN_PATH=$(bash "~/.codex/plugins/ycc/shared/scripts/move-plan-to-worktree.sh" \
+PLAN_PATH=$(bash ~/.codex/plugins/ycc/shared/scripts/move-plan-to-worktree.sh \
   "$ARGUMENTS" "$WT_PARENT_PATH")
 ```
 
@@ -632,7 +632,7 @@ mv "$PLAN_PATH" "$(dirname -- "$PLAN_PATH")/completed/"
 After archiving the plan, run:
 
 ```bash
-bash "~/.codex/plugins/ycc/shared/scripts/list-worktrees.sh" \
+bash ~/.codex/plugins/ycc/shared/scripts/list-worktrees.sh \
   "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}"
 ```
 

--- a/.codex-plugin/ycc/skills/prp-implement/SKILL.md
+++ b/.codex-plugin/ycc/skills/prp-implement/SKILL.md
@@ -174,14 +174,27 @@ git status --porcelain
 
 ### Branch Decision
 
-| Current State                      | Action                                                    |
-| ---------------------------------- | --------------------------------------------------------- |
-| On feature branch                  | Use current branch                                        |
-| On main, clean working tree        | Create feature branch: `git checkout -b feat/{plan-name}` |
-| On main, dirty working tree        | **STOP** — Ask user to stash or commit first              |
-| In a git worktree for this feature | Use the worktree (see WORKTREE_ACTIVE logic below)        |
+Run the shared branch-prep helper **before any agent dispatch** so implementor agents inherit the right branch instead of `main`:
 
-When `WORKTREE_ACTIVE=true`, the branch decision above applies to the **main repo** (from which the parent worktree branches). After resolving the branch, also run the worktree setup step below.
+```bash
+FEATURE_BRANCH=$(bash "~/.codex/plugins/ycc/shared/scripts/prepare-feature-branch.sh" \
+  "${WT_FEATURE_SLUG}")
+```
+
+The script enforces the matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`.
+
+| Current State                                                  | Helper Behavior                                                                            |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| On `feat/<slug>`                                               | Idempotent no-op; echoes branch and exits 0                                                |
+| On main/master/trunk, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                                  |
+| On main/master/trunk, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                               |
+| On another feature branch                                      | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user     |
+| On main with unrelated dirty files                             | Exits 1 — stop and ask user to stash or commit first                                       |
+| In a git worktree for this feature                             | Use the worktree (see `WORKTREE_ACTIVE` logic below); the helper still resolves the branch |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+
+When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so `feat/<slug>` exists locally), then run the worktree setup step below — `setup-worktree.sh parent` will adopt the existing branch.
 
 ### Parent Worktree Setup (when `WORKTREE_ACTIVE=true`)
 

--- a/.cursor-plugin/skills/_shared/references/branch-prep.md
+++ b/.cursor-plugin/skills/_shared/references/branch-prep.md
@@ -1,0 +1,21 @@
+# Branch Prep Helper Contract
+
+Use `prepare-feature-branch.sh` before any worktree setup or implementor-agent dispatch, except in dry-run or plan-only paths that do not touch git. Worktree setup adopts the prepared `feat/<slug>` branch when it exists.
+
+```bash
+FEATURE_BRANCH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+```
+
+The helper echoes the prepared branch name on success.
+
+| Current State                                                                  | Helper Behavior                                                                       |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| On `feat/<slug>`                                                               | Idempotent no-op; echoes branch and exits 0                                           |
+| On `main`/`master`/`trunk`/`develop`, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                             |
+| On `main`/`master`/`trunk`/`develop`, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                          |
+| On another feature branch                                                      | Exits 2; re-run with `--allow-existing-feature-branch` after confirming with the user |
+| On trunk with unrelated dirty files                                            | Exits 1; stop and ask the user to stash or commit first                               |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation.
+
+If it exits 1, stop and have the user clean the tree before dispatching agents.

--- a/.cursor-plugin/skills/_shared/scripts/prepare-feature-branch.sh
+++ b/.cursor-plugin/skills/_shared/scripts/prepare-feature-branch.sh
@@ -7,12 +7,13 @@
 #
 # Behavior:
 #   - Rejects an unrelated dirty checkout (only plan-artifact paths allowed:
-#     docs/plans/<slug>/*, docs/prps/plans/<slug>*, docs/prps/specs/<slug>*).
+#     docs/plans/<slug>/*, docs/orchestration/<slug>*,
+#     docs/prps/{plans,specs,prds}/<slug>*).
 #   - On feat/<slug>: idempotent no-op.
-#   - On trunk (main/master) and feat/<slug> exists: switch to it.
+#   - On trunk (main/master/trunk/develop) and feat/<slug> exists: switch to it.
 #   - On trunk and feat/<slug> missing: create it.
-#   - On another feature branch + --allow-existing-feature-branch: keep it.
-#   - On another feature branch without the flag: exit 2 (caller asks user).
+#   - On another non-trunk branch + --allow-existing-feature-branch: keep it.
+#   - On another non-trunk branch without the flag: exit 2 (caller asks user).
 #
 # Mirrors setup-worktree.sh stdout/stderr discipline:
 #   - Branch name on stdout (one line).
@@ -21,7 +22,7 @@
 # Exit codes:
 #   0  branch is prepared (name on stdout)
 #   1  hard failure (dirty unrelated tree, git error, missing slug, ...)
-#   2  on a different feature branch and --allow-existing-feature-branch not set
+#   2  on a different non-trunk branch and --allow-existing-feature-branch not set
 
 set -euo pipefail
 
@@ -36,8 +37,7 @@ Usage:
 
 Arguments:
   feature-slug                       Kebab-case feature identifier (e.g. "add-widget")
-  --allow-existing-feature-branch    Reuse the current branch if it already starts
-                                     with feat/ and differs from feat/<feature-slug>
+  --allow-existing-feature-branch    Reuse the current non-trunk branch
 EOF
 }
 
@@ -56,6 +56,16 @@ _info() {
 FEATURE_SLUG=""
 ALLOW_EXISTING_FEATURE_BRANCH=false
 
+set_feature_slug() {
+  if [[ -z "$FEATURE_SLUG" ]]; then
+    FEATURE_SLUG="$1"
+  else
+    _error "unexpected positional argument: $1"
+    usage
+    exit 1
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --allow-existing-feature-branch)
@@ -68,6 +78,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --)
       shift
+      while [[ $# -gt 0 ]]; do
+        set_feature_slug "$1"
+        shift
+      done
       break
       ;;
     -*)
@@ -76,13 +90,7 @@ while [[ $# -gt 0 ]]; do
       exit 1
       ;;
     *)
-      if [[ -z "$FEATURE_SLUG" ]]; then
-        FEATURE_SLUG="$1"
-      else
-        _error "unexpected positional argument: $1"
-        usage
-        exit 1
-      fi
+      set_feature_slug "$1"
       shift
       ;;
   esac
@@ -90,6 +98,12 @@ done
 
 if [[ -z "$FEATURE_SLUG" ]]; then
   _error "feature-slug is required"
+  usage
+  exit 1
+fi
+
+if [[ ! "$FEATURE_SLUG" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+  _error "feature-slug must be kebab-case matching [a-z0-9][a-z0-9-]*"
   usage
   exit 1
 fi
@@ -111,6 +125,12 @@ fi
 
 FEATURE_BRANCH="feat/${FEATURE_SLUG}"
 
+if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
+  _info "already on ${FEATURE_BRANCH}"
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
 # ---------------------------------------------------------------------------
 # Dirty-tree guard
 # ---------------------------------------------------------------------------
@@ -121,6 +141,7 @@ is_plan_artifact() {
   local path="$1"
   case "$path" in
     docs/plans/"${FEATURE_SLUG}"/*) return 0 ;;
+    docs/orchestration/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/plans/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/specs/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/prds/"${FEATURE_SLUG}"*) return 0 ;;
@@ -160,6 +181,10 @@ branch_exists() {
   git show-ref --verify --quiet "refs/heads/$1"
 }
 
+remote_branch_exists() {
+  git show-ref --verify --quiet "refs/remotes/origin/$1"
+}
+
 is_trunk_branch() {
   case "$1" in
     main|master|trunk|develop) return 0 ;;
@@ -167,16 +192,16 @@ is_trunk_branch() {
   esac
 }
 
-if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
-  _info "already on ${FEATURE_BRANCH}"
-  echo "$FEATURE_BRANCH"
-  exit 0
-fi
-
 if is_trunk_branch "$CURRENT_BRANCH"; then
   if branch_exists "$FEATURE_BRANCH"; then
     _info "switching from ${CURRENT_BRANCH} to existing ${FEATURE_BRANCH}"
     git checkout "$FEATURE_BRANCH" >&2
+    if ! git merge-base --is-ancestor "$CURRENT_BRANCH" "$FEATURE_BRANCH"; then
+      _info "warning: ${FEATURE_BRANCH} is not based on current ${CURRENT_BRANCH}; consider rebasing before dispatch"
+    fi
+  elif remote_branch_exists "$FEATURE_BRANCH"; then
+    _info "switching from ${CURRENT_BRANCH} to existing origin/${FEATURE_BRANCH}"
+    git checkout --track "origin/${FEATURE_BRANCH}" >&2
   else
     _info "creating ${FEATURE_BRANCH} from ${CURRENT_BRANCH}"
     git checkout -b "$FEATURE_BRANCH" >&2

--- a/.cursor-plugin/skills/_shared/scripts/prepare-feature-branch.sh
+++ b/.cursor-plugin/skills/_shared/scripts/prepare-feature-branch.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# prepare-feature-branch.sh — ensure the current checkout is on the feature
+# branch before dispatching implementor agents in --no-worktree mode.
+#
+# Usage:
+#   prepare-feature-branch.sh <feature-slug> [--allow-existing-feature-branch]
+#
+# Behavior:
+#   - Rejects an unrelated dirty checkout (only plan-artifact paths allowed:
+#     docs/plans/<slug>/*, docs/prps/plans/<slug>*, docs/prps/specs/<slug>*).
+#   - On feat/<slug>: idempotent no-op.
+#   - On trunk (main/master) and feat/<slug> exists: switch to it.
+#   - On trunk and feat/<slug> missing: create it.
+#   - On another feature branch + --allow-existing-feature-branch: keep it.
+#   - On another feature branch without the flag: exit 2 (caller asks user).
+#
+# Mirrors setup-worktree.sh stdout/stderr discipline:
+#   - Branch name on stdout (one line).
+#   - All git output and status messages on stderr.
+#
+# Exit codes:
+#   0  branch is prepared (name on stdout)
+#   1  hard failure (dirty unrelated tree, git error, missing slug, ...)
+#   2  on a different feature branch and --allow-existing-feature-branch not set
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  prepare-feature-branch.sh <feature-slug> [--allow-existing-feature-branch]
+
+Arguments:
+  feature-slug                       Kebab-case feature identifier (e.g. "add-widget")
+  --allow-existing-feature-branch    Reuse the current branch if it already starts
+                                     with feat/ and differs from feat/<feature-slug>
+EOF
+}
+
+_error() {
+  echo "prepare-feature-branch.sh: error: $*" >&2
+}
+
+_info() {
+  echo "prepare-feature-branch.sh: $*" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+FEATURE_SLUG=""
+ALLOW_EXISTING_FEATURE_BRANCH=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-existing-feature-branch)
+      ALLOW_EXISTING_FEATURE_BRANCH=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -z "$FEATURE_SLUG" ]]; then
+        FEATURE_SLUG="$1"
+      else
+        _error "unexpected positional argument: $1"
+        usage
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$FEATURE_SLUG" ]]; then
+  _error "feature-slug is required"
+  usage
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Git context
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository"
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ -z "$CURRENT_BRANCH" ]]; then
+  _error "detached HEAD is not supported; check out a branch first"
+  exit 1
+fi
+
+FEATURE_BRANCH="feat/${FEATURE_SLUG}"
+
+# ---------------------------------------------------------------------------
+# Dirty-tree guard
+# ---------------------------------------------------------------------------
+#
+# Allow plan-artifact paths; reject anything else.
+
+is_plan_artifact() {
+  local path="$1"
+  case "$path" in
+    docs/plans/"${FEATURE_SLUG}"/*) return 0 ;;
+    docs/prps/plans/"${FEATURE_SLUG}"*) return 0 ;;
+    docs/prps/specs/"${FEATURE_SLUG}"*) return 0 ;;
+    docs/prps/prds/"${FEATURE_SLUG}"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+UNRELATED_DIRTY=()
+collect_dirty() {
+  # Untracked files (file-level — avoids `?? dir/` collapsed entries from
+  # `git status --porcelain` and `--untracked-files=all`'s memory cost).
+  git ls-files --others --exclude-standard
+  # Modified-but-unstaged tracked files.
+  git diff --name-only
+  # Staged tracked files (added/modified/renamed/deleted).
+  git diff --name-only --cached
+}
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  if ! is_plan_artifact "$path"; then
+    UNRELATED_DIRTY+=("$path")
+  fi
+done < <(collect_dirty | sort -u)
+
+if (( ${#UNRELATED_DIRTY[@]} > 0 )); then
+  _error "working tree has unrelated changes; stash or commit them first:"
+  printf '  %s\n' "${UNRELATED_DIRTY[@]}" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Branch state machine
+# ---------------------------------------------------------------------------
+
+branch_exists() {
+  git show-ref --verify --quiet "refs/heads/$1"
+}
+
+is_trunk_branch() {
+  case "$1" in
+    main|master|trunk|develop) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
+  _info "already on ${FEATURE_BRANCH}"
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
+if is_trunk_branch "$CURRENT_BRANCH"; then
+  if branch_exists "$FEATURE_BRANCH"; then
+    _info "switching from ${CURRENT_BRANCH} to existing ${FEATURE_BRANCH}"
+    git checkout "$FEATURE_BRANCH" >&2
+  else
+    _info "creating ${FEATURE_BRANCH} from ${CURRENT_BRANCH}"
+    git checkout -b "$FEATURE_BRANCH" >&2
+  fi
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
+# Some other branch — already a non-trunk branch, not feat/<slug>.
+if [[ "$ALLOW_EXISTING_FEATURE_BRANCH" == true ]]; then
+  _info "using current branch ${CURRENT_BRANCH} (--allow-existing-feature-branch)"
+  echo "$CURRENT_BRANCH"
+  exit 0
+fi
+
+_error "on branch '${CURRENT_BRANCH}', expected '${FEATURE_BRANCH}' or a trunk branch"
+_error "pass --allow-existing-feature-branch to reuse the current branch, or check out a trunk branch first"
+exit 2

--- a/.cursor-plugin/skills/implement-plan/SKILL.md
+++ b/.cursor-plugin/skills/implement-plan/SKILL.md
@@ -256,15 +256,23 @@ Store the echoed path as `WT_PARENT_PATH` (overrides any deduced value).
 All agents in every batch — parallel and sequential — operate directly in this
 single feature worktree. No child worktrees are created.
 
-When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout:
+When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout. Run the shared helper **before dispatching any implementor agents** — without this step, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
 
-| Current State                                                                | Action                                                      |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| On `FEATURE_BRANCH`                                                          | Use current branch                                          |
-| On another feature branch                                                    | Use current branch only if the user confirms it is intended |
-| On main, clean/plan-only dirty checkout, and `FEATURE_BRANCH` exists         | Switch to it: `git checkout "${FEATURE_BRANCH}"`            |
-| On main, clean/plan-only dirty checkout, and `FEATURE_BRANCH` does not exist | Create it: `git checkout -b "${FEATURE_BRANCH}"`            |
-| On main with unrelated dirty files                                           | **STOP** — ask user to stash or commit first                |
+```bash
+FEATURE_BRANCH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
+```
+
+The script enforces the branch-decision matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main` (GitHub #TBD).
+
+| Current State                                                            | Helper Behavior                                                                        |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| On `FEATURE_BRANCH`                                                      | Idempotent no-op; echoes `feat/<slug>` and exits 0                                     |
+| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` exists  | `git checkout feat/<slug>`; echoes branch                                              |
+| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` missing | `git checkout -b feat/<slug>`; echoes branch                                           |
+| On another feature branch                                                | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user |
+| On main with unrelated dirty files                                       | Exits 1 — ask user to stash or commit first                                            |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
 
 After this branch step, all agents in every batch operate in the current checkout. Include `Working directory: ${REPO_ROOT}` in each prompt when `--no-worktree` is active so dispatched agents target the prepared branch consistently.
 

--- a/.cursor-plugin/skills/implement-plan/SKILL.md
+++ b/.cursor-plugin/skills/implement-plan/SKILL.md
@@ -242,7 +242,13 @@ Before creating a worktree or branch, inspect `GIT_STATUS`.
 
 ### Step 6.6: Prepare the execution tree
 
-When `WORKTREE_ACTIVE=true`, create the parent worktree **once** before Batch 1. The worktree owns `FEATURE_BRANCH`; do not check out that branch in the main checkout:
+Prepare the feature branch directly in the current checkout **before** any worktree setup or implementor-agent dispatch. The helper exits non-zero on failure and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`. See `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/branch-prep.md` for the helper's behavior and exit-code contract.
+
+```bash
+FEATURE_BRANCH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
+```
+
+When `WORKTREE_ACTIVE=true`, create the parent worktree **once** before Batch 1. The worktree adopts the prepared `FEATURE_BRANCH`:
 
 ```bash
 WT_PARENT_PATH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/setup-worktree.sh parent "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}")
@@ -256,23 +262,7 @@ Store the echoed path as `WT_PARENT_PATH` (overrides any deduced value).
 All agents in every batch — parallel and sequential — operate directly in this
 single feature worktree. No child worktrees are created.
 
-When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout. Run the shared helper **before dispatching any implementor agents** — without this step, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
-
-```bash
-FEATURE_BRANCH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
-```
-
-The script enforces the branch-decision matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main` (GitHub #TBD).
-
-| Current State                                                            | Helper Behavior                                                                        |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| On `FEATURE_BRANCH`                                                      | Idempotent no-op; echoes `feat/<slug>` and exits 0                                     |
-| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` exists  | `git checkout feat/<slug>`; echoes branch                                              |
-| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` missing | `git checkout -b feat/<slug>`; echoes branch                                           |
-| On another feature branch                                                | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user |
-| On main with unrelated dirty files                                       | Exits 1 — ask user to stash or commit first                                            |
-
-If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup.
 
 After this branch step, all agents in every batch operate in the current checkout. Include `Working directory: ${REPO_ROOT}` in each prompt when `--no-worktree` is active so dispatched agents target the prepared branch consistently.
 

--- a/.cursor-plugin/skills/orchestrate/SKILL.md
+++ b/.cursor-plugin/skills/orchestrate/SKILL.md
@@ -50,7 +50,7 @@ Parse flags first, then treat the remainder as the task description:
 
 Strip flags from `$ARGUMENTS` and set `TEAM_FLAG=true|false`, `DRY_RUN=true|false`, `PLAN_ONLY=true|false`, `SEQUENTIAL=true|false`, `WORKTREE_MODE=true|false`. Join the remaining non-flag tokens into `TASK_DESCRIPTION`.
 
-**Feature slug derivation** (used when `WORKTREE_MODE=true`): sanitize `TASK_DESCRIPTION` to produce `FEATURE_SLUG` — lowercase, replace `[^a-z0-9-]` with `-`, collapse runs of `-`, trim leading/trailing `-`, truncate to 20 characters. Fall back to `untitled` if empty. This is the same sanitization used for team-name context in `agent-team-dispatch.md` §1.
+**Feature slug derivation**: after `TASK_DESCRIPTION` is set, always sanitize it to produce `FEATURE_SLUG` before any `WORKTREE_MODE` branching — lowercase, replace `[^a-z0-9-]` with `-`, collapse runs of `-`, trim leading/trailing `-`, truncate to 20 characters. Fall back to `untitled` if empty. This is the same sanitization used for team-name context in `agent-team-dispatch.md` §1.
 
 If no task description is provided after stripping flags, abort with usage instructions:
 

--- a/.cursor-plugin/skills/orchestrate/SKILL.md
+++ b/.cursor-plugin/skills/orchestrate/SKILL.md
@@ -250,15 +250,17 @@ The decision follows a strict precedence order:
 
 `--worktree` is accepted as a silent no-op and matches the new default; it has no additional effect. Note: this skill does not auto-detect `## Worktree Setup` annotations from a plan (it creates its own decomposition), so the only opt-out is `--no-worktree`.
 
-### When `WORKTREE_MODE=false` (`--no-worktree`)
+### Branch Preparation
 
-Skip parent worktree setup, but **always prepare the feature branch** before any agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
+When `DRY_RUN=false` and `PLAN_ONLY=false`, **always prepare the feature branch** before any worktree setup or agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
 
 ```bash
 FEATURE_BRANCH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
 ```
 
-The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+See `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/branch-prep.md` for the helper's behavior and exit-code contract. Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+
+When `WORKTREE_MODE=false` (`--no-worktree`), skip parent worktree setup after branch preparation.
 
 ### When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`
 

--- a/.cursor-plugin/skills/orchestrate/SKILL.md
+++ b/.cursor-plugin/skills/orchestrate/SKILL.md
@@ -22,6 +22,7 @@ allowed-tools:
   - 'Bash(${CURSOR_PLUGIN_ROOT}/skills/orchestrate/scripts/*.sh:*)'
   - 'Bash(${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/setup-worktree.sh:*)'
   - 'Bash(${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/list-worktrees.sh:*)'
+  - 'Bash(${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh:*)'
 ---
 
 # Multi-Agent Orchestration Skill
@@ -249,9 +250,17 @@ The decision follows a strict precedence order:
 
 `--worktree` is accepted as a silent no-op and matches the new default; it has no additional effect. Note: this skill does not auto-detect `## Worktree Setup` annotations from a plan (it creates its own decomposition), so the only opt-out is `--no-worktree`.
 
-Skip this phase entirely when `WORKTREE_MODE=false`.
+### When `WORKTREE_MODE=false` (`--no-worktree`)
 
-When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`:
+Skip parent worktree setup, but **always prepare the feature branch** before any agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
+
+```bash
+FEATURE_BRANCH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+```
+
+The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+
+### When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`
 
 Determine the repository name from the current directory (`basename $(git rev-parse --show-toplevel)`). Use the `FEATURE_SLUG` derived during flag parsing.
 

--- a/.cursor-plugin/skills/plan/SKILL.md
+++ b/.cursor-plugin/skills/plan/SKILL.md
@@ -20,6 +20,7 @@ allowed-tools:
   - Bash(cat:*)
   - Bash(test:*)
   - Bash(git:*)
+  - 'Bash(${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh:*)'
 ---
 
 # Plan Skill
@@ -568,7 +569,18 @@ If the plan was produced with `--parallel` (has a `Batches` section and `Depends
 
 **Option 1 — In-conversation parallel execution (lightweight)**
 
-Process batches sequentially. Within each batch, dispatch one `implementor` agent per step in a SINGLE message with MULTIPLE `Agent` tool calls. Between batches, run the project's type-check and unit-test commands. On failure, stop and ask the user how to proceed.
+Before dispatching any `implementor` agents, prepare the feature branch so agents do not commit on `main`:
+
+- **`WORKTREE_MODE=true` (default)** — the plan already names the parent worktree at `~/.claude-worktrees/<repo>-<feature>/` (branch `feat/<feature>`). Run `setup-worktree.sh parent <repo> <feature>` once, then dispatch agents with `Working directory: <parent path>`.
+- **`WORKTREE_MODE=false` (`--no-worktree`)** — derive `FEATURE_SLUG` from the user's request using the same sanitization as Path B §B.1 (lowercase, non-`[a-z0-9-]` → `-`, collapse runs, truncate to 20 chars, fallback `untitled`), then run:
+
+  ```bash
+  FEATURE_BRANCH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+  ```
+
+  The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). **Do not skip this step** — it is what prevents implementor agents from committing to `main`.
+
+Then process batches sequentially. Within each batch, dispatch one `implementor` agent per step in a SINGLE message with MULTIPLE `Agent` tool calls. Between batches, run the project's type-check and unit-test commands. On failure, stop and ask the user how to proceed.
 
 This keeps everything in the current conversation — no file artifact needed.
 

--- a/.cursor-plugin/skills/prp-implement/SKILL.md
+++ b/.cursor-plugin/skills/prp-implement/SKILL.md
@@ -229,7 +229,7 @@ When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so 
 After the branch decision, create the parent worktree **once** before the first batch:
 
 ```bash
-WT_PARENT_PATH=$(bash "${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/setup-worktree.sh" \
+WT_PARENT_PATH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/setup-worktree.sh \
   parent "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}")
 ```
 
@@ -240,7 +240,7 @@ This creates `~/.claude-worktrees/${WT_REPO_NAME}-${WT_FEATURE_SLUG}/` on branch
 Plan artifacts written by `prp-plan` are pre-commit and live in the **main checkout** when this skill starts. The first thing to do after the worktree exists is **move** them in — never copy, never sync:
 
 ```bash
-PLAN_PATH=$(bash "${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/move-plan-to-worktree.sh" \
+PLAN_PATH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/move-plan-to-worktree.sh \
   "$ARGUMENTS" "$WT_PARENT_PATH")
 ```
 
@@ -658,7 +658,7 @@ mv "$PLAN_PATH" "$(dirname -- "$PLAN_PATH")/completed/"
 After archiving the plan, run:
 
 ```bash
-bash "${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/list-worktrees.sh" \
+bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/list-worktrees.sh \
   "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}"
 ```
 

--- a/.cursor-plugin/skills/prp-implement/SKILL.md
+++ b/.cursor-plugin/skills/prp-implement/SKILL.md
@@ -203,22 +203,11 @@ git status --porcelain
 Run the shared branch-prep helper **before any agent dispatch** so implementor agents inherit the right branch instead of `main`:
 
 ```bash
-FEATURE_BRANCH=$(bash "${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh" \
+FEATURE_BRANCH=$(bash ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh \
   "${WT_FEATURE_SLUG}")
 ```
 
-The script enforces the matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`.
-
-| Current State                                                  | Helper Behavior                                                                            |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| On `feat/<slug>`                                               | Idempotent no-op; echoes branch and exits 0                                                |
-| On main/master/trunk, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                                  |
-| On main/master/trunk, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                               |
-| On another feature branch                                      | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user     |
-| On main with unrelated dirty files                             | Exits 1 — stop and ask user to stash or commit first                                       |
-| In a git worktree for this feature                             | Use the worktree (see `WORKTREE_ACTIVE` logic below); the helper still resolves the branch |
-
-If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+The script exits non-zero on failure and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`. See `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/branch-prep.md` for the helper's behavior and exit-code contract.
 
 When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so `feat/<slug>` exists locally), then run the worktree setup step below — `setup-worktree.sh parent` will adopt the existing branch.
 

--- a/.cursor-plugin/skills/prp-implement/SKILL.md
+++ b/.cursor-plugin/skills/prp-implement/SKILL.md
@@ -37,6 +37,7 @@ allowed-tools:
   - Bash(go:*)
   - Bash(make:*)
   - Bash(curl:*)
+  - 'Bash(${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/*.sh:*)'
 ---
 
 # PRP Implement
@@ -199,14 +200,27 @@ git status --porcelain
 
 ### Branch Decision
 
-| Current State                      | Action                                                    |
-| ---------------------------------- | --------------------------------------------------------- |
-| On feature branch                  | Use current branch                                        |
-| On main, clean working tree        | Create feature branch: `git checkout -b feat/{plan-name}` |
-| On main, dirty working tree        | **STOP** — Ask user to stash or commit first              |
-| In a git worktree for this feature | Use the worktree (see WORKTREE_ACTIVE logic below)        |
+Run the shared branch-prep helper **before any agent dispatch** so implementor agents inherit the right branch instead of `main`:
 
-When `WORKTREE_ACTIVE=true`, the branch decision above applies to the **main repo** (from which the parent worktree branches). After resolving the branch, also run the worktree setup step below.
+```bash
+FEATURE_BRANCH=$(bash "${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh" \
+  "${WT_FEATURE_SLUG}")
+```
+
+The script enforces the matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`.
+
+| Current State                                                  | Helper Behavior                                                                            |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| On `feat/<slug>`                                               | Idempotent no-op; echoes branch and exits 0                                                |
+| On main/master/trunk, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                                  |
+| On main/master/trunk, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                               |
+| On another feature branch                                      | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user     |
+| On main with unrelated dirty files                             | Exits 1 — stop and ask user to stash or commit first                                       |
+| In a git worktree for this feature                             | Use the worktree (see `WORKTREE_ACTIVE` logic below); the helper still resolves the branch |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+
+When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so `feat/<slug>` exists locally), then run the worktree setup step below — `setup-worktree.sh parent` will adopt the existing branch.
 
 ### Parent Worktree Setup (when `WORKTREE_ACTIVE=true`)
 

--- a/.opencode-plugin/shared/references/branch-prep.md
+++ b/.opencode-plugin/shared/references/branch-prep.md
@@ -1,0 +1,21 @@
+# Branch Prep Helper Contract
+
+Use `prepare-feature-branch.sh` before any worktree setup or implementor-agent dispatch, except in dry-run or plan-only paths that do not touch git. Worktree setup adopts the prepared `feat/<slug>` branch when it exists.
+
+```bash
+FEATURE_BRANCH=$(bash ~/.config/opencode/shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+```
+
+The helper echoes the prepared branch name on success.
+
+| Current State                                                                  | Helper Behavior                                                                       |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| On `feat/<slug>`                                                               | Idempotent no-op; echoes branch and exits 0                                           |
+| On `main`/`master`/`trunk`/`develop`, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                             |
+| On `main`/`master`/`trunk`/`develop`, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                          |
+| On another feature branch                                                      | Exits 2; re-run with `--allow-existing-feature-branch` after confirming with the user |
+| On trunk with unrelated dirty files                                            | Exits 1; stop and ask the user to stash or commit first                               |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation.
+
+If it exits 1, stop and have the user clean the tree before dispatching agents.

--- a/.opencode-plugin/shared/scripts/prepare-feature-branch.sh
+++ b/.opencode-plugin/shared/scripts/prepare-feature-branch.sh
@@ -7,12 +7,13 @@
 #
 # Behavior:
 #   - Rejects an unrelated dirty checkout (only plan-artifact paths allowed:
-#     docs/plans/<slug>/*, docs/prps/plans/<slug>*, docs/prps/specs/<slug>*).
+#     docs/plans/<slug>/*, docs/orchestration/<slug>*,
+#     docs/prps/{plans,specs,prds}/<slug>*).
 #   - On feat/<slug>: idempotent no-op.
-#   - On trunk (main/master) and feat/<slug> exists: switch to it.
+#   - On trunk (main/master/trunk/develop) and feat/<slug> exists: switch to it.
 #   - On trunk and feat/<slug> missing: create it.
-#   - On another feature branch + --allow-existing-feature-branch: keep it.
-#   - On another feature branch without the flag: exit 2 (caller asks user).
+#   - On another non-trunk branch + --allow-existing-feature-branch: keep it.
+#   - On another non-trunk branch without the flag: exit 2 (caller asks user).
 #
 # Mirrors setup-worktree.sh stdout/stderr discipline:
 #   - Branch name on stdout (one line).
@@ -21,7 +22,7 @@
 # Exit codes:
 #   0  branch is prepared (name on stdout)
 #   1  hard failure (dirty unrelated tree, git error, missing slug, ...)
-#   2  on a different feature branch and --allow-existing-feature-branch not set
+#   2  on a different non-trunk branch and --allow-existing-feature-branch not set
 
 set -euo pipefail
 
@@ -36,8 +37,7 @@ Usage:
 
 Arguments:
   feature-slug                       Kebab-case feature identifier (e.g. "add-widget")
-  --allow-existing-feature-branch    Reuse the current branch if it already starts
-                                     with feat/ and differs from feat/<feature-slug>
+  --allow-existing-feature-branch    Reuse the current non-trunk branch
 EOF
 }
 
@@ -56,6 +56,16 @@ _info() {
 FEATURE_SLUG=""
 ALLOW_EXISTING_FEATURE_BRANCH=false
 
+set_feature_slug() {
+  if [[ -z "$FEATURE_SLUG" ]]; then
+    FEATURE_SLUG="$1"
+  else
+    _error "unexpected positional argument: $1"
+    usage
+    exit 1
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --allow-existing-feature-branch)
@@ -68,6 +78,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --)
       shift
+      while [[ $# -gt 0 ]]; do
+        set_feature_slug "$1"
+        shift
+      done
       break
       ;;
     -*)
@@ -76,13 +90,7 @@ while [[ $# -gt 0 ]]; do
       exit 1
       ;;
     *)
-      if [[ -z "$FEATURE_SLUG" ]]; then
-        FEATURE_SLUG="$1"
-      else
-        _error "unexpected positional argument: $1"
-        usage
-        exit 1
-      fi
+      set_feature_slug "$1"
       shift
       ;;
   esac
@@ -90,6 +98,12 @@ done
 
 if [[ -z "$FEATURE_SLUG" ]]; then
   _error "feature-slug is required"
+  usage
+  exit 1
+fi
+
+if [[ ! "$FEATURE_SLUG" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+  _error "feature-slug must be kebab-case matching [a-z0-9][a-z0-9-]*"
   usage
   exit 1
 fi
@@ -111,6 +125,12 @@ fi
 
 FEATURE_BRANCH="feat/${FEATURE_SLUG}"
 
+if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
+  _info "already on ${FEATURE_BRANCH}"
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
 # ---------------------------------------------------------------------------
 # Dirty-tree guard
 # ---------------------------------------------------------------------------
@@ -121,6 +141,7 @@ is_plan_artifact() {
   local path="$1"
   case "$path" in
     docs/plans/"${FEATURE_SLUG}"/*) return 0 ;;
+    docs/orchestration/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/plans/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/specs/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/prds/"${FEATURE_SLUG}"*) return 0 ;;
@@ -160,6 +181,10 @@ branch_exists() {
   git show-ref --verify --quiet "refs/heads/$1"
 }
 
+remote_branch_exists() {
+  git show-ref --verify --quiet "refs/remotes/origin/$1"
+}
+
 is_trunk_branch() {
   case "$1" in
     main|master|trunk|develop) return 0 ;;
@@ -167,16 +192,16 @@ is_trunk_branch() {
   esac
 }
 
-if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
-  _info "already on ${FEATURE_BRANCH}"
-  echo "$FEATURE_BRANCH"
-  exit 0
-fi
-
 if is_trunk_branch "$CURRENT_BRANCH"; then
   if branch_exists "$FEATURE_BRANCH"; then
     _info "switching from ${CURRENT_BRANCH} to existing ${FEATURE_BRANCH}"
     git checkout "$FEATURE_BRANCH" >&2
+    if ! git merge-base --is-ancestor "$CURRENT_BRANCH" "$FEATURE_BRANCH"; then
+      _info "warning: ${FEATURE_BRANCH} is not based on current ${CURRENT_BRANCH}; consider rebasing before dispatch"
+    fi
+  elif remote_branch_exists "$FEATURE_BRANCH"; then
+    _info "switching from ${CURRENT_BRANCH} to existing origin/${FEATURE_BRANCH}"
+    git checkout --track "origin/${FEATURE_BRANCH}" >&2
   else
     _info "creating ${FEATURE_BRANCH} from ${CURRENT_BRANCH}"
     git checkout -b "$FEATURE_BRANCH" >&2

--- a/.opencode-plugin/shared/scripts/prepare-feature-branch.sh
+++ b/.opencode-plugin/shared/scripts/prepare-feature-branch.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# prepare-feature-branch.sh — ensure the current checkout is on the feature
+# branch before dispatching implementor agents in --no-worktree mode.
+#
+# Usage:
+#   prepare-feature-branch.sh <feature-slug> [--allow-existing-feature-branch]
+#
+# Behavior:
+#   - Rejects an unrelated dirty checkout (only plan-artifact paths allowed:
+#     docs/plans/<slug>/*, docs/prps/plans/<slug>*, docs/prps/specs/<slug>*).
+#   - On feat/<slug>: idempotent no-op.
+#   - On trunk (main/master) and feat/<slug> exists: switch to it.
+#   - On trunk and feat/<slug> missing: create it.
+#   - On another feature branch + --allow-existing-feature-branch: keep it.
+#   - On another feature branch without the flag: exit 2 (caller asks user).
+#
+# Mirrors setup-worktree.sh stdout/stderr discipline:
+#   - Branch name on stdout (one line).
+#   - All git output and status messages on stderr.
+#
+# Exit codes:
+#   0  branch is prepared (name on stdout)
+#   1  hard failure (dirty unrelated tree, git error, missing slug, ...)
+#   2  on a different feature branch and --allow-existing-feature-branch not set
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  prepare-feature-branch.sh <feature-slug> [--allow-existing-feature-branch]
+
+Arguments:
+  feature-slug                       Kebab-case feature identifier (e.g. "add-widget")
+  --allow-existing-feature-branch    Reuse the current branch if it already starts
+                                     with feat/ and differs from feat/<feature-slug>
+EOF
+}
+
+_error() {
+  echo "prepare-feature-branch.sh: error: $*" >&2
+}
+
+_info() {
+  echo "prepare-feature-branch.sh: $*" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+FEATURE_SLUG=""
+ALLOW_EXISTING_FEATURE_BRANCH=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-existing-feature-branch)
+      ALLOW_EXISTING_FEATURE_BRANCH=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -z "$FEATURE_SLUG" ]]; then
+        FEATURE_SLUG="$1"
+      else
+        _error "unexpected positional argument: $1"
+        usage
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$FEATURE_SLUG" ]]; then
+  _error "feature-slug is required"
+  usage
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Git context
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository"
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ -z "$CURRENT_BRANCH" ]]; then
+  _error "detached HEAD is not supported; check out a branch first"
+  exit 1
+fi
+
+FEATURE_BRANCH="feat/${FEATURE_SLUG}"
+
+# ---------------------------------------------------------------------------
+# Dirty-tree guard
+# ---------------------------------------------------------------------------
+#
+# Allow plan-artifact paths; reject anything else.
+
+is_plan_artifact() {
+  local path="$1"
+  case "$path" in
+    docs/plans/"${FEATURE_SLUG}"/*) return 0 ;;
+    docs/prps/plans/"${FEATURE_SLUG}"*) return 0 ;;
+    docs/prps/specs/"${FEATURE_SLUG}"*) return 0 ;;
+    docs/prps/prds/"${FEATURE_SLUG}"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+UNRELATED_DIRTY=()
+collect_dirty() {
+  # Untracked files (file-level — avoids `?? dir/` collapsed entries from
+  # `git status --porcelain` and `--untracked-files=all`'s memory cost).
+  git ls-files --others --exclude-standard
+  # Modified-but-unstaged tracked files.
+  git diff --name-only
+  # Staged tracked files (added/modified/renamed/deleted).
+  git diff --name-only --cached
+}
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  if ! is_plan_artifact "$path"; then
+    UNRELATED_DIRTY+=("$path")
+  fi
+done < <(collect_dirty | sort -u)
+
+if (( ${#UNRELATED_DIRTY[@]} > 0 )); then
+  _error "working tree has unrelated changes; stash or commit them first:"
+  printf '  %s\n' "${UNRELATED_DIRTY[@]}" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Branch state machine
+# ---------------------------------------------------------------------------
+
+branch_exists() {
+  git show-ref --verify --quiet "refs/heads/$1"
+}
+
+is_trunk_branch() {
+  case "$1" in
+    main|master|trunk|develop) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
+  _info "already on ${FEATURE_BRANCH}"
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
+if is_trunk_branch "$CURRENT_BRANCH"; then
+  if branch_exists "$FEATURE_BRANCH"; then
+    _info "switching from ${CURRENT_BRANCH} to existing ${FEATURE_BRANCH}"
+    git checkout "$FEATURE_BRANCH" >&2
+  else
+    _info "creating ${FEATURE_BRANCH} from ${CURRENT_BRANCH}"
+    git checkout -b "$FEATURE_BRANCH" >&2
+  fi
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
+# Some other branch — already a non-trunk branch, not feat/<slug>.
+if [[ "$ALLOW_EXISTING_FEATURE_BRANCH" == true ]]; then
+  _info "using current branch ${CURRENT_BRANCH} (--allow-existing-feature-branch)"
+  echo "$CURRENT_BRANCH"
+  exit 0
+fi
+
+_error "on branch '${CURRENT_BRANCH}', expected '${FEATURE_BRANCH}' or a trunk branch"
+_error "pass --allow-existing-feature-branch to reuse the current branch, or check out a trunk branch first"
+exit 2

--- a/.opencode-plugin/skills/implement-plan/SKILL.md
+++ b/.opencode-plugin/skills/implement-plan/SKILL.md
@@ -237,15 +237,23 @@ Store the echoed path as `WT_PARENT_PATH` (overrides any deduced value).
 All agents in every batch — parallel and sequential — operate directly in this
 single feature worktree. No child worktrees are created.
 
-When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout:
+When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout. Run the shared helper **before dispatching any implementor agents** — without this step, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
 
-| Current State                                                                | Action                                                      |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| On `FEATURE_BRANCH`                                                          | Use current branch                                          |
-| On another feature branch                                                    | Use current branch only if the user confirms it is intended |
-| On main, clean/plan-only dirty checkout, and `FEATURE_BRANCH` exists         | Switch to it: `git checkout "${FEATURE_BRANCH}"`            |
-| On main, clean/plan-only dirty checkout, and `FEATURE_BRANCH` does not exist | Create it: `git checkout -b "${FEATURE_BRANCH}"`            |
-| On main with unrelated dirty files                                           | **STOP** — ask user to stash or commit first                |
+```bash
+FEATURE_BRANCH=$(bash ~/.config/opencode/shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
+```
+
+The script enforces the branch-decision matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main` (GitHub #TBD).
+
+| Current State                                                            | Helper Behavior                                                                        |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| On `FEATURE_BRANCH`                                                      | Idempotent no-op; echoes `feat/<slug>` and exits 0                                     |
+| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` exists  | `git checkout feat/<slug>`; echoes branch                                              |
+| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` missing | `git checkout -b feat/<slug>`; echoes branch                                           |
+| On another feature branch                                                | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user |
+| On main with unrelated dirty files                                       | Exits 1 — ask user to stash or commit first                                            |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
 
 After this branch step, all agents in every batch operate in the current checkout. Include `Working directory: ${REPO_ROOT}` in each prompt when `--no-worktree` is active so dispatched agents target the prepared branch consistently.
 

--- a/.opencode-plugin/skills/implement-plan/SKILL.md
+++ b/.opencode-plugin/skills/implement-plan/SKILL.md
@@ -223,7 +223,13 @@ Before creating a worktree or branch, inspect `GIT_STATUS`.
 
 ### Step 6.6: Prepare the execution tree
 
-When `WORKTREE_ACTIVE=true`, create the parent worktree **once** before Batch 1. The worktree owns `FEATURE_BRANCH`; do not check out that branch in the main checkout:
+Prepare the feature branch directly in the current checkout **before** any worktree setup or implementor-agent dispatch. The helper exits non-zero on failure and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`. See `~/.config/opencode/shared/references/branch-prep.md` for the helper's behavior and exit-code contract.
+
+```bash
+FEATURE_BRANCH=$(bash ~/.config/opencode/shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
+```
+
+When `WORKTREE_ACTIVE=true`, create the parent worktree **once** before Batch 1. The worktree adopts the prepared `FEATURE_BRANCH`:
 
 ```bash
 WT_PARENT_PATH=$(bash ~/.config/opencode/shared/scripts/setup-worktree.sh parent "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}")
@@ -237,23 +243,7 @@ Store the echoed path as `WT_PARENT_PATH` (overrides any deduced value).
 All agents in every batch — parallel and sequential — operate directly in this
 single feature worktree. No child worktrees are created.
 
-When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout. Run the shared helper **before dispatching any implementor agents** — without this step, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
-
-```bash
-FEATURE_BRANCH=$(bash ~/.config/opencode/shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
-```
-
-The script enforces the branch-decision matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main` (GitHub #TBD).
-
-| Current State                                                            | Helper Behavior                                                                        |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| On `FEATURE_BRANCH`                                                      | Idempotent no-op; echoes `feat/<slug>` and exits 0                                     |
-| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` exists  | `git checkout feat/<slug>`; echoes branch                                              |
-| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` missing | `git checkout -b feat/<slug>`; echoes branch                                           |
-| On another feature branch                                                | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user |
-| On main with unrelated dirty files                                       | Exits 1 — ask user to stash or commit first                                            |
-
-If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup.
 
 After this branch step, all agents in every batch operate in the current checkout. Include `Working directory: ${REPO_ROOT}` in each prompt when `--no-worktree` is active so dispatched agents target the prepared branch consistently.
 

--- a/.opencode-plugin/skills/orchestrate/SKILL.md
+++ b/.opencode-plugin/skills/orchestrate/SKILL.md
@@ -234,9 +234,17 @@ The decision follows a strict precedence order:
 
 `--worktree` is accepted as a silent no-op and matches the new default; it has no additional effect. Note: this skill does not auto-detect `## Worktree Setup` annotations from a plan (it creates its own decomposition), so the only opt-out is `--no-worktree`.
 
-Skip this phase entirely when `WORKTREE_MODE=false`.
+### When `WORKTREE_MODE=false` (`--no-worktree`)
 
-When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`:
+Skip parent worktree setup, but **always prepare the feature branch** before any agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
+
+```bash
+FEATURE_BRANCH=$(bash ~/.config/opencode/shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+```
+
+The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+
+### When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`
 
 Determine the repository name from the current directory (`basename $(git rev-parse --show-toplevel)`). Use the `FEATURE_SLUG` derived during flag parsing.
 

--- a/.opencode-plugin/skills/orchestrate/SKILL.md
+++ b/.opencode-plugin/skills/orchestrate/SKILL.md
@@ -34,7 +34,7 @@ Parse flags first, then treat the remainder as the task description:
 
 Strip flags from `$ARGUMENTS` and set `TEAM_FLAG=true|false`, `DRY_RUN=true|false`, `PLAN_ONLY=true|false`, `SEQUENTIAL=true|false`, `WORKTREE_MODE=true|false`. Join the remaining non-flag tokens into `TASK_DESCRIPTION`.
 
-**Feature slug derivation** (used when `WORKTREE_MODE=true`): sanitize `TASK_DESCRIPTION` to produce `FEATURE_SLUG` — lowercase, replace `[^a-z0-9-]` with `-`, collapse runs of `-`, trim leading/trailing `-`, truncate to 20 characters. Fall back to `untitled` if empty. This is the same sanitization used for team-name context in `agent-team-dispatch.md` §1.
+**Feature slug derivation**: after `TASK_DESCRIPTION` is set, always sanitize it to produce `FEATURE_SLUG` before any `WORKTREE_MODE` branching — lowercase, replace `[^a-z0-9-]` with `-`, collapse runs of `-`, trim leading/trailing `-`, truncate to 20 characters. Fall back to `untitled` if empty. This is the same sanitization used for team-name context in `agent-team-dispatch.md` §1.
 
 If no task description is provided after stripping flags, abort with usage instructions:
 

--- a/.opencode-plugin/skills/orchestrate/SKILL.md
+++ b/.opencode-plugin/skills/orchestrate/SKILL.md
@@ -234,15 +234,17 @@ The decision follows a strict precedence order:
 
 `--worktree` is accepted as a silent no-op and matches the new default; it has no additional effect. Note: this skill does not auto-detect `## Worktree Setup` annotations from a plan (it creates its own decomposition), so the only opt-out is `--no-worktree`.
 
-### When `WORKTREE_MODE=false` (`--no-worktree`)
+### Branch Preparation
 
-Skip parent worktree setup, but **always prepare the feature branch** before any agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
+When `DRY_RUN=false` and `PLAN_ONLY=false`, **always prepare the feature branch** before any worktree setup or agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
 
 ```bash
 FEATURE_BRANCH=$(bash ~/.config/opencode/shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
 ```
 
-The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+See `~/.config/opencode/shared/references/branch-prep.md` for the helper's behavior and exit-code contract. Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+
+When `WORKTREE_MODE=false` (`--no-worktree`), skip parent worktree setup after branch preparation.
 
 ### When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`
 

--- a/.opencode-plugin/skills/plan/SKILL.md
+++ b/.opencode-plugin/skills/plan/SKILL.md
@@ -559,7 +559,18 @@ If the plan was produced with `--parallel` (has a `Batches` section and `Depends
 
 **Option 1 — In-conversation parallel execution (lightweight)**
 
-Process batches sequentially. Within each batch, dispatch one `implementor` agent per step in a SINGLE message with MULTIPLE `Agent` tool calls. Between batches, run the project's type-check and unit-test commands. On failure, stop and ask the user how to proceed.
+Before dispatching any `implementor` agents, prepare the feature branch so agents do not commit on `main`:
+
+- **`WORKTREE_MODE=true` (default)** — the plan already names the parent worktree at `~/.claude-worktrees/<repo>-<feature>/` (branch `feat/<feature>`). Run `setup-worktree.sh parent <repo> <feature>` once, then dispatch agents with `Working directory: <parent path>`.
+- **`WORKTREE_MODE=false` (`--no-worktree`)** — derive `FEATURE_SLUG` from the user's request using the same sanitization as Path B §B.1 (lowercase, non-`[a-z0-9-]` → `-`, collapse runs, truncate to 20 chars, fallback `untitled`), then run:
+
+  ```bash
+  FEATURE_BRANCH=$(bash ~/.config/opencode/shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+  ```
+
+  The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). **Do not skip this step** — it is what prevents implementor agents from committing to `main`.
+
+Then process batches sequentially. Within each batch, dispatch one `implementor` agent per step in a SINGLE message with MULTIPLE `Agent` tool calls. Between batches, run the project's type-check and unit-test commands. On failure, stop and ask the user how to proceed.
 
 This keeps everything in the current conversation — no file artifact needed.
 

--- a/.opencode-plugin/skills/prp-implement/SKILL.md
+++ b/.opencode-plugin/skills/prp-implement/SKILL.md
@@ -177,22 +177,11 @@ git status --porcelain
 Run the shared branch-prep helper **before any agent dispatch** so implementor agents inherit the right branch instead of `main`:
 
 ```bash
-FEATURE_BRANCH=$(bash "~/.config/opencode/shared/scripts/prepare-feature-branch.sh" \
+FEATURE_BRANCH=$(bash ~/.config/opencode/shared/scripts/prepare-feature-branch.sh \
   "${WT_FEATURE_SLUG}")
 ```
 
-The script enforces the matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`.
-
-| Current State                                                  | Helper Behavior                                                                            |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| On `feat/<slug>`                                               | Idempotent no-op; echoes branch and exits 0                                                |
-| On main/master/trunk, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                                  |
-| On main/master/trunk, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                               |
-| On another feature branch                                      | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user     |
-| On main with unrelated dirty files                             | Exits 1 — stop and ask user to stash or commit first                                       |
-| In a git worktree for this feature                             | Use the worktree (see `WORKTREE_ACTIVE` logic below); the helper still resolves the branch |
-
-If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+The script exits non-zero on failure and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`. See `~/.config/opencode/shared/references/branch-prep.md` for the helper's behavior and exit-code contract.
 
 When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so `feat/<slug>` exists locally), then run the worktree setup step below — `setup-worktree.sh parent` will adopt the existing branch.
 

--- a/.opencode-plugin/skills/prp-implement/SKILL.md
+++ b/.opencode-plugin/skills/prp-implement/SKILL.md
@@ -174,14 +174,27 @@ git status --porcelain
 
 ### Branch Decision
 
-| Current State                      | Action                                                    |
-| ---------------------------------- | --------------------------------------------------------- |
-| On feature branch                  | Use current branch                                        |
-| On main, clean working tree        | Create feature branch: `git checkout -b feat/{plan-name}` |
-| On main, dirty working tree        | **STOP** — Ask user to stash or commit first              |
-| In a git worktree for this feature | Use the worktree (see WORKTREE_ACTIVE logic below)        |
+Run the shared branch-prep helper **before any agent dispatch** so implementor agents inherit the right branch instead of `main`:
 
-When `WORKTREE_ACTIVE=true`, the branch decision above applies to the **main repo** (from which the parent worktree branches). After resolving the branch, also run the worktree setup step below.
+```bash
+FEATURE_BRANCH=$(bash "~/.config/opencode/shared/scripts/prepare-feature-branch.sh" \
+  "${WT_FEATURE_SLUG}")
+```
+
+The script enforces the matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`.
+
+| Current State                                                  | Helper Behavior                                                                            |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| On `feat/<slug>`                                               | Idempotent no-op; echoes branch and exits 0                                                |
+| On main/master/trunk, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                                  |
+| On main/master/trunk, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                               |
+| On another feature branch                                      | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user     |
+| On main with unrelated dirty files                             | Exits 1 — stop and ask user to stash or commit first                                       |
+| In a git worktree for this feature                             | Use the worktree (see `WORKTREE_ACTIVE` logic below); the helper still resolves the branch |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+
+When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so `feat/<slug>` exists locally), then run the worktree setup step below — `setup-worktree.sh parent` will adopt the existing branch.
 
 ### Parent Worktree Setup (when `WORKTREE_ACTIVE=true`)
 

--- a/.opencode-plugin/skills/prp-implement/SKILL.md
+++ b/.opencode-plugin/skills/prp-implement/SKILL.md
@@ -203,7 +203,7 @@ When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so 
 After the branch decision, create the parent worktree **once** before the first batch:
 
 ```bash
-WT_PARENT_PATH=$(bash "~/.config/opencode/shared/scripts/setup-worktree.sh" \
+WT_PARENT_PATH=$(bash ~/.config/opencode/shared/scripts/setup-worktree.sh \
   parent "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}")
 ```
 
@@ -214,7 +214,7 @@ This creates `~/.claude-worktrees/${WT_REPO_NAME}-${WT_FEATURE_SLUG}/` on branch
 Plan artifacts written by `prp-plan` are pre-commit and live in the **main checkout** when this skill starts. The first thing to do after the worktree exists is **move** them in — never copy, never sync:
 
 ```bash
-PLAN_PATH=$(bash "~/.config/opencode/shared/scripts/move-plan-to-worktree.sh" \
+PLAN_PATH=$(bash ~/.config/opencode/shared/scripts/move-plan-to-worktree.sh \
   "$ARGUMENTS" "$WT_PARENT_PATH")
 ```
 
@@ -632,7 +632,7 @@ mv "$PLAN_PATH" "$(dirname -- "$PLAN_PATH")/completed/"
 After archiving the plan, run:
 
 ```bash
-bash "~/.config/opencode/shared/scripts/list-worktrees.sh" \
+bash ~/.config/opencode/shared/scripts/list-worktrees.sh \
   "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}"
 ```
 

--- a/docs/prps/reviews/fixes/pr-91-fixes.md
+++ b/docs/prps/reviews/fixes/pr-91-fixes.md
@@ -1,0 +1,67 @@
+# Fix Report: pr-91-review
+
+**Source**: docs/prps/reviews/pr-91-review.md
+**Applied**: 2026-05-06T00:43:38Z
+**Mode**: Parallel sub-agents (1 batch, max width 2)
+**Severity threshold**: MEDIUM
+
+## Summary
+
+- **Total findings in source**: 17
+- **Already processed before this run**:
+  - Fixed: 0
+  - Failed: 0
+- **Eligible this run**: 13
+- **Applied this run**:
+  - Fixed: 13
+  - Failed: 0
+- **Skipped this run**:
+  - Below severity threshold: 4
+  - No suggested fix: 0
+  - Missing file: 0
+
+## Fixes Applied
+
+| ID   | Severity | File                                                                                                   | Line    | Status | Notes                                      |
+| ---- | -------- | ------------------------------------------------------------------------------------------------------ | ------- | ------ | ------------------------------------------ |
+| F001 | HIGH     | ycc/skills/\_shared/scripts/prepare-feature-branch.sh                                                  | 131-185 | Fixed  | Idempotent branch check moved earlier.     |
+| F002 | HIGH     | ycc/skills/prp-implement/SKILL.md                                                                      | 206     | Fixed  | Removed quoted helper path.                |
+| F003 | MEDIUM   | ycc/skills/\_shared/scripts/prepare-feature-branch.sh                                                  | 8-13    | Fixed  | Header behavior now matches code.          |
+| F004 | MEDIUM   | ycc/skills/\_shared/scripts/prepare-feature-branch.sh                                                  | 38-40   | Fixed  | Usage text documents non-trunk reuse.      |
+| F005 | MEDIUM   | ycc/skills/\_shared/scripts/prepare-feature-branch.sh                                                  | 69-71   | Fixed  | `--` now preserves positional args.        |
+| F006 | MEDIUM   | ycc/skills/\_shared/scripts/prepare-feature-branch.sh                                                  | 91      | Fixed  | Added slug format guard.                   |
+| F007 | MEDIUM   | ycc/skills/\_shared/scripts/prepare-feature-branch.sh                                                  | 120-128 | Fixed  | Allows `docs/orchestration/<slug>*`.       |
+| F008 | MEDIUM   | ycc/skills/\_shared/scripts/prepare-feature-branch.sh                                                  | 159-185 | Fixed  | Tracks existing `origin/feat/<slug>`.      |
+| F009 | MEDIUM   | ycc/skills/\_shared/scripts/prepare-feature-branch.sh                                                  | 176-185 | Fixed  | Warns when local feature branch is stale.  |
+| F010 | MEDIUM   | ycc/skills/implement-plan/SKILL.md                                                                     | 259-263 | Fixed  | Uses unconditional branch prep convention. |
+| F011 | MEDIUM   | ycc/skills/implement-plan/SKILL.md                                                                     | 265     | Fixed  | Removed `GitHub #TBD`.                     |
+| F012 | MEDIUM   | ycc/skills/implement-plan/SKILL.md, ycc/skills/prp-implement/SKILL.md, ycc/skills/orchestrate/SKILL.md | 267-274 | Fixed  | Extracted shared branch-prep reference.    |
+| F013 | MEDIUM   | ycc/skills/implement-plan/SKILL.md, ycc/skills/prp-implement/SKILL.md, ycc/skills/orchestrate/SKILL.md | 271     | Fixed  | Shared reference includes `develop`.       |
+
+## Files Changed
+
+- `ycc/skills/_shared/scripts/prepare-feature-branch.sh` (F001, F003-F009)
+- `ycc/skills/_shared/references/branch-prep.md` (F010, F012, F013)
+- `ycc/skills/implement-plan/SKILL.md` (F010-F013)
+- `ycc/skills/orchestrate/SKILL.md` (F012, F013)
+- `ycc/skills/prp-implement/SKILL.md` (F002, F012, F013)
+- Generated Cursor, Codex, and opencode mirrors from `./scripts/sync.sh`
+- `docs/prps/reviews/pr-91-review.md` (status updates)
+
+## Failed Fixes
+
+None.
+
+## Validation Results
+
+| Check                   | Result |
+| ----------------------- | ------ |
+| `./scripts/sync.sh`     | Pass   |
+| `./scripts/validate.sh` | Pass   |
+| `npm run lint`          | Pass   |
+
+## Next Steps
+
+- Re-run `$code-review 91` to verify the remaining open findings and confirm these fixes resolved the issues.
+- Address the remaining LOW findings if they are in scope for this PR.
+- Run `$git-workflow` to commit the changes when satisfied.

--- a/docs/prps/reviews/pr-91-review.md
+++ b/docs/prps/reviews/pr-91-review.md
@@ -1,0 +1,137 @@
+# PR Review #91 — fix(skills): wire prepare-feature-branch.sh into --no-worktree paths
+
+**Reviewed**: 2026-05-06
+**Mode**: PR (parallel, --no-worktree)
+**Author**: yandy-r
+**Branch**: `fix/no-worktree-branch-creation` → `main`
+**Decision**: REQUEST CHANGES
+
+## Summary
+
+The PR closes the right gap — narrative-only branch instructions in `--no-worktree` paths really did let implementor agents commit to `main`, and a small idempotent helper script is the right shape for the fix. Validation is fully green (`./scripts/validate.sh`, `npm run lint`, `shellcheck -x`, JSON, executable bits). Two HIGH issues block merge: (a) the new dispatch site in `prp-implement/SKILL.md` quotes the helper path, and the bundle generator's tilde rewrite produces literal `"~/..."` that bash will not expand — Codex and opencode users running `/ycc:prp-implement` will hit "no such file or directory"; (b) inside the helper itself the dirty-tree guard runs _before_ the idempotent on-feature-branch check, so a developer re-invoking the helper while WIP is staged on `feat/<slug>` exits 1 instead of the documented no-op. Several MEDIUM findings are documentation/contract drift between the docblock, usage text, SKILL.md tables, and the actual code (the `develop` trunk branch and `docs/prps/prds/` plan-artifact path are accepted by the script but missing from the prose; `--allow-existing-feature-branch` accepts any non-trunk branch despite usage saying "starts with `feat/`"; `docs/orchestration/<slug>.md` plans break the dirty-tree guard).
+
+## Findings
+
+### CRITICAL
+
+(none)
+
+### HIGH
+
+- **[F001]** `ycc/skills/_shared/scripts/prepare-feature-branch.sh:131-185` — Dirty-tree guard executes before the idempotent on-feature-branch check, so any invocation on `feat/<slug>` with non-plan-artifact WIP (e.g., `src/x.ts` modified) exits 1 instead of returning the no-op success path the docblock and SKILL.md tables advertise. The PR's manual test #3 covered the clean case only; the dirty re-invocation case (orchestrator re-running `/ycc:implement-plan` mid-batch after partial work) regresses the documented idempotent contract.
+  - **Status**: Fixed
+  - **Category**: Correctness
+  - **Suggested fix**: Move the `if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then echo "$FEATURE_BRANCH"; exit 0; fi` early-exit to immediately after `FEATURE_BRANCH` is computed (line 112), before `collect_dirty` runs. The dirty-tree guard is only meaningful when the script is about to switch or create a branch.
+
+- **[F002]** `ycc/skills/prp-implement/SKILL.md:206` — The new helper invocation is double-quoted: `bash "${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh"`. The Codex and opencode bundle generators rewrite `${CLAUDE_PLUGIN_ROOT}` to literal `~/.codex/plugins/ycc/shared` / `~/.config/opencode/shared` while preserving the surrounding double quotes. Bash does **not** tilde-expand inside double quotes (verified: `bash -c 'echo "~/foo"'` echoes literal `~/foo`), so `/ycc:prp-implement` will fail with "no such file or directory" in those bundles. The other 3 dispatch sites (`plan`, `implement-plan`, `orchestrate`) intentionally write the path **unquoted**, which keeps the tilde expansion intact post-rewrite.
+  - **Status**: Fixed
+  - **Category**: Correctness
+  - **Suggested fix**: Drop the surrounding double quotes in source: `FEATURE_BRANCH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")`. Then re-run `./scripts/sync.sh` to regenerate the cursor/codex/opencode mirrors. (Pre-existing identical bugs at lines 232, 243, 661 of the same file are out of scope for this PR but should be tracked separately — this PR adds _one_ new instance.)
+
+### MEDIUM
+
+- **[F003]** `ycc/skills/_shared/scripts/prepare-feature-branch.sh:8-13` — Header docblock lists allowed plan-artifact paths as `docs/plans/<slug>/*, docs/prps/plans/<slug>*, docs/prps/specs/<slug>*` and trunk as `(main/master)`, but `is_plan_artifact` (lines 123-128) also allows `docs/prps/prds/<slug>*` and `is_trunk_branch` (line 165) also accepts `trunk` and `develop`. Future maintainers reading the docblock will not match the code's actual behavior.
+  - **Status**: Fixed
+  - **Category**: Maintainability
+  - **Suggested fix**: Update the Behavior bullets to: "Allow plan-artifact paths (`docs/plans/<slug>/*`, `docs/prps/{plans,specs,prds}/<slug>*`)" and "On trunk (`main`/`master`/`trunk`/`develop`)" so the contract matches the code in one read.
+
+- **[F004]** `ycc/skills/_shared/scripts/prepare-feature-branch.sh:38-40` — `usage()` says `--allow-existing-feature-branch` "Reuse the current branch if it already starts with `feat/`", but line 189 returns `CURRENT_BRANCH` for any non-trunk branch — including `chore/x`, `hotfix/y`, `release/1.0`. The flag's actual semantics are broader than documented; a user reading `--help` will form the wrong mental model.
+  - **Status**: Fixed
+  - **Category**: Maintainability
+  - **Suggested fix**: Decide which is canonical. If broader is intended, change usage to "Reuse the current non-trunk branch" and rename the flag accordingly (`--allow-existing-branch`?). If narrower is intended, add a `[[ "$CURRENT_BRANCH" == feat/* ]]` guard before line 189 and exit 2 otherwise.
+
+- **[F005]** `ycc/skills/_shared/scripts/prepare-feature-branch.sh:69-71` — After the `--` separator's `break`, any positional argument that follows it (e.g., `prepare-feature-branch.sh -- my-slug`) is silently dropped: the loop exits, `FEATURE_SLUG` stays empty, and the script exits 1 with "feature-slug is required". The `--` convention typically implies "treat the rest as positional".
+  - **Status**: Fixed
+  - **Category**: Correctness
+  - **Suggested fix**: After `break`, process remaining `"$@"` as positional args (consume the first into `FEATURE_SLUG`, error on extras), or remove the `--` case arm entirely and document that `--` is not supported.
+
+- **[F006]** `ycc/skills/_shared/scripts/prepare-feature-branch.sh:91` — A whitespace-only or otherwise malformed slug passes the `[[ -z "$FEATURE_SLUG" ]]` guard and is composed directly into `feat/${FEATURE_SLUG}` and `git checkout -b`. The user gets an opaque git error rather than a script-controlled message. Not a security issue in this developer-tool trust model (variables are double-quoted; git rejects invalid refs), but a poor failure mode.
+  - **Status**: Fixed
+  - **Category**: Correctness
+  - **Suggested fix**: Add a format guard immediately after the empty check: `[[ "$FEATURE_SLUG" =~ ^[a-z0-9][a-z0-9-]*$ ]] || { _error "slug must be kebab-case [a-z0-9-]: '$FEATURE_SLUG'"; exit 1; }`.
+
+- **[F007]** `ycc/skills/_shared/scripts/prepare-feature-branch.sh:120-128` — `is_plan_artifact` allows `docs/plans/`, `docs/prps/{plans,specs,prds}/`, but **not** `docs/orchestration/<slug>.md` — which is exactly where `orchestrate --plan-only --no-worktree` writes its plan (`orchestrate/SKILL.md` line 45 and 362 confirm the path). A subsequent `orchestrate --no-worktree` re-invocation against the same task would be blocked by the dirty-tree guard with no recovery beyond stashing the plan the user just generated.
+  - **Status**: Fixed
+  - **Category**: Correctness
+  - **Suggested fix**: Add `docs/orchestration/"${FEATURE_SLUG}"*) return 0 ;;` to the `case` in `is_plan_artifact`, mirroring the other plan-artifact entries. Update the docblock per F003 in the same edit.
+
+- **[F008]** `ycc/skills/_shared/scripts/prepare-feature-branch.sh:159-185` — `branch_exists` only probes local refs (`refs/heads/$1`), not `refs/remotes/origin/$1`. If `feat/<slug>` exists on origin but was never fetched locally, the helper falls into the "create new branch from trunk" path and silently builds a divergent local history. Push later fails with non-fast-forward, so this is recoverable, but it surprises the user at push time and the agent has already done work on the wrong branch.
+  - **Status**: Fixed
+  - **Category**: Correctness
+  - **Suggested fix**: Extend `branch_exists` (or add a parallel `remote_branch_exists`) to also check `refs/remotes/origin/$1`. If only the remote ref exists, run `git checkout --track "origin/$1"` instead of `git checkout -b`. At minimum, emit a stderr warning when the remote ref exists and the local one does not. (No `git fetch` — keep network dependency out per the security reviewer's guidance.)
+
+- **[F009]** `ycc/skills/_shared/scripts/prepare-feature-branch.sh:176-185` — When `feat/<slug>` exists locally and is behind the trunk merge-base, the helper switches to it without warning. Implementor agents then commit on a stale base. Same recoverable-but-surprising failure mode as F008.
+  - **Status**: Fixed
+  - **Category**: Correctness
+  - **Suggested fix**: After `git checkout "$FEATURE_BRANCH"` succeeds, compare with trunk via `git merge-base --is-ancestor "$CURRENT_BRANCH" "$FEATURE_BRANCH"` and emit a stderr `_info` warning if behind, so the orchestrator can surface the staleness to the user before dispatching agents.
+
+- **[F010]** `ycc/skills/implement-plan/SKILL.md:259-263` — `implement-plan` gates the `prepare-feature-branch.sh` call on `WORKTREE_ACTIVE=false`, while `prp-implement/SKILL.md:201-223` calls it unconditionally (and then runs `setup-worktree.sh parent` for the worktree-on path). Both work — `setup-worktree.sh` uses `git worktree add -B "$branch" ... HEAD` which creates the branch when missing — but the inconsistency is confusing for future maintainers reading both skills.
+  - **Status**: Fixed
+  - **Category**: Pattern Compliance
+  - **Suggested fix**: Pick one convention and apply it to all four dispatch sites. Either (a) call `prepare-feature-branch.sh` unconditionally and let `setup-worktree.sh` adopt the existing branch (matches `prp-implement`), or (b) gate the helper on `WORKTREE_ACTIVE=false` and rely on `setup-worktree.sh -B` for the worktree path (matches `implement-plan`). Document the chosen convention in `_shared/scripts/prepare-feature-branch.sh` header.
+
+- **[F011]** `ycc/skills/implement-plan/SKILL.md:265` — Inline cross-reference reads `(GitHub #TBD)`. The PR description has the same placeholder (`Closes #<!-- issue number, fill in after filing -->`). A `#TBD` reference inside a canonical skill prompt will ship to every Claude/Cursor/Codex/opencode user.
+  - **Status**: Fixed
+  - **Category**: Maintainability
+  - **Suggested fix**: File the issue (the PR description implies one was planned) and replace `#TBD` with the real number, or remove the parenthetical entirely if the prose stands on its own without the cross-reference.
+
+- **[F012]** `ycc/skills/implement-plan/SKILL.md:267-274`, `ycc/skills/prp-implement/SKILL.md:211-219`, `ycc/skills/orchestrate/SKILL.md` — The branch-decision matrix is duplicated (with minor wording variation) across three SKILL.md files. The project already uses `_shared/references/agent-team-dispatch.md` for exactly this single-source-of-truth pattern. If `prepare-feature-branch.sh`'s exit codes or accepted states change, three docs must be updated in lockstep.
+  - **Status**: Fixed
+  - **Category**: Maintainability
+  - **Suggested fix**: Extract the matrix and the "exits 1 → stop / exits 2 → re-run with --allow-existing-feature-branch" guidance to `ycc/skills/_shared/references/branch-prep.md` (next to `agent-team-dispatch.md`). Replace the three inline copies with a single pointer: "See `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/branch-prep.md` for the helper's behavior and exit-code contract."
+
+- **[F013]** `ycc/skills/implement-plan/SKILL.md:271`, `ycc/skills/prp-implement/SKILL.md:215`, `ycc/skills/orchestrate/SKILL.md` — All four SKILL.md branch-decision tables enumerate trunk as `main/master/trunk` but the helper's `is_trunk_branch` also accepts `develop`. Orchestrators reading the tables won't know `develop` is a valid starting point.
+  - **Status**: Fixed
+  - **Category**: Maintainability
+  - **Suggested fix**: Add `develop` to the trunk row label in all SKILL.md tables (or, if F012 is taken, do this in the new `_shared/references/branch-prep.md` only). Pair with the F003 docblock fix.
+
+### LOW
+
+- **[F014]** `ycc/skills/_shared/scripts/prepare-feature-branch.sh:1-25` — Header comment scopes the script to `--no-worktree` mode ("ensure the current checkout is on the feature branch before dispatching implementor agents in --no-worktree mode"), but `prp-implement/SKILL.md:223` now invokes it in the worktree-on path too. The scope claim is stale.
+  - **Status**: Open
+  - **Category**: Maintainability
+  - **Suggested fix**: Update header to "ensure the current checkout is on the feature branch before dispatching implementor agents (both worktree and `--no-worktree` modes)".
+
+- **[F015]** `ycc/skills/plan/SKILL.md:572-580` — Slug-derivation rules ("lowercase, non-`[a-z0-9-]` → `-`, collapse runs, truncate to 20 chars, fallback `untitled`") are embedded in prose, requiring the LLM orchestrator to apply them in its head. Risk of inconsistent slugs across `plan` vs `parallel-plan` vs `implement-plan`.
+  - **Status**: Open
+  - **Category**: Maintainability
+  - **Suggested fix**: Add a deterministic `--slug-from "<raw text>"` mode to `prepare-feature-branch.sh` (or a sibling `derive-feature-slug.sh`) so all skills produce identical slugs via tool call instead of prose rule interpretation. Follow-up, not a blocker.
+
+- **[F016]** `ycc/skills/_shared/scripts/prepare-feature-branch.sh:48-50` — Defines `_info()` (writes to stderr without prefix) while sibling `_shared/scripts/move-plan-to-worktree.sh:65` uses `_debug()` for the same role. Setup-worktree.sh and list-worktrees.sh use neither helper. No project-wide convention exists yet, so this is a small drift.
+  - **Status**: Open
+  - **Category**: Pattern Compliance
+  - **Suggested fix**: Pick one name (`_info` reads more like a release-time message, `_debug` like noise; `_info` is probably the better choice since these messages are user-facing) and apply it across the helper family in a follow-up.
+
+- **[F017]** PR description test scenario #3 ("Already on `feat/foo` → idempotent no-op, exit 0") is documented as PASS, but the test was run against a clean tree only. The dirty variant (F001) was not exercised. The reviewer notes section claims test coverage that does not exist for the most common re-invocation case.
+  - **Status**: Open
+  - **Category**: Completeness
+  - **Suggested fix**: After applying F001's fix, add a test scenario "On `feat/foo` with WIP non-plan-artifact dirty file → exit 0 (idempotent no-op)". The PR description's test table can be updated in the same commit.
+
+## Validation Results
+
+| Check                                    | Result                                                          |
+| ---------------------------------------- | --------------------------------------------------------------- |
+| JSON (`marketplace.json`, `plugin.json`) | Pass                                                            |
+| Shell scripts executable                 | Pass (only 2 pre-existing library files are non-executable)     |
+| `./scripts/validate.sh`                  | Pass (cursor + codex + opencode sync, content policy, manifest) |
+| `npm run lint`                           | Pass (markdownlint, prettier, ruff, black, shellcheck)          |
+| `shellcheck -x` on new helper            | Pass (clean)                                                    |
+
+## Files Reviewed
+
+Source (5 files, the reviewable surface):
+
+- `ycc/skills/_shared/scripts/prepare-feature-branch.sh` (Added, 197 lines)
+- `ycc/skills/plan/SKILL.md` (Modified — Option 1 in-conversation parallel execution + frontmatter)
+- `ycc/skills/implement-plan/SKILL.md` (Modified — Step 6.6 branch prep)
+- `ycc/skills/orchestrate/SKILL.md` (Modified — Phase 2.5 worktree-mode-false branch + frontmatter)
+- `ycc/skills/prp-implement/SKILL.md` (Modified — Phase 2 Branch Decision rewrite + frontmatter)
+
+Generated bundle mirrors (15 files, spot-checked for parity):
+
+- `.codex-plugin/ycc/shared/scripts/prepare-feature-branch.sh` (Added — identical to source)
+- `.codex-plugin/ycc/skills/{plan,implement-plan,orchestrate,prp-implement}/SKILL.md` (Modified)
+- `.cursor-plugin/skills/_shared/scripts/prepare-feature-branch.sh` (Added — identical to source)
+- `.cursor-plugin/skills/{plan,implement-plan,orchestrate,prp-implement}/SKILL.md` (Modified)
+- `.opencode-plugin/shared/scripts/prepare-feature-branch.sh` (Added — identical to source)
+- `.opencode-plugin/skills/{plan,implement-plan,orchestrate,prp-implement}/SKILL.md` (Modified)

--- a/ycc/skills/_shared/references/branch-prep.md
+++ b/ycc/skills/_shared/references/branch-prep.md
@@ -1,0 +1,21 @@
+# Branch Prep Helper Contract
+
+Use `prepare-feature-branch.sh` before any worktree setup or implementor-agent dispatch, except in dry-run or plan-only paths that do not touch git. Worktree setup adopts the prepared `feat/<slug>` branch when it exists.
+
+```bash
+FEATURE_BRANCH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+```
+
+The helper echoes the prepared branch name on success.
+
+| Current State                                                                  | Helper Behavior                                                                       |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| On `feat/<slug>`                                                               | Idempotent no-op; echoes branch and exits 0                                           |
+| On `main`/`master`/`trunk`/`develop`, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                             |
+| On `main`/`master`/`trunk`/`develop`, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                          |
+| On another feature branch                                                      | Exits 2; re-run with `--allow-existing-feature-branch` after confirming with the user |
+| On trunk with unrelated dirty files                                            | Exits 1; stop and ask the user to stash or commit first                               |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation.
+
+If it exits 1, stop and have the user clean the tree before dispatching agents.

--- a/ycc/skills/_shared/scripts/prepare-feature-branch.sh
+++ b/ycc/skills/_shared/scripts/prepare-feature-branch.sh
@@ -7,12 +7,13 @@
 #
 # Behavior:
 #   - Rejects an unrelated dirty checkout (only plan-artifact paths allowed:
-#     docs/plans/<slug>/*, docs/prps/plans/<slug>*, docs/prps/specs/<slug>*).
+#     docs/plans/<slug>/*, docs/orchestration/<slug>*,
+#     docs/prps/{plans,specs,prds}/<slug>*).
 #   - On feat/<slug>: idempotent no-op.
-#   - On trunk (main/master) and feat/<slug> exists: switch to it.
+#   - On trunk (main/master/trunk/develop) and feat/<slug> exists: switch to it.
 #   - On trunk and feat/<slug> missing: create it.
-#   - On another feature branch + --allow-existing-feature-branch: keep it.
-#   - On another feature branch without the flag: exit 2 (caller asks user).
+#   - On another non-trunk branch + --allow-existing-feature-branch: keep it.
+#   - On another non-trunk branch without the flag: exit 2 (caller asks user).
 #
 # Mirrors setup-worktree.sh stdout/stderr discipline:
 #   - Branch name on stdout (one line).
@@ -21,7 +22,7 @@
 # Exit codes:
 #   0  branch is prepared (name on stdout)
 #   1  hard failure (dirty unrelated tree, git error, missing slug, ...)
-#   2  on a different feature branch and --allow-existing-feature-branch not set
+#   2  on a different non-trunk branch and --allow-existing-feature-branch not set
 
 set -euo pipefail
 
@@ -36,8 +37,7 @@ Usage:
 
 Arguments:
   feature-slug                       Kebab-case feature identifier (e.g. "add-widget")
-  --allow-existing-feature-branch    Reuse the current branch if it already starts
-                                     with feat/ and differs from feat/<feature-slug>
+  --allow-existing-feature-branch    Reuse the current non-trunk branch
 EOF
 }
 
@@ -56,6 +56,16 @@ _info() {
 FEATURE_SLUG=""
 ALLOW_EXISTING_FEATURE_BRANCH=false
 
+set_feature_slug() {
+  if [[ -z "$FEATURE_SLUG" ]]; then
+    FEATURE_SLUG="$1"
+  else
+    _error "unexpected positional argument: $1"
+    usage
+    exit 1
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --allow-existing-feature-branch)
@@ -68,6 +78,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --)
       shift
+      while [[ $# -gt 0 ]]; do
+        set_feature_slug "$1"
+        shift
+      done
       break
       ;;
     -*)
@@ -76,13 +90,7 @@ while [[ $# -gt 0 ]]; do
       exit 1
       ;;
     *)
-      if [[ -z "$FEATURE_SLUG" ]]; then
-        FEATURE_SLUG="$1"
-      else
-        _error "unexpected positional argument: $1"
-        usage
-        exit 1
-      fi
+      set_feature_slug "$1"
       shift
       ;;
   esac
@@ -90,6 +98,12 @@ done
 
 if [[ -z "$FEATURE_SLUG" ]]; then
   _error "feature-slug is required"
+  usage
+  exit 1
+fi
+
+if [[ ! "$FEATURE_SLUG" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+  _error "feature-slug must be kebab-case matching [a-z0-9][a-z0-9-]*"
   usage
   exit 1
 fi
@@ -111,6 +125,12 @@ fi
 
 FEATURE_BRANCH="feat/${FEATURE_SLUG}"
 
+if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
+  _info "already on ${FEATURE_BRANCH}"
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
 # ---------------------------------------------------------------------------
 # Dirty-tree guard
 # ---------------------------------------------------------------------------
@@ -121,6 +141,7 @@ is_plan_artifact() {
   local path="$1"
   case "$path" in
     docs/plans/"${FEATURE_SLUG}"/*) return 0 ;;
+    docs/orchestration/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/plans/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/specs/"${FEATURE_SLUG}"*) return 0 ;;
     docs/prps/prds/"${FEATURE_SLUG}"*) return 0 ;;
@@ -160,6 +181,10 @@ branch_exists() {
   git show-ref --verify --quiet "refs/heads/$1"
 }
 
+remote_branch_exists() {
+  git show-ref --verify --quiet "refs/remotes/origin/$1"
+}
+
 is_trunk_branch() {
   case "$1" in
     main|master|trunk|develop) return 0 ;;
@@ -167,16 +192,16 @@ is_trunk_branch() {
   esac
 }
 
-if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
-  _info "already on ${FEATURE_BRANCH}"
-  echo "$FEATURE_BRANCH"
-  exit 0
-fi
-
 if is_trunk_branch "$CURRENT_BRANCH"; then
   if branch_exists "$FEATURE_BRANCH"; then
     _info "switching from ${CURRENT_BRANCH} to existing ${FEATURE_BRANCH}"
     git checkout "$FEATURE_BRANCH" >&2
+    if ! git merge-base --is-ancestor "$CURRENT_BRANCH" "$FEATURE_BRANCH"; then
+      _info "warning: ${FEATURE_BRANCH} is not based on current ${CURRENT_BRANCH}; consider rebasing before dispatch"
+    fi
+  elif remote_branch_exists "$FEATURE_BRANCH"; then
+    _info "switching from ${CURRENT_BRANCH} to existing origin/${FEATURE_BRANCH}"
+    git checkout --track "origin/${FEATURE_BRANCH}" >&2
   else
     _info "creating ${FEATURE_BRANCH} from ${CURRENT_BRANCH}"
     git checkout -b "$FEATURE_BRANCH" >&2

--- a/ycc/skills/_shared/scripts/prepare-feature-branch.sh
+++ b/ycc/skills/_shared/scripts/prepare-feature-branch.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# prepare-feature-branch.sh — ensure the current checkout is on the feature
+# branch before dispatching implementor agents in --no-worktree mode.
+#
+# Usage:
+#   prepare-feature-branch.sh <feature-slug> [--allow-existing-feature-branch]
+#
+# Behavior:
+#   - Rejects an unrelated dirty checkout (only plan-artifact paths allowed:
+#     docs/plans/<slug>/*, docs/prps/plans/<slug>*, docs/prps/specs/<slug>*).
+#   - On feat/<slug>: idempotent no-op.
+#   - On trunk (main/master) and feat/<slug> exists: switch to it.
+#   - On trunk and feat/<slug> missing: create it.
+#   - On another feature branch + --allow-existing-feature-branch: keep it.
+#   - On another feature branch without the flag: exit 2 (caller asks user).
+#
+# Mirrors setup-worktree.sh stdout/stderr discipline:
+#   - Branch name on stdout (one line).
+#   - All git output and status messages on stderr.
+#
+# Exit codes:
+#   0  branch is prepared (name on stdout)
+#   1  hard failure (dirty unrelated tree, git error, missing slug, ...)
+#   2  on a different feature branch and --allow-existing-feature-branch not set
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  prepare-feature-branch.sh <feature-slug> [--allow-existing-feature-branch]
+
+Arguments:
+  feature-slug                       Kebab-case feature identifier (e.g. "add-widget")
+  --allow-existing-feature-branch    Reuse the current branch if it already starts
+                                     with feat/ and differs from feat/<feature-slug>
+EOF
+}
+
+_error() {
+  echo "prepare-feature-branch.sh: error: $*" >&2
+}
+
+_info() {
+  echo "prepare-feature-branch.sh: $*" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+FEATURE_SLUG=""
+ALLOW_EXISTING_FEATURE_BRANCH=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-existing-feature-branch)
+      ALLOW_EXISTING_FEATURE_BRANCH=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -z "$FEATURE_SLUG" ]]; then
+        FEATURE_SLUG="$1"
+      else
+        _error "unexpected positional argument: $1"
+        usage
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$FEATURE_SLUG" ]]; then
+  _error "feature-slug is required"
+  usage
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Git context
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository"
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ -z "$CURRENT_BRANCH" ]]; then
+  _error "detached HEAD is not supported; check out a branch first"
+  exit 1
+fi
+
+FEATURE_BRANCH="feat/${FEATURE_SLUG}"
+
+# ---------------------------------------------------------------------------
+# Dirty-tree guard
+# ---------------------------------------------------------------------------
+#
+# Allow plan-artifact paths; reject anything else.
+
+is_plan_artifact() {
+  local path="$1"
+  case "$path" in
+    docs/plans/"${FEATURE_SLUG}"/*) return 0 ;;
+    docs/prps/plans/"${FEATURE_SLUG}"*) return 0 ;;
+    docs/prps/specs/"${FEATURE_SLUG}"*) return 0 ;;
+    docs/prps/prds/"${FEATURE_SLUG}"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+UNRELATED_DIRTY=()
+collect_dirty() {
+  # Untracked files (file-level — avoids `?? dir/` collapsed entries from
+  # `git status --porcelain` and `--untracked-files=all`'s memory cost).
+  git ls-files --others --exclude-standard
+  # Modified-but-unstaged tracked files.
+  git diff --name-only
+  # Staged tracked files (added/modified/renamed/deleted).
+  git diff --name-only --cached
+}
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  if ! is_plan_artifact "$path"; then
+    UNRELATED_DIRTY+=("$path")
+  fi
+done < <(collect_dirty | sort -u)
+
+if (( ${#UNRELATED_DIRTY[@]} > 0 )); then
+  _error "working tree has unrelated changes; stash or commit them first:"
+  printf '  %s\n' "${UNRELATED_DIRTY[@]}" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Branch state machine
+# ---------------------------------------------------------------------------
+
+branch_exists() {
+  git show-ref --verify --quiet "refs/heads/$1"
+}
+
+is_trunk_branch() {
+  case "$1" in
+    main|master|trunk|develop) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ "$CURRENT_BRANCH" == "$FEATURE_BRANCH" ]]; then
+  _info "already on ${FEATURE_BRANCH}"
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
+if is_trunk_branch "$CURRENT_BRANCH"; then
+  if branch_exists "$FEATURE_BRANCH"; then
+    _info "switching from ${CURRENT_BRANCH} to existing ${FEATURE_BRANCH}"
+    git checkout "$FEATURE_BRANCH" >&2
+  else
+    _info "creating ${FEATURE_BRANCH} from ${CURRENT_BRANCH}"
+    git checkout -b "$FEATURE_BRANCH" >&2
+  fi
+  echo "$FEATURE_BRANCH"
+  exit 0
+fi
+
+# Some other branch — already a non-trunk branch, not feat/<slug>.
+if [[ "$ALLOW_EXISTING_FEATURE_BRANCH" == true ]]; then
+  _info "using current branch ${CURRENT_BRANCH} (--allow-existing-feature-branch)"
+  echo "$CURRENT_BRANCH"
+  exit 0
+fi
+
+_error "on branch '${CURRENT_BRANCH}', expected '${FEATURE_BRANCH}' or a trunk branch"
+_error "pass --allow-existing-feature-branch to reuse the current branch, or check out a trunk branch first"
+exit 2

--- a/ycc/skills/implement-plan/SKILL.md
+++ b/ycc/skills/implement-plan/SKILL.md
@@ -256,15 +256,23 @@ Store the echoed path as `WT_PARENT_PATH` (overrides any deduced value).
 All agents in every batch — parallel and sequential — operate directly in this
 single feature worktree. No child worktrees are created.
 
-When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout:
+When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout. Run the shared helper **before dispatching any implementor agents** — without this step, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
 
-| Current State                                                                | Action                                                      |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| On `FEATURE_BRANCH`                                                          | Use current branch                                          |
-| On another feature branch                                                    | Use current branch only if the user confirms it is intended |
-| On main, clean/plan-only dirty checkout, and `FEATURE_BRANCH` exists         | Switch to it: `git checkout "${FEATURE_BRANCH}"`            |
-| On main, clean/plan-only dirty checkout, and `FEATURE_BRANCH` does not exist | Create it: `git checkout -b "${FEATURE_BRANCH}"`            |
-| On main with unrelated dirty files                                           | **STOP** — ask user to stash or commit first                |
+```bash
+FEATURE_BRANCH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
+```
+
+The script enforces the branch-decision matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main` (GitHub #TBD).
+
+| Current State                                                            | Helper Behavior                                                                        |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| On `FEATURE_BRANCH`                                                      | Idempotent no-op; echoes `feat/<slug>` and exits 0                                     |
+| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` exists  | `git checkout feat/<slug>`; echoes branch                                              |
+| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` missing | `git checkout -b feat/<slug>`; echoes branch                                           |
+| On another feature branch                                                | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user |
+| On main with unrelated dirty files                                       | Exits 1 — ask user to stash or commit first                                            |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
 
 After this branch step, all agents in every batch operate in the current checkout. Include `Working directory: ${REPO_ROOT}` in each prompt when `--no-worktree` is active so dispatched agents target the prepared branch consistently.
 

--- a/ycc/skills/implement-plan/SKILL.md
+++ b/ycc/skills/implement-plan/SKILL.md
@@ -242,7 +242,13 @@ Before creating a worktree or branch, inspect `GIT_STATUS`.
 
 ### Step 6.6: Prepare the execution tree
 
-When `WORKTREE_ACTIVE=true`, create the parent worktree **once** before Batch 1. The worktree owns `FEATURE_BRANCH`; do not check out that branch in the main checkout:
+Prepare the feature branch directly in the current checkout **before** any worktree setup or implementor-agent dispatch. The helper exits non-zero on failure and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`. See `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/branch-prep.md` for the helper's behavior and exit-code contract.
+
+```bash
+FEATURE_BRANCH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
+```
+
+When `WORKTREE_ACTIVE=true`, create the parent worktree **once** before Batch 1. The worktree adopts the prepared `FEATURE_BRANCH`:
 
 ```bash
 WT_PARENT_PATH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/setup-worktree.sh parent "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}")
@@ -256,23 +262,7 @@ Store the echoed path as `WT_PARENT_PATH` (overrides any deduced value).
 All agents in every batch — parallel and sequential — operate directly in this
 single feature worktree. No child worktrees are created.
 
-When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup and prepare the feature branch directly in the current checkout. Run the shared helper **before dispatching any implementor agents** — without this step, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
-
-```bash
-FEATURE_BRANCH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${WT_FEATURE_SLUG}")
-```
-
-The script enforces the branch-decision matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main` (GitHub #TBD).
-
-| Current State                                                            | Helper Behavior                                                                        |
-| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| On `FEATURE_BRANCH`                                                      | Idempotent no-op; echoes `feat/<slug>` and exits 0                                     |
-| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` exists  | `git checkout feat/<slug>`; echoes branch                                              |
-| On main/master/trunk, clean or plan-only dirty, `FEATURE_BRANCH` missing | `git checkout -b feat/<slug>`; echoes branch                                           |
-| On another feature branch                                                | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user |
-| On main with unrelated dirty files                                       | Exits 1 — ask user to stash or commit first                                            |
-
-If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+When `WORKTREE_ACTIVE=false` (`--no-worktree`), skip parent-worktree setup.
 
 After this branch step, all agents in every batch operate in the current checkout. Include `Working directory: ${REPO_ROOT}` in each prompt when `--no-worktree` is active so dispatched agents target the prepared branch consistently.
 

--- a/ycc/skills/orchestrate/SKILL.md
+++ b/ycc/skills/orchestrate/SKILL.md
@@ -50,7 +50,7 @@ Parse flags first, then treat the remainder as the task description:
 
 Strip flags from `$ARGUMENTS` and set `TEAM_FLAG=true|false`, `DRY_RUN=true|false`, `PLAN_ONLY=true|false`, `SEQUENTIAL=true|false`, `WORKTREE_MODE=true|false`. Join the remaining non-flag tokens into `TASK_DESCRIPTION`.
 
-**Feature slug derivation** (used when `WORKTREE_MODE=true`): sanitize `TASK_DESCRIPTION` to produce `FEATURE_SLUG` — lowercase, replace `[^a-z0-9-]` with `-`, collapse runs of `-`, trim leading/trailing `-`, truncate to 20 characters. Fall back to `untitled` if empty. This is the same sanitization used for team-name context in `agent-team-dispatch.md` §1.
+**Feature slug derivation**: after `TASK_DESCRIPTION` is set, always sanitize it to produce `FEATURE_SLUG` before any `WORKTREE_MODE` branching — lowercase, replace `[^a-z0-9-]` with `-`, collapse runs of `-`, trim leading/trailing `-`, truncate to 20 characters. Fall back to `untitled` if empty. This is the same sanitization used for team-name context in `agent-team-dispatch.md` §1.
 
 If no task description is provided after stripping flags, abort with usage instructions:
 

--- a/ycc/skills/orchestrate/SKILL.md
+++ b/ycc/skills/orchestrate/SKILL.md
@@ -22,6 +22,7 @@ allowed-tools:
   - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/orchestrate/scripts/*.sh:*)'
   - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/setup-worktree.sh:*)'
   - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/list-worktrees.sh:*)'
+  - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh:*)'
 ---
 
 # Multi-Agent Orchestration Skill
@@ -249,9 +250,17 @@ The decision follows a strict precedence order:
 
 `--worktree` is accepted as a silent no-op and matches the new default; it has no additional effect. Note: this skill does not auto-detect `## Worktree Setup` annotations from a plan (it creates its own decomposition), so the only opt-out is `--no-worktree`.
 
-Skip this phase entirely when `WORKTREE_MODE=false`.
+### When `WORKTREE_MODE=false` (`--no-worktree`)
 
-When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`:
+Skip parent worktree setup, but **always prepare the feature branch** before any agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
+
+```bash
+FEATURE_BRANCH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+```
+
+The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+
+### When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`
 
 Determine the repository name from the current directory (`basename $(git rev-parse --show-toplevel)`). Use the `FEATURE_SLUG` derived during flag parsing.
 

--- a/ycc/skills/orchestrate/SKILL.md
+++ b/ycc/skills/orchestrate/SKILL.md
@@ -250,15 +250,17 @@ The decision follows a strict precedence order:
 
 `--worktree` is accepted as a silent no-op and matches the new default; it has no additional effect. Note: this skill does not auto-detect `## Worktree Setup` annotations from a plan (it creates its own decomposition), so the only opt-out is `--no-worktree`.
 
-### When `WORKTREE_MODE=false` (`--no-worktree`)
+### Branch Preparation
 
-Skip parent worktree setup, but **always prepare the feature branch** before any agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
+When `DRY_RUN=false` and `PLAN_ONLY=false`, **always prepare the feature branch** before any worktree setup or agent dispatches. Without this, agents inherit whatever branch the orchestrator started on (typically `main`) and commit there:
 
 ```bash
 FEATURE_BRANCH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
 ```
 
-The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+See `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/branch-prep.md` for the helper's behavior and exit-code contract. Skip both this call and the worktree setup below when `DRY_RUN=true` or `PLAN_ONLY=true`.
+
+When `WORKTREE_MODE=false` (`--no-worktree`), skip parent worktree setup after branch preparation.
 
 ### When `WORKTREE_MODE=true` and `DRY_RUN=false` and `PLAN_ONLY=false`
 

--- a/ycc/skills/plan/SKILL.md
+++ b/ycc/skills/plan/SKILL.md
@@ -20,6 +20,7 @@ allowed-tools:
   - Bash(cat:*)
   - Bash(test:*)
   - Bash(git:*)
+  - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh:*)'
 ---
 
 # Plan Skill
@@ -568,7 +569,18 @@ If the plan was produced with `--parallel` (has a `Batches` section and `Depends
 
 **Option 1 — In-conversation parallel execution (lightweight)**
 
-Process batches sequentially. Within each batch, dispatch one `ycc:implementor` agent per step in a SINGLE message with MULTIPLE `Agent` tool calls. Between batches, run the project's type-check and unit-test commands. On failure, stop and ask the user how to proceed.
+Before dispatching any `ycc:implementor` agents, prepare the feature branch so agents do not commit on `main`:
+
+- **`WORKTREE_MODE=true` (default)** — the plan already names the parent worktree at `~/.claude-worktrees/<repo>-<feature>/` (branch `feat/<feature>`). Run `setup-worktree.sh parent <repo> <feature>` once, then dispatch agents with `Working directory: <parent path>`.
+- **`WORKTREE_MODE=false` (`--no-worktree`)** — derive `FEATURE_SLUG` from the user's request using the same sanitization as Path B §B.1 (lowercase, non-`[a-z0-9-]` → `-`, collapse runs, truncate to 20 chars, fallback `untitled`), then run:
+
+  ```bash
+  FEATURE_BRANCH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh "${FEATURE_SLUG}")
+  ```
+
+  The script is idempotent on `feat/${FEATURE_SLUG}`, creates it from a trunk branch, exits 1 on unrelated dirty tree, and exits 2 on a different feature branch (re-run with `--allow-existing-feature-branch` after user confirmation). **Do not skip this step** — it is what prevents implementor agents from committing to `main`.
+
+Then process batches sequentially. Within each batch, dispatch one `ycc:implementor` agent per step in a SINGLE message with MULTIPLE `Agent` tool calls. Between batches, run the project's type-check and unit-test commands. On failure, stop and ask the user how to proceed.
 
 This keeps everything in the current conversation — no file artifact needed.
 

--- a/ycc/skills/prp-implement/SKILL.md
+++ b/ycc/skills/prp-implement/SKILL.md
@@ -229,7 +229,7 @@ When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so 
 After the branch decision, create the parent worktree **once** before the first batch:
 
 ```bash
-WT_PARENT_PATH=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/setup-worktree.sh" \
+WT_PARENT_PATH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/setup-worktree.sh \
   parent "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}")
 ```
 
@@ -240,7 +240,7 @@ This creates `~/.claude-worktrees/${WT_REPO_NAME}-${WT_FEATURE_SLUG}/` on branch
 Plan artifacts written by `ycc:prp-plan` are pre-commit and live in the **main checkout** when this skill starts. The first thing to do after the worktree exists is **move** them in — never copy, never sync:
 
 ```bash
-PLAN_PATH=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/move-plan-to-worktree.sh" \
+PLAN_PATH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/move-plan-to-worktree.sh \
   "$ARGUMENTS" "$WT_PARENT_PATH")
 ```
 
@@ -658,7 +658,7 @@ mv "$PLAN_PATH" "$(dirname -- "$PLAN_PATH")/completed/"
 After archiving the plan, run:
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/list-worktrees.sh" \
+bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/list-worktrees.sh \
   "${WT_REPO_NAME}" "${WT_FEATURE_SLUG}"
 ```
 

--- a/ycc/skills/prp-implement/SKILL.md
+++ b/ycc/skills/prp-implement/SKILL.md
@@ -37,6 +37,7 @@ allowed-tools:
   - Bash(go:*)
   - Bash(make:*)
   - Bash(curl:*)
+  - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/*.sh:*)'
 ---
 
 # PRP Implement
@@ -199,14 +200,27 @@ git status --porcelain
 
 ### Branch Decision
 
-| Current State                      | Action                                                    |
-| ---------------------------------- | --------------------------------------------------------- |
-| On feature branch                  | Use current branch                                        |
-| On main, clean working tree        | Create feature branch: `git checkout -b feat/{plan-name}` |
-| On main, dirty working tree        | **STOP** — Ask user to stash or commit first              |
-| In a git worktree for this feature | Use the worktree (see WORKTREE_ACTIVE logic below)        |
+Run the shared branch-prep helper **before any agent dispatch** so implementor agents inherit the right branch instead of `main`:
 
-When `WORKTREE_ACTIVE=true`, the branch decision above applies to the **main repo** (from which the parent worktree branches). After resolving the branch, also run the worktree setup step below.
+```bash
+FEATURE_BRANCH=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh" \
+  "${WT_FEATURE_SLUG}")
+```
+
+The script enforces the matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`.
+
+| Current State                                                  | Helper Behavior                                                                            |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| On `feat/<slug>`                                               | Idempotent no-op; echoes branch and exits 0                                                |
+| On main/master/trunk, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                                  |
+| On main/master/trunk, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                               |
+| On another feature branch                                      | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user     |
+| On main with unrelated dirty files                             | Exits 1 — stop and ask user to stash or commit first                                       |
+| In a git worktree for this feature                             | Use the worktree (see `WORKTREE_ACTIVE` logic below); the helper still resolves the branch |
+
+If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+
+When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so `feat/<slug>` exists locally), then run the worktree setup step below — `setup-worktree.sh parent` will adopt the existing branch.
 
 ### Parent Worktree Setup (when `WORKTREE_ACTIVE=true`)
 

--- a/ycc/skills/prp-implement/SKILL.md
+++ b/ycc/skills/prp-implement/SKILL.md
@@ -203,22 +203,11 @@ git status --porcelain
 Run the shared branch-prep helper **before any agent dispatch** so implementor agents inherit the right branch instead of `main`:
 
 ```bash
-FEATURE_BRANCH=$(bash "${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh" \
+FEATURE_BRANCH=$(bash ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/prepare-feature-branch.sh \
   "${WT_FEATURE_SLUG}")
 ```
 
-The script enforces the matrix below, exits non-zero on failure, and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`.
-
-| Current State                                                  | Helper Behavior                                                                            |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| On `feat/<slug>`                                               | Idempotent no-op; echoes branch and exits 0                                                |
-| On main/master/trunk, clean or plan-only dirty, branch exists  | `git checkout feat/<slug>`; echoes branch                                                  |
-| On main/master/trunk, clean or plan-only dirty, branch missing | `git checkout -b feat/<slug>`; echoes branch                                               |
-| On another feature branch                                      | Exits 2 — re-run with `--allow-existing-feature-branch` after confirming with the user     |
-| On main with unrelated dirty files                             | Exits 1 — stop and ask user to stash or commit first                                       |
-| In a git worktree for this feature                             | Use the worktree (see `WORKTREE_ACTIVE` logic below); the helper still resolves the branch |
-
-If the helper exits 2, surface the message to the user, ask whether to reuse the current branch, and re-invoke with `--allow-existing-feature-branch` on confirmation. If it exits 1, stop and have the user clean the tree.
+The script exits non-zero on failure and echoes the prepared branch name on success. **Do not skip it** — narrative-only branch instructions are how the original `--no-worktree` bug allowed agents to commit to `main`. See `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/branch-prep.md` for the helper's behavior and exit-code contract.
 
 When `WORKTREE_ACTIVE=true`, run the helper first against the **main repo** (so `feat/<slug>` exists locally), then run the worktree setup step below — `setup-worktree.sh parent` will adopt the existing branch.
 


### PR DESCRIPTION
## Summary

When `/ycc:plan --no-worktree` (or any of `/ycc:implement-plan`, `/ycc:prp-implement`, `/ycc:orchestrate` with `--no-worktree`) handed off to implementor agents, those agents committed directly to `main` instead of creating/using a feature branch. The user had to manually `git checkout -b` first to avoid this.

Closes #<!-- issue number, fill in after filing -->

## Root Cause

Every `--no-worktree` path described the branch decision as a narrative markdown table (e.g. `implement-plan/SKILL.md` Step 6.6 lines 259-269), but never actually invoked `git checkout -b`. The orchestrator was expected to read the table and run the right `git` command itself, but in practice the step was silently skipped — agents inherited `main` and committed there.

Mirror image of the worktree path, which calls `setup-worktree.sh parent` explicitly and works reliably.

## Changes

- **New**: `ycc/skills/_shared/scripts/prepare-feature-branch.sh` — idempotent on `feat/<slug>`, creates from trunk, exits 1 on unrelated dirty trees (allows `docs/plans/<slug>/*` artifacts), exits 2 on other feature branches (caller asks user, re-runs with `--allow-existing-feature-branch`). Mirrors `setup-worktree.sh` stdout/stderr discipline.
- **Wired into 4 dispatch sites** that previously relied on narrative tables:
  - `ycc/skills/plan/SKILL.md` — Option 1 in-conversation parallel execution
  - `ycc/skills/implement-plan/SKILL.md` — Step 6.6 branch prep
  - `ycc/skills/prp-implement/SKILL.md` — Phase 2 Branch Decision
  - `ycc/skills/orchestrate/SKILL.md` — Phase 2.5 worktree-mode-false branch
- **allowed-tools**: added `Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/*.sh:*)` (or the file-specific path for orchestrate, matching its existing style) to the three skills that previously lacked it.
- **Bundle regen**: cursor/codex/opencode mirrors regenerated via `./scripts/sync.sh` (separate commit so the source change is reviewable on its own).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactor (no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
- [ ] Build / CI
- [ ] Chore

## Testing

- [x] Linter passes (`npm run lint`: markdownlint + prettier + ruff + black + shellcheck — all green)
- [x] Tests pass (8 unit-style scenarios on the new script — see Reviewer Notes)
- [x] `npm run lint` passes
- [ ] `npm test` passes _(no `npm test` defined for this repo — verification is `./scripts/validate.sh`, which passes)_
- [ ] TypeScript strict mode checks pass (if applicable) _(not applicable — no TS files changed)_
- [x] `ruff check .` passes (if Python files changed) _(no Python changed; ruff still green)_
- [ ] `mypy --strict` passes (if Python files changed) _(no Python files changed)_

Additional verification:

- `python3 -m json.tool` on `marketplace.json` and `plugin.json` — valid
- `find ycc/skills -name "*.sh" -not -executable` returns only 2 pre-existing library files
- `./scripts/sync.sh` regenerates cleanly; `./scripts/validate.sh` is fully green (cursor/codex/opencode sync checks, frontmatter, content policy, JSON, install-coverage, hooks symlink)

## Reviewer Notes

**Helper script unit tests** — run from a temp git repo (covered manually before commit):

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| 1 | On `main`, clean tree, `feat/foo` missing | creates `feat/foo`, echoes name, exit 0 | PASS |
| 2 | On `main`, clean tree, `feat/foo` exists | switches to `feat/foo`, no duplicate | PASS |
| 3 | Already on `feat/foo` | idempotent no-op, echoes name, exit 0 | PASS |
| 4 | On `main` with unrelated dirty file | exit 1, "unrelated changes" message | PASS |
| 5 | On `main` with `docs/plans/foo/parallel-plan.md` dirty | allowed; creates branch | PASS |
| 6 | On `feat/other` without `--allow-existing-feature-branch` | exit 2 | PASS |
| 7 | On `feat/other` with the flag | echoes `feat/other`, exit 0 | PASS |
| 8 | Missing slug arg | exit 1, usage shown | PASS |

**Why `git ls-files --others --exclude-standard` instead of `git status --porcelain`**: porcelain collapses untracked directories (e.g. `?? docs/`), and CLAUDE.md prohibits `--untracked-files=all` for memory reasons on large repos. Using the plumbing commands (`ls-files --others`, `diff --name-only`, `diff --name-only --cached`) gives reliable file-level paths without that tradeoff.

**Risk areas**:
- `--allow-existing-feature-branch` UX: when the helper exits 2, each caller now needs to surface the message and prompt the user. The SKILL.md edits include that instruction, but it relies on the orchestrator following the prose. Belt-and-suspenders option for a follow-up: have implementor agents verify `git branch --show-current` matches an expected branch passed in via the prompt.
- The orchestrate skill uses an explicit per-file allowed-tools entry (matching its existing style), while the other three use the wildcard. Both work; just calling out the inconsistency.