### PR TITLE
feat(review-fix): add /goal pairing section and Goal Signals block

### DIFF
--- a/.codex-plugin/ycc/shared/references/goal-pairing.md
+++ b/.codex-plugin/ycc/shared/references/goal-pairing.md
@@ -2,7 +2,7 @@
 
 Reference for ycc skills that recommend pairing with the platform `/goal` session
 directive for autonomous, loop-to-completion execution — currently `prp-implement`,
-`implement-plan`, and `pr-autofix`. Each skill cites this doc so the
+`implement-plan`, `review-fix`, and `pr-autofix`. Each skill cites this doc so the
 transcript-output contract, the condition-template shape, and the caveats stay
 convergent. Fix them here, not per skill.
 

--- a/.codex-plugin/ycc/skills/review-fix/SKILL.md
+++ b/.codex-plugin/ycc/skills/review-fix/SKILL.md
@@ -729,6 +729,7 @@ Report to the user:
 - Fixed:    X
 - Failed:   Y
 - Skipped:  C (below threshold) + D (no suggestion) + E (missing file)
+- Open remaining: <M - X - Y>
 
 ### Source Review File Updated
 The source review at <path> has been updated in place:
@@ -743,7 +744,16 @@ The source review at <path> has been updated in place:
 ### Next Steps
   $code-review <same target>   # re-review to verify fixes landed
   $git-workflow --commit       # commit the fixes when satisfied
+
+### Goal Signals (machine-readable — printed verbatim for /goal)
+PLAN_VALID: <PASS|FAIL>
+REVIEW_UPDATED: <PASS|FAIL>
+REPORT_CREATED: <PASS|FAIL>
+VALIDATION_RUN: <PASS|FAIL>
+REPORT_COMMITTED: <PASS|FAIL|n/a>
 ```
+
+Print every signal verbatim as the last lines of the Phase 7 output, one `KEY: PASS|FAIL` per line. Use `PASS` only when the matching criterion in `## Success Criteria` is met; otherwise `FAIL`. `REPORT_COMMITTED` is `n/a` in `--no-worktree` mode, where the report is written to disk but no automatic commit is made.
 
 ---
 
@@ -783,6 +793,38 @@ The review file is updated incrementally after each agent returns, so if the run
 - **REPORT_CREATED**: A fix report is written to `docs/prps/reviews/fixes/`
 - **VALIDATION_RUN**: Phase 5 type-check + tests completed (even if they failed)
 - **REPORT_COMMITTED**: The fix report is committed and pushed to the PR branch alongside the fix commits (in worktree mode). In `--no-worktree` mode, the report is written to disk; no automatic commit is made.
+
+These keys are emitted verbatim in the Phase 7 OUTPUT 'Goal Signals' block so a `/goal` evaluator can observe completion from the transcript.
+
+---
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive to drive the fix pipeline to completion — through every batch of fixer agents and the Phase 5 validation pass — without returning control between batches. Supply an explicit done condition that references the Phase 7 Goal Signals block rather than file paths.
+
+The loop driver for `review-fix` is artifact-driven with no CI loop: the done signal is "no Open findings remain", which is observable from the `Open remaining: 0` reconciliation line and the five Goal Signals keys printed in Phase 7. There is no `RESULT=`/`CI_GREEN` marker.
+
+`Failed` findings that the fixer agent already judged unfixable are **terminal** — they are not re-dispatched automatically. When `Open remaining` is non-zero only because of `Failed` findings (i.e. `Fixed + Failed == Eligible`), the pipeline is complete: do not loop again on already-failed findings.
+
+Recommended condition template:
+
+```
+/goal Run $review-fix <review-file-or-pr> using the review-fix workflow,
+continuing through every batch of fixer agents and the Phase 5 validation pass
+without returning control to me. Done when the transcript shows the Phase 7
+"## Review Fixes Complete" output followed by all five Goal Signals printed verbatim —
+PLAN_VALID: PASS, REVIEW_UPDATED: PASS, REPORT_CREATED: PASS, VALIDATION_RUN: PASS,
+and REPORT_COMMITTED: PASS (or n/a in --no-worktree mode) — and the "Open remaining"
+line shows 0 (or all remaining Open findings are accounted for by Failed entries). If
+any non-terminal signal prints FAIL, keep fixing and re-running until resolved. Stop
+after 25 turns if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+~/.codex/plugins/ycc/shared/references/goal-pairing.md
+```
 
 ---
 

--- a/.cursor-plugin/skills/_shared/references/goal-pairing.md
+++ b/.cursor-plugin/skills/_shared/references/goal-pairing.md
@@ -2,7 +2,7 @@
 
 Reference for ycc skills that recommend pairing with the platform `/goal` session
 directive for autonomous, loop-to-completion execution — currently `prp-implement`,
-`implement-plan`, and `pr-autofix`. Each skill cites this doc so the
+`implement-plan`, `review-fix`, and `pr-autofix`. Each skill cites this doc so the
 transcript-output contract, the condition-template shape, and the caveats stay
 convergent. Fix them here, not per skill.
 

--- a/.cursor-plugin/skills/review-fix/SKILL.md
+++ b/.cursor-plugin/skills/review-fix/SKILL.md
@@ -759,6 +759,7 @@ Report to the user:
 - Fixed:    X
 - Failed:   Y
 - Skipped:  C (below threshold) + D (no suggestion) + E (missing file)
+- Open remaining: <M - X - Y>
 
 ### Source Review File Updated
 The source review at <path> has been updated in place:
@@ -773,7 +774,16 @@ The source review at <path> has been updated in place:
 ### Next Steps
   /code-review <same target>   # re-review to verify fixes landed
   /git-workflow --commit       # commit the fixes when satisfied
+
+### Goal Signals (machine-readable — printed verbatim for /goal)
+PLAN_VALID: <PASS|FAIL>
+REVIEW_UPDATED: <PASS|FAIL>
+REPORT_CREATED: <PASS|FAIL>
+VALIDATION_RUN: <PASS|FAIL>
+REPORT_COMMITTED: <PASS|FAIL|n/a>
 ```
+
+Print every signal verbatim as the last lines of the Phase 7 output, one `KEY: PASS|FAIL` per line. Use `PASS` only when the matching criterion in `## Success Criteria` is met; otherwise `FAIL`. `REPORT_COMMITTED` is `n/a` in `--no-worktree` mode, where the report is written to disk but no automatic commit is made.
 
 ---
 
@@ -813,6 +823,38 @@ The review file is updated incrementally after each agent returns, so if the run
 - **REPORT_CREATED**: A fix report is written to `docs/prps/reviews/fixes/`
 - **VALIDATION_RUN**: Phase 5 type-check + tests completed (even if they failed)
 - **REPORT_COMMITTED**: The fix report is committed and pushed to the PR branch alongside the fix commits (in worktree mode). In `--no-worktree` mode, the report is written to disk; no automatic commit is made.
+
+These keys are emitted verbatim in the Phase 7 OUTPUT 'Goal Signals' block so a `/goal` evaluator can observe completion from the transcript.
+
+---
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive to drive the fix pipeline to completion — through every batch of fixer agents and the Phase 5 validation pass — without returning control between batches. Supply an explicit done condition that references the Phase 7 Goal Signals block rather than file paths.
+
+The loop driver for `review-fix` is artifact-driven with no CI loop: the done signal is "no Open findings remain", which is observable from the `Open remaining: 0` reconciliation line and the five Goal Signals keys printed in Phase 7. There is no `RESULT=`/`CI_GREEN` marker.
+
+`Failed` findings that the fixer agent already judged unfixable are **terminal** — they are not re-dispatched automatically. When `Open remaining` is non-zero only because of `Failed` findings (i.e. `Fixed + Failed == Eligible`), the pipeline is complete: do not loop again on already-failed findings.
+
+Recommended condition template:
+
+```
+/goal Run /review-fix <review-file-or-pr> using the review-fix workflow,
+continuing through every batch of fixer agents and the Phase 5 validation pass
+without returning control to me. Done when the transcript shows the Phase 7
+"## Review Fixes Complete" output followed by all five Goal Signals printed verbatim —
+PLAN_VALID: PASS, REVIEW_UPDATED: PASS, REPORT_CREATED: PASS, VALIDATION_RUN: PASS,
+and REPORT_COMMITTED: PASS (or n/a in --no-worktree mode) — and the "Open remaining"
+line shows 0 (or all remaining Open findings are accounted for by Failed entries). If
+any non-terminal signal prints FAIL, keep fixing and re-running until resolved. Stop
+after 25 turns if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+${CURSOR_PLUGIN_ROOT}/skills/_shared/references/goal-pairing.md
+```
 
 ---
 

--- a/.opencode-plugin/shared/references/goal-pairing.md
+++ b/.opencode-plugin/shared/references/goal-pairing.md
@@ -2,7 +2,7 @@
 
 Reference for ycc skills that recommend pairing with the platform `/goal` session
 directive for autonomous, loop-to-completion execution — currently `prp-implement`,
-`implement-plan`, and `pr-autofix`. Each skill cites this doc so the
+`implement-plan`, `review-fix`, and `pr-autofix`. Each skill cites this doc so the
 transcript-output contract, the condition-template shape, and the caveats stay
 convergent. Fix them here, not per skill.
 

--- a/.opencode-plugin/skills/review-fix/SKILL.md
+++ b/.opencode-plugin/skills/review-fix/SKILL.md
@@ -729,6 +729,7 @@ Report to the user:
 - Fixed:    X
 - Failed:   Y
 - Skipped:  C (below threshold) + D (no suggestion) + E (missing file)
+- Open remaining: <M - X - Y>
 
 ### Source Review File Updated
 The source review at <path> has been updated in place:
@@ -743,7 +744,16 @@ The source review at <path> has been updated in place:
 ### Next Steps
   /code-review <same target>   # re-review to verify fixes landed
   /git-workflow --commit       # commit the fixes when satisfied
+
+### Goal Signals (machine-readable — printed verbatim for /goal)
+PLAN_VALID: <PASS|FAIL>
+REVIEW_UPDATED: <PASS|FAIL>
+REPORT_CREATED: <PASS|FAIL>
+VALIDATION_RUN: <PASS|FAIL>
+REPORT_COMMITTED: <PASS|FAIL|n/a>
 ```
+
+Print every signal verbatim as the last lines of the Phase 7 output, one `KEY: PASS|FAIL` per line. Use `PASS` only when the matching criterion in `## Success Criteria` is met; otherwise `FAIL`. `REPORT_COMMITTED` is `n/a` in `--no-worktree` mode, where the report is written to disk but no automatic commit is made.
 
 ---
 
@@ -783,6 +793,38 @@ The review file is updated incrementally after each agent returns, so if the run
 - **REPORT_CREATED**: A fix report is written to `docs/prps/reviews/fixes/`
 - **VALIDATION_RUN**: Phase 5 type-check + tests completed (even if they failed)
 - **REPORT_COMMITTED**: The fix report is committed and pushed to the PR branch alongside the fix commits (in worktree mode). In `--no-worktree` mode, the report is written to disk; no automatic commit is made.
+
+These keys are emitted verbatim in the Phase 7 OUTPUT 'Goal Signals' block so a `/goal` evaluator can observe completion from the transcript.
+
+---
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive to drive the fix pipeline to completion — through every batch of fixer agents and the Phase 5 validation pass — without returning control between batches. Supply an explicit done condition that references the Phase 7 Goal Signals block rather than file paths.
+
+The loop driver for `review-fix` is artifact-driven with no CI loop: the done signal is "no Open findings remain", which is observable from the `Open remaining: 0` reconciliation line and the five Goal Signals keys printed in Phase 7. There is no `RESULT=`/`CI_GREEN` marker.
+
+`Failed` findings that the fixer agent already judged unfixable are **terminal** — they are not re-dispatched automatically. When `Open remaining` is non-zero only because of `Failed` findings (i.e. `Fixed + Failed == Eligible`), the pipeline is complete: do not loop again on already-failed findings.
+
+Recommended condition template:
+
+```
+/goal Run /review-fix <review-file-or-pr> using the review-fix workflow,
+continuing through every batch of fixer agents and the Phase 5 validation pass
+without returning control to me. Done when the transcript shows the Phase 7
+"## Review Fixes Complete" output followed by all five Goal Signals printed verbatim —
+PLAN_VALID: PASS, REVIEW_UPDATED: PASS, REPORT_CREATED: PASS, VALIDATION_RUN: PASS,
+and REPORT_COMMITTED: PASS (or n/a in --no-worktree mode) — and the "Open remaining"
+line shows 0 (or all remaining Open findings are accounted for by Failed entries). If
+any non-terminal signal prints FAIL, keep fixing and re-running until resolved. Stop
+after 25 turns if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+~/.config/opencode/shared/references/goal-pairing.md
+```
 
 ---
 

--- a/ycc/skills/_shared/references/goal-pairing.md
+++ b/ycc/skills/_shared/references/goal-pairing.md
@@ -2,7 +2,7 @@
 
 Reference for ycc skills that recommend pairing with the platform `/goal` session
 directive for autonomous, loop-to-completion execution — currently `ycc:prp-implement`,
-`ycc:implement-plan`, and `ycc:pr-autofix`. Each skill cites this doc so the
+`ycc:implement-plan`, `ycc:review-fix`, and `ycc:pr-autofix`. Each skill cites this doc so the
 transcript-output contract, the condition-template shape, and the caveats stay
 convergent. Fix them here, not per skill.
 

--- a/ycc/skills/review-fix/SKILL.md
+++ b/ycc/skills/review-fix/SKILL.md
@@ -759,6 +759,7 @@ Report to the user:
 - Fixed:    X
 - Failed:   Y
 - Skipped:  C (below threshold) + D (no suggestion) + E (missing file)
+- Open remaining: <M - X - Y>
 
 ### Source Review File Updated
 The source review at <path> has been updated in place:
@@ -773,7 +774,16 @@ The source review at <path> has been updated in place:
 ### Next Steps
   /ycc:code-review <same target>   # re-review to verify fixes landed
   /ycc:git-workflow --commit       # commit the fixes when satisfied
+
+### Goal Signals (machine-readable — printed verbatim for /goal)
+PLAN_VALID: <PASS|FAIL>
+REVIEW_UPDATED: <PASS|FAIL>
+REPORT_CREATED: <PASS|FAIL>
+VALIDATION_RUN: <PASS|FAIL>
+REPORT_COMMITTED: <PASS|FAIL|n/a>
 ```
+
+Print every signal verbatim as the last lines of the Phase 7 output, one `KEY: PASS|FAIL` per line. Use `PASS` only when the matching criterion in `## Success Criteria` is met; otherwise `FAIL`. `REPORT_COMMITTED` is `n/a` in `--no-worktree` mode, where the report is written to disk but no automatic commit is made.
 
 ---
 
@@ -813,6 +823,38 @@ The review file is updated incrementally after each agent returns, so if the run
 - **REPORT_CREATED**: A fix report is written to `docs/prps/reviews/fixes/`
 - **VALIDATION_RUN**: Phase 5 type-check + tests completed (even if they failed)
 - **REPORT_COMMITTED**: The fix report is committed and pushed to the PR branch alongside the fix commits (in worktree mode). In `--no-worktree` mode, the report is written to disk; no automatic commit is made.
+
+These keys are emitted verbatim in the Phase 7 OUTPUT 'Goal Signals' block so a `/goal` evaluator can observe completion from the transcript.
+
+---
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive to drive the fix pipeline to completion — through every batch of fixer agents and the Phase 5 validation pass — without returning control between batches. Supply an explicit done condition that references the Phase 7 Goal Signals block rather than file paths.
+
+The loop driver for `ycc:review-fix` is artifact-driven with no CI loop: the done signal is "no Open findings remain", which is observable from the `Open remaining: 0` reconciliation line and the five Goal Signals keys printed in Phase 7. There is no `RESULT=`/`CI_GREEN` marker.
+
+`Failed` findings that the fixer agent already judged unfixable are **terminal** — they are not re-dispatched automatically. When `Open remaining` is non-zero only because of `Failed` findings (i.e. `Fixed + Failed == Eligible`), the pipeline is complete: do not loop again on already-failed findings.
+
+Recommended condition template:
+
+```
+/goal Run /ycc:review-fix <review-file-or-pr> using the ycc:review-fix workflow,
+continuing through every batch of fixer agents and the Phase 5 validation pass
+without returning control to me. Done when the transcript shows the Phase 7
+"## Review Fixes Complete" output followed by all five Goal Signals printed verbatim —
+PLAN_VALID: PASS, REVIEW_UPDATED: PASS, REPORT_CREATED: PASS, VALIDATION_RUN: PASS,
+and REPORT_COMMITTED: PASS (or n/a in --no-worktree mode) — and the "Open remaining"
+line shows 0 (or all remaining Open findings are accounted for by Failed entries). If
+any non-terminal signal prints FAIL, keep fixing and re-running until resolved. Stop
+after 25 turns if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/goal-pairing.md
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Adds `/goal` integration to `ycc:review-fix` so the fix pipeline can be driven to completion under the Claude Code / Codex `/goal` session directive without re-prompting between phases. Mirrors the convention already shipped for `pr-autofix`, `implement-plan`, and `prp-implement`.

Because the `/goal` evaluator reads transcript text only (never files), the done signal is made observable in Phase 7 stdout rather than in the on-disk report.

Closes #95

## Changes

- **Phase 7 OUTPUT** emits a verbatim **Goal Signals** block (`PLAN_VALID`, `REVIEW_UPDATED`, `REPORT_CREATED`, `VALIDATION_RUN`, `REPORT_COMMITTED`) keyed to `## Success Criteria`. `REPORT_COMMITTED` is `n/a` (non-blocking) in `--no-worktree` mode where no auto-commit happens.
- **Phase 7** prints an explicit `Open remaining: <M - X - Y>` reconciliation line so the issue's `Eligible == Fixed + Failed` signal is directly observable in the transcript.
- New **`## /goal pairing`** section with artifact-driven prose (no CI loop — the done signal is "no Open findings remain", not `CI_GREEN`), a recommended condition template referencing the printed signals (never file paths), and the shared `goal-pairing.md` reference pointer. Notes that `Failed` findings are terminal (no auto-retry loop).
- `## Success Criteria` annotated to state the keys are emitted verbatim in Phase 7.
- Registered `ycc:review-fix` in `ycc/skills/_shared/references/goal-pairing.md`.
- Regenerated the Cursor / Codex / opencode compatibility bundles.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation

## Testing

- [x] `./scripts/validate.sh` passes clean (exit 0) across all targets — JSON, Cursor, Codex, opencode skill/agent/command/plugin validators, sync-check, and content policy
- [x] `./scripts/sync.sh` regenerated all three bundles; diff scoped to the 2 source files + their 6 regenerated counterparts (no incidental drift in README/inventory)
- [x] Linter passes (lefthook pre-commit: prettier + commitlint)

## Reviewer Notes

- This is a skill-content (source-of-truth) change under `ycc/skills/`; the 6 bundle files are regenerated outputs, not hand-edited.
- The pairing prose deliberately diverges from `pr-autofix` (which has a CI loop): `review-fix` is artifact-driven, so the loop driver is "Open findings remaining" and the closer structural template is `implement-plan` (also no CI loop).
