### PR TITLE
feat: add /goal pairing to ycc:prp-pr --ci and ycc:releaser Phase 8.5

### DIFF
--- a/.codex-plugin/ycc/shared/references/goal-pairing.md
+++ b/.codex-plugin/ycc/shared/references/goal-pairing.md
@@ -2,9 +2,10 @@
 
 Reference for ycc skills that recommend pairing with the platform `/goal` session
 directive for autonomous, loop-to-completion execution — currently `prp-implement`,
-`implement-plan`, `review-fix`, and `pr-autofix`. Each skill cites this doc so the
-transcript-output contract, the condition-template shape, and the caveats stay
-convergent. Fix them here, not per skill.
+`implement-plan`, `review-fix`, `pr-autofix`, `prp-pr` (`--ci` mode only),
+and `releaser` (the bounded Phase 8.5 release-CI loop only — never the human approval
+gates). Each skill cites this doc so the transcript-output contract, the condition-template
+shape, and the caveats stay convergent. Fix them here, not per skill.
 
 ## Transcript-output contract
 

--- a/.codex-plugin/ycc/skills/prp-pr/SKILL.md
+++ b/.codex-plugin/ycc/skills/prp-pr/SKILL.md
@@ -203,7 +203,20 @@ Next steps:
   - gh pr view <number> --web      → open in browser
   - $code-review <number>      → review the PR
   - gh pr merge <number>           → merge when ready
+
+Goal Signals (machine-readable — printed verbatim for /goal)
+PR_IN_SCOPE: <PASS|FAIL>
+PR_URL_PRINTED: <PASS|FAIL>
+CI_GREEN: <PASS|FAIL|n/a>
+CI_BAIL_VISIBLE: <PASS|n/a>
 ```
+
+Print every Goal Signal verbatim, one `KEY: PASS|FAIL` per line, as the **last lines of
+the run**. When `--ci` is set, defer the block to the end of the Phase 7 final report (Step 6) so the CI signals reflect the loop outcome; otherwise emit it here at the end of Phase 6.
+Use `PASS` only when the matching `## Success Criteria` item holds; otherwise `FAIL`. The two
+CI signals are `n/a` when `--ci` was not set; with `--ci`, `CI_GREEN` is `PASS` only when
+Phase 7 reported `green`, and `CI_BAIL_VISIBLE` is `PASS` when a `bail-*` and its `REASON=`
+were printed (otherwise `n/a`).
 
 ---
 
@@ -303,6 +316,47 @@ full policy.
 - **Force push needed**: If remote has diverged and rebase was done, use `git push --force-with-lease` (never `--force`).
 - **Multiple PR templates**: If `.github/PULL_REQUEST_TEMPLATE/` has multiple files, list them and ask user to choose.
 - **Large PR (>20 files)**: Warn about PR size. Suggest splitting if changes are logically separable.
+
+---
+
+## Success Criteria
+
+- **PR_IN_SCOPE**: A PR is in scope for this run — either created in Phase 4, or an existing open PR confirmed for `--ci` monitoring per the Phase 1 continuation.
+- **PR_URL_PRINTED**: The Phase 6 OUTPUT block printed the PR number and URL.
+- **CI_GREEN**: If `--ci` ran, the Phase 7 loop reached `RESULT=green` and the Step 6 report shows `✓ CI green`. `n/a` when `--ci` was not set.
+- **CI_BAIL_VISIBLE**: If `--ci` bailed, the Step 6 report states the `bail-*` code and the cap/constraint that fired. `n/a` when `--ci` reached green or was not set.
+
+These keys are emitted verbatim in the Goal Signals block (end of Phase 6, or end of Phase 7 under `--ci`) so a `/goal` evaluator can observe completion from the transcript alone.
+
+---
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive **only in `--ci` mode**. Without `--ci`, `$prp-pr` is a one-shot create-PR-and-exit flow with nothing to loop on — a `/goal` directive adds no value there. In `--ci` mode, Phase 7 enters the bounded CI auto-fix loop (sharing the `ci-monitor.sh` contract with `pr-autofix` and `releaser`), and `/goal` drives it through every `handoff` fix-and-push and `rerun-pending` flake retry without returning control between iterations.
+
+The Phase 7 loop's stdout `RESULT=` markers tell the evaluator when to keep looping versus when to stop:
+
+- **Keep looping** — `handoff` (apply the fix per the classification table, commit, push to the PR head branch, re-invoke the monitor) and `rerun-pending` (flake suspected; sleep, then re-invoke). These are recoverable progress markers, not endpoints.
+- **Done** — `RESULT=green` (`CI_GREEN: PASS`), with the Phase 6 PR URL block already printed.
+- **Stop** — any `bail-*` (`bail-recurrence`, `bail-nonfixable`, `bail-pushes`, `bail-timeout`). All are terminal: `ci-monitor.sh` exhausts the recoverable `rerun-pending` retries internally before emitting a bail, so a printed `bail-*` means no further automatic progress is possible. The evaluator distinguishes "loop again" from "stop" by `green` vs `bail-*` in the Step 6 report — never by re-classifying bail codes. See `~/.codex/plugins/ycc/shared/references/ci-monitoring.md` for the authoritative bail taxonomy.
+
+Recommended condition template (`--ci` mode):
+
+```
+/goal Run $prp-pr <base> --ci using the prp-pr workflow, continuing through every
+handoff and rerun-pending iteration of the Phase 7 CI loop without returning control to me.
+Done when the transcript shows the Phase 6 OUTPUT with the PR number and URL, followed by the
+Goal Signals printed verbatim — PR_IN_SCOPE: PASS, PR_URL_PRINTED: PASS, and CI_GREEN: PASS.
+If CI_GREEN prints FAIL alongside CI_BAIL_VISIBLE: PASS (a terminal bail-* fired), stop and
+report the bail — do not re-run. If any other signal prints FAIL, keep fixing and re-running
+until all are PASS. Stop after 25 turns if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+~/.codex/plugins/ycc/shared/references/goal-pairing.md
+```
 
 ---
 

--- a/.codex-plugin/ycc/skills/releaser/SKILL.md
+++ b/.codex-plugin/ycc/skills/releaser/SKILL.md
@@ -340,6 +340,23 @@ Render a one-time block showing:
 Wait for `yes`/`no`. Any other input aborts the loop and proceeds to Phase 9 with
 "loop declined" status.
 
+#### `/goal` re-confirmation (safety)
+
+If a `/goal` session directive is active when Phase 8.5 is reached, this gate is the
+one human approval the bounded, destructive-capable loop depends on. Therefore:
+
+- **`--ci-yes` does NOT suppress this gate under an active `/goal`.** When `/goal` is
+  active, always render the 8.5.1 block and wait for an explicit `yes`/`no`, even if
+  `--ci-yes` was passed. `--ci-yes` is honored only when no `/goal` directive is active.
+- A `/goal` evaluator is transcript-only and cannot answer this prompt, so the loop
+  **pauses here until you respond in person**. That pause is intentional: `/goal` may
+  drive the Phase 8.5.2+ fix-and-recut loop to green, but it must never auto-authorize
+  entry into that loop. Print one line making the pause legible:
+  `/goal active — Phase 8.5.1 authorization stays interactive; --ci-yes ignored. Waiting for yes/no.`
+- This guard applies **only** to the post-publish CI loop. The Phase 2 version confirm
+  and the Phase 5 manifest diff review are likewise never auto-approved under `/goal`;
+  see `## /goal pairing` for the full out-of-scope list.
+
 ### 8.5.2 Loop protocol
 
 1. Initialize audit log:
@@ -465,6 +482,66 @@ Report to the user:
   (with reason and cap that fired), `loop-blocked`, `declined`, or `skipped` (no
   successful publish). Include the audit log path so the user can inspect it.
 - The exact command block from Phase 8.
+
+Then, as the **last lines** of the summary, print the Goal Signals block verbatim:
+
+```
+Goal Signals (machine-readable — printed verbatim for /goal)
+RELEASE_PUBLISHED: <PASS|FAIL|n/a>
+GATES_INTERACTIVE: <PASS|FAIL>
+CI_GREEN: <PASS|FAIL|n/a>
+CI_BAIL_VISIBLE: <PASS|n/a>
+AUDIT_LOG_PRINTED: <PASS|FAIL|n/a>
+```
+
+Print one `KEY: PASS|FAIL` per line. Use `PASS` only when the matching `## Success
+Criteria` item holds; otherwise `FAIL`. See `## Success Criteria` for each key's exact
+condition and `n/a` rules.
+
+## Success Criteria
+
+- **RELEASE_PUBLISHED**: `--publish --confirm` ran and `publish-release.sh --confirm` exited 0 (the release exists on GitHub). `n/a` when `--publish` was not set or ran in preview-only mode.
+- **GATES_INTERACTIVE**: Every human gate that applied this run — Phase 2 version confirm, Phase 5 manifest diff review, and the Phase 8.5.1 authorization — was satisfied by explicit user input and **none** was auto-approved or bypassed (including under an active `/goal`). `FAIL` if any applicable gate was skipped without a human `yes`. This is the safety invariant that keeps `/goal` from wrapping the whole skill.
+- **CI_GREEN**: If `--ci` ran, the Phase 8.5 loop reached `RESULT=green` and the Phase 9 summary shows "Release CI loop outcome: `green`". `n/a` when `--ci` was not set or the loop was skipped (no successful publish).
+- **CI_BAIL_VISIBLE**: If `--ci` ended without green, the summary states the terminal outcome (`bail-*`, `loop-blocked`, or `declined`) and the cap/constraint that fired. `n/a` when `--ci` reached green or was not set.
+- **AUDIT_LOG_PRINTED**: If `--ci` ran, the Phase 9 summary printed the audit-log path. `n/a` when `--ci` was not set or the loop was skipped.
+
+These keys are emitted verbatim in the Phase 9 Goal Signals block so a `/goal` evaluator can observe completion from the transcript alone.
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive **only for the bounded Phase 8.5 release-CI auto-fix loop** — never for the skill as a whole. The full `releaser` flow has three human approval gates that exist specifically to prevent unattended publishing and looping; `/goal` must never auto-satisfy them:
+
+- **Phase 2 — version confirm.** The user must approve the proposed version bump.
+- **Phase 5 — manifest diff review.** The user must approve what changed before any commit.
+- **Phase 8.5.1 — CI authorization gate.** The user must approve before the bounded, destructive-capable loop starts. `--ci-yes` does **not** bypass this gate under an active `/goal` (see the 8.5.1 `/goal` re-confirmation guard).
+
+Because the `/goal` evaluator is transcript-only it cannot answer these prompts, so a `/goal` loop will **pause** at each gate until you respond in person. That is the intended behavior: only after you have published (`--publish --confirm`) and authorized the loop does `/goal` add value — driving Phase 8.5.2+ through every `handoff` fix-and-recut and `rerun-pending` retry to green without returning control between iterations. The `GATES_INTERACTIVE` Goal Signal records that none of the three gates was auto-approved.
+
+The Phase 8.5 loop's `RESULT=` markers (from `release-ci-monitor.sh`, sharing the `ci-monitor.sh` contract with `pr-autofix` and `prp-pr`) tell the evaluator when to keep looping versus when to stop:
+
+- **Keep looping** — `handoff` (8.5.3 fix-and-recut) and `rerun-pending` (8.5.2 wait-and-retry). Recoverable progress markers, not endpoints.
+- **Done** — `RESULT=green`, with the Phase 9 summary showing "Release CI loop outcome: `green`" and the audit-log path (`CI_GREEN: PASS`, `AUDIT_LOG_PRINTED: PASS`).
+- **Stop** — any terminal `bail-*` (`bail-recurrence`, `bail-nonfixable`, `bail-pushes`, `bail-timeout`, `not-found`) or `loop-blocked`. `release-ci-monitor.sh` exhausts recoverable retries internally before emitting a bail, so a printed terminal marker means no further automatic progress is possible. The evaluator distinguishes "loop again" from "stop" by `green` vs `bail-*`/`loop-blocked` in the Phase 9 summary — never by re-classifying bail codes. See [`../_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md) ("Release mode") for the authoritative bail taxonomy.
+
+Recommended condition template (set this **after** you have approved Phases 2 and 5, published with `--publish --confirm`, and authorized the loop at 8.5.1):
+
+```
+/goal Drive the releaser Phase 8.5 release-CI loop to green, continuing through every
+handoff and rerun-pending iteration without returning control to me. Done when the Phase 9
+summary shows "Release CI loop outcome: green", the audit-log path is printed, and the Goal
+Signals print verbatim — GATES_INTERACTIVE: PASS, CI_GREEN: PASS, and AUDIT_LOG_PRINTED:
+PASS. If CI_GREEN prints FAIL alongside CI_BAIL_VISIBLE: PASS (a terminal bail-*, loop-blocked,
+or declined), stop and report it — do not re-run. Never auto-approve the Phase 2 version
+confirm, the Phase 5 manifest review, or the Phase 8.5.1 authorization. Stop after 25 turns
+if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+~/.codex/plugins/ycc/shared/references/goal-pairing.md
+```
 
 ## Important Notes
 

--- a/.cursor-plugin/skills/_shared/references/goal-pairing.md
+++ b/.cursor-plugin/skills/_shared/references/goal-pairing.md
@@ -2,9 +2,10 @@
 
 Reference for ycc skills that recommend pairing with the platform `/goal` session
 directive for autonomous, loop-to-completion execution — currently `prp-implement`,
-`implement-plan`, `review-fix`, and `pr-autofix`. Each skill cites this doc so the
-transcript-output contract, the condition-template shape, and the caveats stay
-convergent. Fix them here, not per skill.
+`implement-plan`, `review-fix`, `pr-autofix`, `prp-pr` (`--ci` mode only),
+and `releaser` (the bounded Phase 8.5 release-CI loop only — never the human approval
+gates). Each skill cites this doc so the transcript-output contract, the condition-template
+shape, and the caveats stay convergent. Fix them here, not per skill.
 
 ## Transcript-output contract
 

--- a/.cursor-plugin/skills/prp-pr/SKILL.md
+++ b/.cursor-plugin/skills/prp-pr/SKILL.md
@@ -211,7 +211,20 @@ Next steps:
   - gh pr view <number> --web      → open in browser
   - /code-review <number>      → review the PR
   - gh pr merge <number>           → merge when ready
+
+Goal Signals (machine-readable — printed verbatim for /goal)
+PR_IN_SCOPE: <PASS|FAIL>
+PR_URL_PRINTED: <PASS|FAIL>
+CI_GREEN: <PASS|FAIL|n/a>
+CI_BAIL_VISIBLE: <PASS|n/a>
 ```
+
+Print every Goal Signal verbatim, one `KEY: PASS|FAIL` per line, as the **last lines of
+the run**. When `--ci` is set, defer the block to the end of the Phase 7 final report (Step 6) so the CI signals reflect the loop outcome; otherwise emit it here at the end of Phase 6.
+Use `PASS` only when the matching `## Success Criteria` item holds; otherwise `FAIL`. The two
+CI signals are `n/a` when `--ci` was not set; with `--ci`, `CI_GREEN` is `PASS` only when
+Phase 7 reported `green`, and `CI_BAIL_VISIBLE` is `PASS` when a `bail-*` and its `REASON=`
+were printed (otherwise `n/a`).
 
 ---
 
@@ -311,6 +324,47 @@ full policy.
 - **Force push needed**: If remote has diverged and rebase was done, use `git push --force-with-lease` (never `--force`).
 - **Multiple PR templates**: If `.github/PULL_REQUEST_TEMPLATE/` has multiple files, list them and ask user to choose.
 - **Large PR (>20 files)**: Warn about PR size. Suggest splitting if changes are logically separable.
+
+---
+
+## Success Criteria
+
+- **PR_IN_SCOPE**: A PR is in scope for this run — either created in Phase 4, or an existing open PR confirmed for `--ci` monitoring per the Phase 1 continuation.
+- **PR_URL_PRINTED**: The Phase 6 OUTPUT block printed the PR number and URL.
+- **CI_GREEN**: If `--ci` ran, the Phase 7 loop reached `RESULT=green` and the Step 6 report shows `✓ CI green`. `n/a` when `--ci` was not set.
+- **CI_BAIL_VISIBLE**: If `--ci` bailed, the Step 6 report states the `bail-*` code and the cap/constraint that fired. `n/a` when `--ci` reached green or was not set.
+
+These keys are emitted verbatim in the Goal Signals block (end of Phase 6, or end of Phase 7 under `--ci`) so a `/goal` evaluator can observe completion from the transcript alone.
+
+---
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive **only in `--ci` mode**. Without `--ci`, `/prp-pr` is a one-shot create-PR-and-exit flow with nothing to loop on — a `/goal` directive adds no value there. In `--ci` mode, Phase 7 enters the bounded CI auto-fix loop (sharing the `ci-monitor.sh` contract with `pr-autofix` and `releaser`), and `/goal` drives it through every `handoff` fix-and-push and `rerun-pending` flake retry without returning control between iterations.
+
+The Phase 7 loop's stdout `RESULT=` markers tell the evaluator when to keep looping versus when to stop:
+
+- **Keep looping** — `handoff` (apply the fix per the classification table, commit, push to the PR head branch, re-invoke the monitor) and `rerun-pending` (flake suspected; sleep, then re-invoke). These are recoverable progress markers, not endpoints.
+- **Done** — `RESULT=green` (`CI_GREEN: PASS`), with the Phase 6 PR URL block already printed.
+- **Stop** — any `bail-*` (`bail-recurrence`, `bail-nonfixable`, `bail-pushes`, `bail-timeout`). All are terminal: `ci-monitor.sh` exhausts the recoverable `rerun-pending` retries internally before emitting a bail, so a printed `bail-*` means no further automatic progress is possible. The evaluator distinguishes "loop again" from "stop" by `green` vs `bail-*` in the Step 6 report — never by re-classifying bail codes. See `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/ci-monitoring.md` for the authoritative bail taxonomy.
+
+Recommended condition template (`--ci` mode):
+
+```
+/goal Run /prp-pr <base> --ci using the prp-pr workflow, continuing through every
+handoff and rerun-pending iteration of the Phase 7 CI loop without returning control to me.
+Done when the transcript shows the Phase 6 OUTPUT with the PR number and URL, followed by the
+Goal Signals printed verbatim — PR_IN_SCOPE: PASS, PR_URL_PRINTED: PASS, and CI_GREEN: PASS.
+If CI_GREEN prints FAIL alongside CI_BAIL_VISIBLE: PASS (a terminal bail-* fired), stop and
+report the bail — do not re-run. If any other signal prints FAIL, keep fixing and re-running
+until all are PASS. Stop after 25 turns if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+${CURSOR_PLUGIN_ROOT}/skills/_shared/references/goal-pairing.md
+```
 
 ---
 

--- a/.cursor-plugin/skills/releaser/SKILL.md
+++ b/.cursor-plugin/skills/releaser/SKILL.md
@@ -351,6 +351,23 @@ Render a one-time block showing:
 Wait for `yes`/`no`. Any other input aborts the loop and proceeds to Phase 9 with
 "loop declined" status.
 
+#### `/goal` re-confirmation (safety)
+
+If a `/goal` session directive is active when Phase 8.5 is reached, this gate is the
+one human approval the bounded, destructive-capable loop depends on. Therefore:
+
+- **`--ci-yes` does NOT suppress this gate under an active `/goal`.** When `/goal` is
+  active, always render the 8.5.1 block and wait for an explicit `yes`/`no`, even if
+  `--ci-yes` was passed. `--ci-yes` is honored only when no `/goal` directive is active.
+- A `/goal` evaluator is transcript-only and cannot answer this prompt, so the loop
+  **pauses here until you respond in person**. That pause is intentional: `/goal` may
+  drive the Phase 8.5.2+ fix-and-recut loop to green, but it must never auto-authorize
+  entry into that loop. Print one line making the pause legible:
+  `/goal active — Phase 8.5.1 authorization stays interactive; --ci-yes ignored. Waiting for yes/no.`
+- This guard applies **only** to the post-publish CI loop. The Phase 2 version confirm
+  and the Phase 5 manifest diff review are likewise never auto-approved under `/goal`;
+  see `## /goal pairing` for the full out-of-scope list.
+
 ### 8.5.2 Loop protocol
 
 1. Initialize audit log:
@@ -476,6 +493,66 @@ Report to the user:
   (with reason and cap that fired), `loop-blocked`, `declined`, or `skipped` (no
   successful publish). Include the audit log path so the user can inspect it.
 - The exact command block from Phase 8.
+
+Then, as the **last lines** of the summary, print the Goal Signals block verbatim:
+
+```
+Goal Signals (machine-readable — printed verbatim for /goal)
+RELEASE_PUBLISHED: <PASS|FAIL|n/a>
+GATES_INTERACTIVE: <PASS|FAIL>
+CI_GREEN: <PASS|FAIL|n/a>
+CI_BAIL_VISIBLE: <PASS|n/a>
+AUDIT_LOG_PRINTED: <PASS|FAIL|n/a>
+```
+
+Print one `KEY: PASS|FAIL` per line. Use `PASS` only when the matching `## Success
+Criteria` item holds; otherwise `FAIL`. See `## Success Criteria` for each key's exact
+condition and `n/a` rules.
+
+## Success Criteria
+
+- **RELEASE_PUBLISHED**: `--publish --confirm` ran and `publish-release.sh --confirm` exited 0 (the release exists on GitHub). `n/a` when `--publish` was not set or ran in preview-only mode.
+- **GATES_INTERACTIVE**: Every human gate that applied this run — Phase 2 version confirm, Phase 5 manifest diff review, and the Phase 8.5.1 authorization — was satisfied by explicit user input and **none** was auto-approved or bypassed (including under an active `/goal`). `FAIL` if any applicable gate was skipped without a human `yes`. This is the safety invariant that keeps `/goal` from wrapping the whole skill.
+- **CI_GREEN**: If `--ci` ran, the Phase 8.5 loop reached `RESULT=green` and the Phase 9 summary shows "Release CI loop outcome: `green`". `n/a` when `--ci` was not set or the loop was skipped (no successful publish).
+- **CI_BAIL_VISIBLE**: If `--ci` ended without green, the summary states the terminal outcome (`bail-*`, `loop-blocked`, or `declined`) and the cap/constraint that fired. `n/a` when `--ci` reached green or was not set.
+- **AUDIT_LOG_PRINTED**: If `--ci` ran, the Phase 9 summary printed the audit-log path. `n/a` when `--ci` was not set or the loop was skipped.
+
+These keys are emitted verbatim in the Phase 9 Goal Signals block so a `/goal` evaluator can observe completion from the transcript alone.
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive **only for the bounded Phase 8.5 release-CI auto-fix loop** — never for the skill as a whole. The full `releaser` flow has three human approval gates that exist specifically to prevent unattended publishing and looping; `/goal` must never auto-satisfy them:
+
+- **Phase 2 — version confirm.** The user must approve the proposed version bump.
+- **Phase 5 — manifest diff review.** The user must approve what changed before any commit.
+- **Phase 8.5.1 — CI authorization gate.** The user must approve before the bounded, destructive-capable loop starts. `--ci-yes` does **not** bypass this gate under an active `/goal` (see the 8.5.1 `/goal` re-confirmation guard).
+
+Because the `/goal` evaluator is transcript-only it cannot answer these prompts, so a `/goal` loop will **pause** at each gate until you respond in person. That is the intended behavior: only after you have published (`--publish --confirm`) and authorized the loop does `/goal` add value — driving Phase 8.5.2+ through every `handoff` fix-and-recut and `rerun-pending` retry to green without returning control between iterations. The `GATES_INTERACTIVE` Goal Signal records that none of the three gates was auto-approved.
+
+The Phase 8.5 loop's `RESULT=` markers (from `release-ci-monitor.sh`, sharing the `ci-monitor.sh` contract with `pr-autofix` and `prp-pr`) tell the evaluator when to keep looping versus when to stop:
+
+- **Keep looping** — `handoff` (8.5.3 fix-and-recut) and `rerun-pending` (8.5.2 wait-and-retry). Recoverable progress markers, not endpoints.
+- **Done** — `RESULT=green`, with the Phase 9 summary showing "Release CI loop outcome: `green`" and the audit-log path (`CI_GREEN: PASS`, `AUDIT_LOG_PRINTED: PASS`).
+- **Stop** — any terminal `bail-*` (`bail-recurrence`, `bail-nonfixable`, `bail-pushes`, `bail-timeout`, `not-found`) or `loop-blocked`. `release-ci-monitor.sh` exhausts recoverable retries internally before emitting a bail, so a printed terminal marker means no further automatic progress is possible. The evaluator distinguishes "loop again" from "stop" by `green` vs `bail-*`/`loop-blocked` in the Phase 9 summary — never by re-classifying bail codes. See [`../_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md) ("Release mode") for the authoritative bail taxonomy.
+
+Recommended condition template (set this **after** you have approved Phases 2 and 5, published with `--publish --confirm`, and authorized the loop at 8.5.1):
+
+```
+/goal Drive the releaser Phase 8.5 release-CI loop to green, continuing through every
+handoff and rerun-pending iteration without returning control to me. Done when the Phase 9
+summary shows "Release CI loop outcome: green", the audit-log path is printed, and the Goal
+Signals print verbatim — GATES_INTERACTIVE: PASS, CI_GREEN: PASS, and AUDIT_LOG_PRINTED:
+PASS. If CI_GREEN prints FAIL alongside CI_BAIL_VISIBLE: PASS (a terminal bail-*, loop-blocked,
+or declined), stop and report it — do not re-run. Never auto-approve the Phase 2 version
+confirm, the Phase 5 manifest review, or the Phase 8.5.1 authorization. Stop after 25 turns
+if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+${CURSOR_PLUGIN_ROOT}/skills/_shared/references/goal-pairing.md
+```
 
 ## Important Notes
 

--- a/.opencode-plugin/shared/references/goal-pairing.md
+++ b/.opencode-plugin/shared/references/goal-pairing.md
@@ -2,9 +2,10 @@
 
 Reference for ycc skills that recommend pairing with the platform `/goal` session
 directive for autonomous, loop-to-completion execution — currently `prp-implement`,
-`implement-plan`, `review-fix`, and `pr-autofix`. Each skill cites this doc so the
-transcript-output contract, the condition-template shape, and the caveats stay
-convergent. Fix them here, not per skill.
+`implement-plan`, `review-fix`, `pr-autofix`, `prp-pr` (`--ci` mode only),
+and `releaser` (the bounded Phase 8.5 release-CI loop only — never the human approval
+gates). Each skill cites this doc so the transcript-output contract, the condition-template
+shape, and the caveats stay convergent. Fix them here, not per skill.
 
 ## Transcript-output contract
 

--- a/.opencode-plugin/skills/prp-pr/SKILL.md
+++ b/.opencode-plugin/skills/prp-pr/SKILL.md
@@ -203,7 +203,20 @@ Next steps:
   - gh pr view <number> --web      → open in browser
   - /code-review <number>      → review the PR
   - gh pr merge <number>           → merge when ready
+
+Goal Signals (machine-readable — printed verbatim for /goal)
+PR_IN_SCOPE: <PASS|FAIL>
+PR_URL_PRINTED: <PASS|FAIL>
+CI_GREEN: <PASS|FAIL|n/a>
+CI_BAIL_VISIBLE: <PASS|n/a>
 ```
+
+Print every Goal Signal verbatim, one `KEY: PASS|FAIL` per line, as the **last lines of
+the run**. When `--ci` is set, defer the block to the end of the Phase 7 final report (Step 6) so the CI signals reflect the loop outcome; otherwise emit it here at the end of Phase 6.
+Use `PASS` only when the matching `## Success Criteria` item holds; otherwise `FAIL`. The two
+CI signals are `n/a` when `--ci` was not set; with `--ci`, `CI_GREEN` is `PASS` only when
+Phase 7 reported `green`, and `CI_BAIL_VISIBLE` is `PASS` when a `bail-*` and its `REASON=`
+were printed (otherwise `n/a`).
 
 ---
 
@@ -303,6 +316,47 @@ full policy.
 - **Force push needed**: If remote has diverged and rebase was done, use `git push --force-with-lease` (never `--force`).
 - **Multiple PR templates**: If `.github/PULL_REQUEST_TEMPLATE/` has multiple files, list them and ask user to choose.
 - **Large PR (>20 files)**: Warn about PR size. Suggest splitting if changes are logically separable.
+
+---
+
+## Success Criteria
+
+- **PR_IN_SCOPE**: A PR is in scope for this run — either created in Phase 4, or an existing open PR confirmed for `--ci` monitoring per the Phase 1 continuation.
+- **PR_URL_PRINTED**: The Phase 6 OUTPUT block printed the PR number and URL.
+- **CI_GREEN**: If `--ci` ran, the Phase 7 loop reached `RESULT=green` and the Step 6 report shows `✓ CI green`. `n/a` when `--ci` was not set.
+- **CI_BAIL_VISIBLE**: If `--ci` bailed, the Step 6 report states the `bail-*` code and the cap/constraint that fired. `n/a` when `--ci` reached green or was not set.
+
+These keys are emitted verbatim in the Goal Signals block (end of Phase 6, or end of Phase 7 under `--ci`) so a `/goal` evaluator can observe completion from the transcript alone.
+
+---
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive **only in `--ci` mode**. Without `--ci`, `/prp-pr` is a one-shot create-PR-and-exit flow with nothing to loop on — a `/goal` directive adds no value there. In `--ci` mode, Phase 7 enters the bounded CI auto-fix loop (sharing the `ci-monitor.sh` contract with `pr-autofix` and `releaser`), and `/goal` drives it through every `handoff` fix-and-push and `rerun-pending` flake retry without returning control between iterations.
+
+The Phase 7 loop's stdout `RESULT=` markers tell the evaluator when to keep looping versus when to stop:
+
+- **Keep looping** — `handoff` (apply the fix per the classification table, commit, push to the PR head branch, re-invoke the monitor) and `rerun-pending` (flake suspected; sleep, then re-invoke). These are recoverable progress markers, not endpoints.
+- **Done** — `RESULT=green` (`CI_GREEN: PASS`), with the Phase 6 PR URL block already printed.
+- **Stop** — any `bail-*` (`bail-recurrence`, `bail-nonfixable`, `bail-pushes`, `bail-timeout`). All are terminal: `ci-monitor.sh` exhausts the recoverable `rerun-pending` retries internally before emitting a bail, so a printed `bail-*` means no further automatic progress is possible. The evaluator distinguishes "loop again" from "stop" by `green` vs `bail-*` in the Step 6 report — never by re-classifying bail codes. See `~/.config/opencode/shared/references/ci-monitoring.md` for the authoritative bail taxonomy.
+
+Recommended condition template (`--ci` mode):
+
+```
+/goal Run /prp-pr <base> --ci using the prp-pr workflow, continuing through every
+handoff and rerun-pending iteration of the Phase 7 CI loop without returning control to me.
+Done when the transcript shows the Phase 6 OUTPUT with the PR number and URL, followed by the
+Goal Signals printed verbatim — PR_IN_SCOPE: PASS, PR_URL_PRINTED: PASS, and CI_GREEN: PASS.
+If CI_GREEN prints FAIL alongside CI_BAIL_VISIBLE: PASS (a terminal bail-* fired), stop and
+report the bail — do not re-run. If any other signal prints FAIL, keep fixing and re-running
+until all are PASS. Stop after 25 turns if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+~/.config/opencode/shared/references/goal-pairing.md
+```
 
 ---
 

--- a/.opencode-plugin/skills/releaser/SKILL.md
+++ b/.opencode-plugin/skills/releaser/SKILL.md
@@ -340,6 +340,23 @@ Render a one-time block showing:
 Wait for `yes`/`no`. Any other input aborts the loop and proceeds to Phase 9 with
 "loop declined" status.
 
+#### `/goal` re-confirmation (safety)
+
+If a `/goal` session directive is active when Phase 8.5 is reached, this gate is the
+one human approval the bounded, destructive-capable loop depends on. Therefore:
+
+- **`--ci-yes` does NOT suppress this gate under an active `/goal`.** When `/goal` is
+  active, always render the 8.5.1 block and wait for an explicit `yes`/`no`, even if
+  `--ci-yes` was passed. `--ci-yes` is honored only when no `/goal` directive is active.
+- A `/goal` evaluator is transcript-only and cannot answer this prompt, so the loop
+  **pauses here until you respond in person**. That pause is intentional: `/goal` may
+  drive the Phase 8.5.2+ fix-and-recut loop to green, but it must never auto-authorize
+  entry into that loop. Print one line making the pause legible:
+  `/goal active — Phase 8.5.1 authorization stays interactive; --ci-yes ignored. Waiting for yes/no.`
+- This guard applies **only** to the post-publish CI loop. The Phase 2 version confirm
+  and the Phase 5 manifest diff review are likewise never auto-approved under `/goal`;
+  see `## /goal pairing` for the full out-of-scope list.
+
 ### 8.5.2 Loop protocol
 
 1. Initialize audit log:
@@ -465,6 +482,66 @@ Report to the user:
   (with reason and cap that fired), `loop-blocked`, `declined`, or `skipped` (no
   successful publish). Include the audit log path so the user can inspect it.
 - The exact command block from Phase 8.
+
+Then, as the **last lines** of the summary, print the Goal Signals block verbatim:
+
+```
+Goal Signals (machine-readable — printed verbatim for /goal)
+RELEASE_PUBLISHED: <PASS|FAIL|n/a>
+GATES_INTERACTIVE: <PASS|FAIL>
+CI_GREEN: <PASS|FAIL|n/a>
+CI_BAIL_VISIBLE: <PASS|n/a>
+AUDIT_LOG_PRINTED: <PASS|FAIL|n/a>
+```
+
+Print one `KEY: PASS|FAIL` per line. Use `PASS` only when the matching `## Success
+Criteria` item holds; otherwise `FAIL`. See `## Success Criteria` for each key's exact
+condition and `n/a` rules.
+
+## Success Criteria
+
+- **RELEASE_PUBLISHED**: `--publish --confirm` ran and `publish-release.sh --confirm` exited 0 (the release exists on GitHub). `n/a` when `--publish` was not set or ran in preview-only mode.
+- **GATES_INTERACTIVE**: Every human gate that applied this run — Phase 2 version confirm, Phase 5 manifest diff review, and the Phase 8.5.1 authorization — was satisfied by explicit user input and **none** was auto-approved or bypassed (including under an active `/goal`). `FAIL` if any applicable gate was skipped without a human `yes`. This is the safety invariant that keeps `/goal` from wrapping the whole skill.
+- **CI_GREEN**: If `--ci` ran, the Phase 8.5 loop reached `RESULT=green` and the Phase 9 summary shows "Release CI loop outcome: `green`". `n/a` when `--ci` was not set or the loop was skipped (no successful publish).
+- **CI_BAIL_VISIBLE**: If `--ci` ended without green, the summary states the terminal outcome (`bail-*`, `loop-blocked`, or `declined`) and the cap/constraint that fired. `n/a` when `--ci` reached green or was not set.
+- **AUDIT_LOG_PRINTED**: If `--ci` ran, the Phase 9 summary printed the audit-log path. `n/a` when `--ci` was not set or the loop was skipped.
+
+These keys are emitted verbatim in the Phase 9 Goal Signals block so a `/goal` evaluator can observe completion from the transcript alone.
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive **only for the bounded Phase 8.5 release-CI auto-fix loop** — never for the skill as a whole. The full `releaser` flow has three human approval gates that exist specifically to prevent unattended publishing and looping; `/goal` must never auto-satisfy them:
+
+- **Phase 2 — version confirm.** The user must approve the proposed version bump.
+- **Phase 5 — manifest diff review.** The user must approve what changed before any commit.
+- **Phase 8.5.1 — CI authorization gate.** The user must approve before the bounded, destructive-capable loop starts. `--ci-yes` does **not** bypass this gate under an active `/goal` (see the 8.5.1 `/goal` re-confirmation guard).
+
+Because the `/goal` evaluator is transcript-only it cannot answer these prompts, so a `/goal` loop will **pause** at each gate until you respond in person. That is the intended behavior: only after you have published (`--publish --confirm`) and authorized the loop does `/goal` add value — driving Phase 8.5.2+ through every `handoff` fix-and-recut and `rerun-pending` retry to green without returning control between iterations. The `GATES_INTERACTIVE` Goal Signal records that none of the three gates was auto-approved.
+
+The Phase 8.5 loop's `RESULT=` markers (from `release-ci-monitor.sh`, sharing the `ci-monitor.sh` contract with `pr-autofix` and `prp-pr`) tell the evaluator when to keep looping versus when to stop:
+
+- **Keep looping** — `handoff` (8.5.3 fix-and-recut) and `rerun-pending` (8.5.2 wait-and-retry). Recoverable progress markers, not endpoints.
+- **Done** — `RESULT=green`, with the Phase 9 summary showing "Release CI loop outcome: `green`" and the audit-log path (`CI_GREEN: PASS`, `AUDIT_LOG_PRINTED: PASS`).
+- **Stop** — any terminal `bail-*` (`bail-recurrence`, `bail-nonfixable`, `bail-pushes`, `bail-timeout`, `not-found`) or `loop-blocked`. `release-ci-monitor.sh` exhausts recoverable retries internally before emitting a bail, so a printed terminal marker means no further automatic progress is possible. The evaluator distinguishes "loop again" from "stop" by `green` vs `bail-*`/`loop-blocked` in the Phase 9 summary — never by re-classifying bail codes. See [`../_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md) ("Release mode") for the authoritative bail taxonomy.
+
+Recommended condition template (set this **after** you have approved Phases 2 and 5, published with `--publish --confirm`, and authorized the loop at 8.5.1):
+
+```
+/goal Drive the releaser Phase 8.5 release-CI loop to green, continuing through every
+handoff and rerun-pending iteration without returning control to me. Done when the Phase 9
+summary shows "Release CI loop outcome: green", the audit-log path is printed, and the Goal
+Signals print verbatim — GATES_INTERACTIVE: PASS, CI_GREEN: PASS, and AUDIT_LOG_PRINTED:
+PASS. If CI_GREEN prints FAIL alongside CI_BAIL_VISIBLE: PASS (a terminal bail-*, loop-blocked,
+or declined), stop and report it — do not re-run. Never auto-approve the Phase 2 version
+confirm, the Phase 5 manifest review, or the Phase 8.5.1 authorization. Stop after 25 turns
+if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+~/.config/opencode/shared/references/goal-pairing.md
+```
 
 ## Important Notes
 

--- a/ycc/skills/_shared/references/goal-pairing.md
+++ b/ycc/skills/_shared/references/goal-pairing.md
@@ -2,9 +2,10 @@
 
 Reference for ycc skills that recommend pairing with the platform `/goal` session
 directive for autonomous, loop-to-completion execution — currently `ycc:prp-implement`,
-`ycc:implement-plan`, `ycc:review-fix`, and `ycc:pr-autofix`. Each skill cites this doc so the
-transcript-output contract, the condition-template shape, and the caveats stay
-convergent. Fix them here, not per skill.
+`ycc:implement-plan`, `ycc:review-fix`, `ycc:pr-autofix`, `ycc:prp-pr` (`--ci` mode only),
+and `ycc:releaser` (the bounded Phase 8.5 release-CI loop only — never the human approval
+gates). Each skill cites this doc so the transcript-output contract, the condition-template
+shape, and the caveats stay convergent. Fix them here, not per skill.
 
 ## Transcript-output contract
 

--- a/ycc/skills/prp-pr/SKILL.md
+++ b/ycc/skills/prp-pr/SKILL.md
@@ -211,7 +211,20 @@ Next steps:
   - gh pr view <number> --web      → open in browser
   - /ycc:code-review <number>      → review the PR
   - gh pr merge <number>           → merge when ready
+
+Goal Signals (machine-readable — printed verbatim for /goal)
+PR_IN_SCOPE: <PASS|FAIL>
+PR_URL_PRINTED: <PASS|FAIL>
+CI_GREEN: <PASS|FAIL|n/a>
+CI_BAIL_VISIBLE: <PASS|n/a>
 ```
+
+Print every Goal Signal verbatim, one `KEY: PASS|FAIL` per line, as the **last lines of
+the run**. When `--ci` is set, defer the block to the end of the Phase 7 final report (Step 6) so the CI signals reflect the loop outcome; otherwise emit it here at the end of Phase 6.
+Use `PASS` only when the matching `## Success Criteria` item holds; otherwise `FAIL`. The two
+CI signals are `n/a` when `--ci` was not set; with `--ci`, `CI_GREEN` is `PASS` only when
+Phase 7 reported `green`, and `CI_BAIL_VISIBLE` is `PASS` when a `bail-*` and its `REASON=`
+were printed (otherwise `n/a`).
 
 ---
 
@@ -311,6 +324,47 @@ full policy.
 - **Force push needed**: If remote has diverged and rebase was done, use `git push --force-with-lease` (never `--force`).
 - **Multiple PR templates**: If `.github/PULL_REQUEST_TEMPLATE/` has multiple files, list them and ask user to choose.
 - **Large PR (>20 files)**: Warn about PR size. Suggest splitting if changes are logically separable.
+
+---
+
+## Success Criteria
+
+- **PR_IN_SCOPE**: A PR is in scope for this run — either created in Phase 4, or an existing open PR confirmed for `--ci` monitoring per the Phase 1 continuation.
+- **PR_URL_PRINTED**: The Phase 6 OUTPUT block printed the PR number and URL.
+- **CI_GREEN**: If `--ci` ran, the Phase 7 loop reached `RESULT=green` and the Step 6 report shows `✓ CI green`. `n/a` when `--ci` was not set.
+- **CI_BAIL_VISIBLE**: If `--ci` bailed, the Step 6 report states the `bail-*` code and the cap/constraint that fired. `n/a` when `--ci` reached green or was not set.
+
+These keys are emitted verbatim in the Goal Signals block (end of Phase 6, or end of Phase 7 under `--ci`) so a `/goal` evaluator can observe completion from the transcript alone.
+
+---
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive **only in `--ci` mode**. Without `--ci`, `/ycc:prp-pr` is a one-shot create-PR-and-exit flow with nothing to loop on — a `/goal` directive adds no value there. In `--ci` mode, Phase 7 enters the bounded CI auto-fix loop (sharing the `ci-monitor.sh` contract with `ycc:pr-autofix` and `ycc:releaser`), and `/goal` drives it through every `handoff` fix-and-push and `rerun-pending` flake retry without returning control between iterations.
+
+The Phase 7 loop's stdout `RESULT=` markers tell the evaluator when to keep looping versus when to stop:
+
+- **Keep looping** — `handoff` (apply the fix per the classification table, commit, push to the PR head branch, re-invoke the monitor) and `rerun-pending` (flake suspected; sleep, then re-invoke). These are recoverable progress markers, not endpoints.
+- **Done** — `RESULT=green` (`CI_GREEN: PASS`), with the Phase 6 PR URL block already printed.
+- **Stop** — any `bail-*` (`bail-recurrence`, `bail-nonfixable`, `bail-pushes`, `bail-timeout`). All are terminal: `ci-monitor.sh` exhausts the recoverable `rerun-pending` retries internally before emitting a bail, so a printed `bail-*` means no further automatic progress is possible. The evaluator distinguishes "loop again" from "stop" by `green` vs `bail-*` in the Step 6 report — never by re-classifying bail codes. See `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/ci-monitoring.md` for the authoritative bail taxonomy.
+
+Recommended condition template (`--ci` mode):
+
+```
+/goal Run /ycc:prp-pr <base> --ci using the ycc:prp-pr workflow, continuing through every
+handoff and rerun-pending iteration of the Phase 7 CI loop without returning control to me.
+Done when the transcript shows the Phase 6 OUTPUT with the PR number and URL, followed by the
+Goal Signals printed verbatim — PR_IN_SCOPE: PASS, PR_URL_PRINTED: PASS, and CI_GREEN: PASS.
+If CI_GREEN prints FAIL alongside CI_BAIL_VISIBLE: PASS (a terminal bail-* fired), stop and
+report the bail — do not re-run. If any other signal prints FAIL, keep fixing and re-running
+until all are PASS. Stop after 25 turns if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/goal-pairing.md
+```
 
 ---
 

--- a/ycc/skills/releaser/SKILL.md
+++ b/ycc/skills/releaser/SKILL.md
@@ -351,6 +351,23 @@ Render a one-time block showing:
 Wait for `yes`/`no`. Any other input aborts the loop and proceeds to Phase 9 with
 "loop declined" status.
 
+#### `/goal` re-confirmation (safety)
+
+If a `/goal` session directive is active when Phase 8.5 is reached, this gate is the
+one human approval the bounded, destructive-capable loop depends on. Therefore:
+
+- **`--ci-yes` does NOT suppress this gate under an active `/goal`.** When `/goal` is
+  active, always render the 8.5.1 block and wait for an explicit `yes`/`no`, even if
+  `--ci-yes` was passed. `--ci-yes` is honored only when no `/goal` directive is active.
+- A `/goal` evaluator is transcript-only and cannot answer this prompt, so the loop
+  **pauses here until you respond in person**. That pause is intentional: `/goal` may
+  drive the Phase 8.5.2+ fix-and-recut loop to green, but it must never auto-authorize
+  entry into that loop. Print one line making the pause legible:
+  `/goal active — Phase 8.5.1 authorization stays interactive; --ci-yes ignored. Waiting for yes/no.`
+- This guard applies **only** to the post-publish CI loop. The Phase 2 version confirm
+  and the Phase 5 manifest diff review are likewise never auto-approved under `/goal`;
+  see `## /goal pairing` for the full out-of-scope list.
+
 ### 8.5.2 Loop protocol
 
 1. Initialize audit log:
@@ -476,6 +493,66 @@ Report to the user:
   (with reason and cap that fired), `loop-blocked`, `declined`, or `skipped` (no
   successful publish). Include the audit log path so the user can inspect it.
 - The exact command block from Phase 8.
+
+Then, as the **last lines** of the summary, print the Goal Signals block verbatim:
+
+```
+Goal Signals (machine-readable — printed verbatim for /goal)
+RELEASE_PUBLISHED: <PASS|FAIL|n/a>
+GATES_INTERACTIVE: <PASS|FAIL>
+CI_GREEN: <PASS|FAIL|n/a>
+CI_BAIL_VISIBLE: <PASS|n/a>
+AUDIT_LOG_PRINTED: <PASS|FAIL|n/a>
+```
+
+Print one `KEY: PASS|FAIL` per line. Use `PASS` only when the matching `## Success
+Criteria` item holds; otherwise `FAIL`. See `## Success Criteria` for each key's exact
+condition and `n/a` rules.
+
+## Success Criteria
+
+- **RELEASE_PUBLISHED**: `--publish --confirm` ran and `publish-release.sh --confirm` exited 0 (the release exists on GitHub). `n/a` when `--publish` was not set or ran in preview-only mode.
+- **GATES_INTERACTIVE**: Every human gate that applied this run — Phase 2 version confirm, Phase 5 manifest diff review, and the Phase 8.5.1 authorization — was satisfied by explicit user input and **none** was auto-approved or bypassed (including under an active `/goal`). `FAIL` if any applicable gate was skipped without a human `yes`. This is the safety invariant that keeps `/goal` from wrapping the whole skill.
+- **CI_GREEN**: If `--ci` ran, the Phase 8.5 loop reached `RESULT=green` and the Phase 9 summary shows "Release CI loop outcome: `green`". `n/a` when `--ci` was not set or the loop was skipped (no successful publish).
+- **CI_BAIL_VISIBLE**: If `--ci` ended without green, the summary states the terminal outcome (`bail-*`, `loop-blocked`, or `declined`) and the cap/constraint that fired. `n/a` when `--ci` reached green or was not set.
+- **AUDIT_LOG_PRINTED**: If `--ci` ran, the Phase 9 summary printed the audit-log path. `n/a` when `--ci` was not set or the loop was skipped.
+
+These keys are emitted verbatim in the Phase 9 Goal Signals block so a `/goal` evaluator can observe completion from the transcript alone.
+
+## /goal pairing
+
+Pair this skill with the `/goal` session directive **only for the bounded Phase 8.5 release-CI auto-fix loop** — never for the skill as a whole. The full `ycc:releaser` flow has three human approval gates that exist specifically to prevent unattended publishing and looping; `/goal` must never auto-satisfy them:
+
+- **Phase 2 — version confirm.** The user must approve the proposed version bump.
+- **Phase 5 — manifest diff review.** The user must approve what changed before any commit.
+- **Phase 8.5.1 — CI authorization gate.** The user must approve before the bounded, destructive-capable loop starts. `--ci-yes` does **not** bypass this gate under an active `/goal` (see the 8.5.1 `/goal` re-confirmation guard).
+
+Because the `/goal` evaluator is transcript-only it cannot answer these prompts, so a `/goal` loop will **pause** at each gate until you respond in person. That is the intended behavior: only after you have published (`--publish --confirm`) and authorized the loop does `/goal` add value — driving Phase 8.5.2+ through every `handoff` fix-and-recut and `rerun-pending` retry to green without returning control between iterations. The `GATES_INTERACTIVE` Goal Signal records that none of the three gates was auto-approved.
+
+The Phase 8.5 loop's `RESULT=` markers (from `release-ci-monitor.sh`, sharing the `ci-monitor.sh` contract with `ycc:pr-autofix` and `ycc:prp-pr`) tell the evaluator when to keep looping versus when to stop:
+
+- **Keep looping** — `handoff` (8.5.3 fix-and-recut) and `rerun-pending` (8.5.2 wait-and-retry). Recoverable progress markers, not endpoints.
+- **Done** — `RESULT=green`, with the Phase 9 summary showing "Release CI loop outcome: `green`" and the audit-log path (`CI_GREEN: PASS`, `AUDIT_LOG_PRINTED: PASS`).
+- **Stop** — any terminal `bail-*` (`bail-recurrence`, `bail-nonfixable`, `bail-pushes`, `bail-timeout`, `not-found`) or `loop-blocked`. `release-ci-monitor.sh` exhausts recoverable retries internally before emitting a bail, so a printed terminal marker means no further automatic progress is possible. The evaluator distinguishes "loop again" from "stop" by `green` vs `bail-*`/`loop-blocked` in the Phase 9 summary — never by re-classifying bail codes. See [`../_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md) ("Release mode") for the authoritative bail taxonomy.
+
+Recommended condition template (set this **after** you have approved Phases 2 and 5, published with `--publish --confirm`, and authorized the loop at 8.5.1):
+
+```
+/goal Drive the ycc:releaser Phase 8.5 release-CI loop to green, continuing through every
+handoff and rerun-pending iteration without returning control to me. Done when the Phase 9
+summary shows "Release CI loop outcome: green", the audit-log path is printed, and the Goal
+Signals print verbatim — GATES_INTERACTIVE: PASS, CI_GREEN: PASS, and AUDIT_LOG_PRINTED:
+PASS. If CI_GREEN prints FAIL alongside CI_BAIL_VISIBLE: PASS (a terminal bail-*, loop-blocked,
+or declined), stop and report it — do not re-run. Never auto-approve the Phase 2 version
+confirm, the Phase 5 manifest review, or the Phase 8.5.1 authorization. Stop after 25 turns
+if not achieved.
+```
+
+The transcript-output contract and shared caveats (worktree cwd, interactive failure prompts, platform availability) live in the shared reference — read it before relying on a `/goal` loop:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/goal-pairing.md
+```
 
 ## Important Notes
 


### PR DESCRIPTION
## Summary

Extends the `/goal`-feature audit (issue #92 family) to the two remaining CI-loop skills, following the established 4-part convention already shipped to `prp-implement`, `implement-plan`, `pr-autofix`, and `review-fix` (#100): a verbatim **Goal Signals** block, a `## Success Criteria` section keyed 1:1 to those signals, and a `## /goal pairing` section pointing at the printed signals (never file paths, since the `/goal` evaluator is transcript-only).

Closes #97
Closes #96

## Changes

- **`prp-pr` (#97)** — `/goal` pairing scoped to `--ci` mode only (non-CI is one-shot and needs no loop):
  - Goal Signals block: `PR_IN_SCOPE`, `PR_URL_PRINTED`, `CI_GREEN`, `CI_BAIL_VISIBLE`, printed as the last lines of the run (deferred to the end of Phase 7 under `--ci`).
  - New `## Success Criteria` + `## /goal pairing` sections with a `--ci` condition template and `handoff`/`rerun-pending`/`bail-*` loop semantics; cross-references the shared `ci-monitor.sh` contract with `pr-autofix` and `releaser`.
- **`releaser` (#96)** — `/goal` pairing narrowly scoped to the bounded **Phase 8.5** release-CI loop, never the human approval gates:
  - **Phase 8.5.1 `/goal` re-confirmation guard**: under an active `/goal`, `--ci-yes` no longer suppresses the authorization gate, so the loop pauses for explicit human approval before entering (the evaluator can't answer the prompt — that pause is intentional).
  - Goal Signals block: `RELEASE_PUBLISHED`, `GATES_INTERACTIVE`, `CI_GREEN`, `CI_BAIL_VISIBLE`, `AUDIT_LOG_PRINTED`. `GATES_INTERACTIVE` makes the "gates stay human" non-goal transcript-observable.
  - New `## Success Criteria` + `## /goal pairing` sections enumerating the three gates that MUST remain interactive (Phase 2 version confirm, Phase 5 manifest review, Phase 8.5.1 authorization) plus a post-gate condition template.
- **Shared** — registered both skills in `_shared/references/goal-pairing.md` citing-skills list.
- Regenerated Cursor / Codex / opencode bundles via `scripts/sync.sh`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation

## Testing

- [x] `./scripts/validate.sh` passes (sync check + frontmatter/content lint across Cursor/Codex/opencode + JSON manifests) — also runs in pre-push
- [x] `prettier --check` clean on all edited source files
- [x] commitlint passes on both commits (Conventional Commits)

## Reviewer Notes

- The two issues are coupled through a single shared-reference edit and one `sync.sh` run, so they ship as one PR with two focused commits (one per skill).
- The interesting design point is `releaser`: because `/goal` is transcript-only and can't answer interactive prompts, the three approval gates naturally *stall* a `/goal` loop. The Phase 8.5.1 guard hardens this by refusing to honor `--ci-yes` under an active `/goal`, and `GATES_INTERACTIVE` encodes the safety invariant as an observable signal. `/goal` only adds value *after* the user has approved the gates and published.
- No generated files were hand-edited; all bundle changes come from the generator.