### PR TITLE
feat(blueprint): add whole-project spec skill

### DIFF
--- a/.codex-plugin/ycc/skills/blueprint/SKILL.md
+++ b/.codex-plugin/ycc/skills/blueprint/SKILL.md
@@ -1,0 +1,405 @@
+---
+name: blueprint
+description: Interactive, whole-project source-of-truth spec generator. Takes a raw
+  software idea, interrogates it through a multi-gate process (Foundation → Grounding
+  → Scope → Tech Stack → Architecture → Generate), and writes a durable project charter
+  at docs/blueprint.md — vision, users, scope, tech-stack decision, architecture,
+  modules, NFRs, milestones, risks. Its machine-readable Bootstrap section then drives
+  project bootstrap (code init, CI, formatters) by orchestrating $init and $formatters.
+  Use when the user asks to "create a project spec", "write a software spec", "whole-project
+  spec", "source of truth spec", "scaffold/bootstrap a new software project from an
+  idea", "project charter/blueprint", or says "/blueprint". Sits UPSTREAM of prp-prd/prp-spec
+  — those are per-feature; this is the whole software.
+---
+
+# Project Blueprint Generator
+
+> The whole-software charter. Sits at the top of the funnel — upstream of `prp-prd`,
+> `prp-spec`, and every other planning skill. Produces ONE durable source-of-truth spec
+> for an entire piece of software, then bootstraps the project from it.
+
+**Input**: `$ARGUMENTS`
+
+---
+
+## Your Role
+
+You are a principal engineer + product strategist who:
+
+- Starts from the PROBLEM and the desired end-state, not a tech wishlist
+- Makes the tech-stack decision explicit and justified — it has downstream cost
+- Decomposes a whole system into modules with clear responsibilities
+- Asks clarifying questions before assuming; acknowledges uncertainty honestly
+- Treats the blueprint as a living source of truth, not a one-shot document
+
+**Anti-pattern**: Do not fill sections with fluff. If information is missing, write
+`TBD — needs research` rather than inventing plausible-sounding requirements.
+
+---
+
+## Flags & Process Overview
+
+Parse from `$ARGUMENTS`:
+
+- `--update` — re-run over an existing `docs/blueprint.md`; diff-and-merge instead of overwrite.
+- `--dry-run` — walk the gates and show the spec preview, but do NOT write the file or
+  bootstrap. If set, also pass `--dry-run` through to any orchestrated `$init` call.
+
+```
+DETECT → INITIATE → FOUNDATION → GROUNDING → SCOPE → TECH STACK → ARCHITECTURE → GENERATE → HANDOFF
+```
+
+Each phase builds on previous answers. Grounding uses the `prp-researcher` agent for
+dual-mode (market + codebase) discovery. Every `[GATE]` means: present the questions via
+`ask the user`, then WAIT for the user before proceeding. Do not batch gates together.
+
+---
+
+## Phase 0: DETECT — Project Context
+
+Determine whether this is greenfield, an existing repo, or a re-run.
+
+1. Run the shared profiler (read its `key=value` output; do NOT reimplement profiling):
+
+   ```bash
+   ~/.codex/plugins/ycc/skills/init/scripts/profile-project.sh
+   ```
+
+   If the script is unavailable (non-Claude target / missing path), fall back gracefully:
+   `test -f docs/blueprint.md` and a quick `ls` to judge emptiness. Do not fail the run.
+
+2. Classify:
+   - **Greenfield** (`is_empty=true`): tech-stack phase is forward-looking; skip codebase grounding.
+   - **Existing repo**: grounding includes codebase mode; reconcile the _detected_ profile
+     against the _desired_ profile and flag any mismatch as a risk/decision.
+   - **Re-run** (`docs/blueprint.md` exists): if `--update`, do a structured refresh
+     (diff each section, merge, preserve user edits). Without `--update`, tell the user the
+     file exists and ask whether to refresh (`--update`) or abort. Never silently overwrite.
+
+---
+
+## Phase 1: INITIATE — What Are We Building?
+
+**If no input provided**, ask:
+
+> **What software do you want to build?**
+> Describe the product or system in a few sentences — what it does and who it's for.
+
+**If input provided**, confirm by restating:
+
+> I understand you want to build: `{restated understanding}`
+> Is this correct, or should I adjust?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 2: FOUNDATION — Vision & Problem
+
+Ask (present all at once):
+
+> **Foundation:**
+>
+> 1. **Vision**: In one sentence, what's the ideal end state if this succeeds wildly?
+> 2. **Target users**: Who is this for? Be specific — roles/segments, not just "users".
+> 3. **Problem**: What observable pain does it solve? Why do today's alternatives fail?
+> 4. **Why now**: What changed that makes this worth building now?
+> 5. **North star**: What single measure tells you it's working?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 3: GROUNDING — Market & Context
+
+Dispatch **`prp-researcher`** in **dual (market + codebase) mode** to investigate:
+
+- Comparable products/systems and how they're typically built (their stacks are useful
+  priors for the Tech Stack phase)
+- Common architectures, patterns, and anti-patterns in this space
+- Recent trends or shifts
+- If a codebase exists: relevant existing functionality, reusable patterns, constraints
+
+Instruct the researcher to return URL citations for market findings and `file:line`
+references for codebase findings.
+
+**Summarize to the user:**
+
+> **What I found:**
+>
+> - `{Market insight}`
+> - `{Common architecture / stack in this space}`
+> - `{Relevant existing code, if applicable}`
+>
+> Does this change or refine your thinking?
+
+**GATE** (light): brief pause — "continue" or adjustments.
+
+---
+
+## Phase 4: SCOPE — Boundaries & Success
+
+Ask:
+
+> **Scope & Success:**
+>
+> 1. **MVP**: What's the absolute minimum that proves this is worth building?
+> 2. **Capabilities (MoSCoW)**: What MUST be in v1? What SHOULD/COULD wait? (capability level, not feature list)
+> 3. **Non-goals**: What are you explicitly NOT building, even if asked?
+> 4. **Success criteria**: How will you know the whole project succeeded? (beyond the north star)
+> 5. **Constraints**: Time, budget, team size, regulatory, platform.
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 5: TECH STACK — Decisions That Drive Bootstrap
+
+> This phase is gated on its own because its answers are the ONLY ones that map 1:1 to
+> `$init` and `$formatters` flags. They must be unambiguous. Use the Phase 3
+> research findings as priors and recommend defaults, but let the user decide.
+
+Ask:
+
+> **Tech Stack:**
+>
+> 1. **Primary language**: one of `rust | ts-node | python | go | mixed | empty`
+>    (these are the values `$init` understands — pick the closest fit).
+> 2. **Secondary languages** (for mixed stacks): e.g. shell, python alongside ts.
+> 3. **Package manager**: e.g. pnpm/npm/yarn, uv/poetry/pip, cargo, go mod.
+> 4. **Key frameworks / runtime / datastore / deploy target** (captured as prose; not mapped to flags).
+> 5. **CI from day one?** (yes → `$formatters --ci`, `$init --templates`)
+> 6. **Formatter/lint stacks to enable** (defaults follow the language: ts/python/rust/go/docs/shell).
+> 7. **GitHub conventions**: issue + PR templates? (`--templates`)
+> 8. **Git conventions**: conventional commits + pre-commit hooks? (`--git`, `--hooks`)
+
+**Coercion rule**: if the primary-language answer is outside
+`rust | ts-node | python | go | mixed | empty`, coerce to the nearest valid value and record
+the coercion in the Decisions Log — this guarantees the orchestrated `--profile=` call cannot fail.
+
+See `~/.codex/plugins/ycc/skills/blueprint/references/bootstrap-mapping.md` for the full
+key→flag mapping used when generating the Bootstrap section.
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 6: ARCHITECTURE — Decomposition & Risks
+
+Ask:
+
+> **Architecture:**
+>
+> 1. **Modules/components**: What are the major parts of the system and what does each own?
+> 2. **Data flow**: How does data/control move through the system at a high level?
+> 3. **Non-functional requirements**: perf, availability, security posture, scale targets.
+> 4. **Milestones/phases**: What's the rough delivery sequence, and what depends on what?
+> 5. **Top risks**: What could derail this, and how would you mitigate it?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 7: GENERATE — Write the Blueprint
+
+**Output path**: `docs/blueprint.md` (fixed — there is exactly one per repo).
+
+If `--dry-run`, render the spec preview to the user and skip writing. Otherwise:
+
+```bash
+mkdir -p docs
+```
+
+If re-running with `--update`, merge into the existing file section-by-section, preserving
+user edits; otherwise write fresh.
+
+### Blueprint Template
+
+````markdown
+# Project Blueprint: {Project Name}
+
+## Vision
+
+{One sentence: the ideal end state.}
+
+## Target Users
+
+- **Primary**: {role/segment, context, trigger}
+- **Job to be done**: When {situation}, I want to {motivation}, so I can {outcome}.
+- **Non-users**: {who this is explicitly NOT for}
+
+## Problem & Why Now
+
+{The observable problem, why alternatives fail, and what changed to make this worth building.}
+
+## Scope
+
+### In Scope (MVP)
+
+| Priority | Capability   | Rationale        |
+| -------- | ------------ | ---------------- |
+| Must     | {capability} | {why essential}  |
+| Should   | {capability} | {why it matters} |
+| Could    | {capability} | {nice to have}   |
+
+### Out of Scope / Non-Goals
+
+- {non-goal} — {why}
+
+### Success Criteria
+
+- **North star**: {single measure}
+- {supporting criterion}
+
+## Tech Stack
+
+{Prose: primary + secondary languages, package manager, frameworks, datastore, deploy
+target — each with a one-line rationale. Note any reconciliation with a detected profile.}
+
+## Architecture
+
+### Module / Component Breakdown
+
+| Component | Responsibility | Depends On |
+| --------- | -------------- | ---------- |
+| {name}    | {what it owns} | {deps}     |
+
+### High-Level Data Flow
+
+{How data/control moves through the system.}
+
+## Non-Functional Requirements
+
+| NFR             | Target   | Rationale |
+| --------------- | -------- | --------- |
+| {perf/security} | {target} | {why}     |
+
+## Milestones / Phases
+
+| #   | Milestone | Description        | Status  | Depends |
+| --- | --------- | ------------------ | ------- | ------- |
+| 1   | {name}    | {what it delivers} | pending | -       |
+| 2   | {name}    | {what it delivers} | pending | 1       |
+
+## Risks
+
+| Risk   | Likelihood | Impact  | Mitigation      |
+| ------ | ---------- | ------- | --------------- |
+| {risk} | {H/M/L}    | {H/M/L} | {how to handle} |
+
+## Decisions Log
+
+| Decision   | Choice   | Alternatives         | Rationale      |
+| ---------- | -------- | -------------------- | -------------- |
+| {decision} | {choice} | {options considered} | {why this one} |
+
+## Bootstrap
+
+<!-- MACHINE-CONSUMABLE: drives $init and $formatters. -->
+<!-- See references/bootstrap-mapping.md for the canonical key→flag table. -->
+
+| Key                 | Value                                     | Maps to                               |
+| ------------------- | ----------------------------------------- | ------------------------------------- |
+| profile             | {rust\|ts-node\|python\|go\|mixed\|empty} | init/formatters `--profile=`          |
+| secondary_languages | {e.g. python, shell}                      | multi-stack gitignore/style           |
+| package_manager     | {pnpm\|uv\|cargo\|...}                    | init next-steps + formatters aliases  |
+| ci                  | {yes\|no}                                 | formatters `--ci`; init `--templates` |
+| autofix_ci          | {yes\|no}                                 | omit `--no-autofix` when yes          |
+| formatter_stacks    | {ts, python, shell}                       | formatters `--ts --python --shell`    |
+| github_templates    | {yes\|no}                                 | init `--templates`                    |
+| git_conventions     | {yes\|no}                                 | init `--git`; formatters `--hooks`    |
+| vendor_neutral      | {yes\|no}                                 | init `--vendor-neutral`               |
+
+### Derived Commands
+
+```bash
+{e.g. $init --profile=ts-node --templates --git --formatters}
+{e.g. $formatters --profile=ts-node --ts --python --shell --ci --hooks}
+```
+
+## Research Summary
+
+**Market Context**: {key findings}
+**Technical Context**: {key findings}
+
+---
+
+_Generated: {timestamp}_
+_Status: source of truth_
+````
+
+When filling the Bootstrap table and Derived Commands, follow
+`references/bootstrap-mapping.md`. Note that `$init --formatters` already chains
+`formatters` at its Phase 6.5, so the single `init` line is usually sufficient; emit the
+explicit `$formatters …` line only when richer formatter flags (`--ci`, specific stacks,
+`--hooks`) are wanted.
+
+---
+
+## Phase 8: HANDOFF — Bootstrap & Summary
+
+If `--dry-run`, skip orchestration; just print the summary and the Derived Commands.
+
+Otherwise ask via `ask the user`:
+
+> **Bootstrap this project now?**
+>
+> - **(a) Run it** — invoke `$init` (+ `formatters`) with the derived flags.
+> - **(b) Show commands** — print the derived commands; I'll run them myself.
+> - **(c) Skip** — just keep the blueprint.
+
+- **On (a)**: invoke the **`init`** skill, passing the derived flags from the Bootstrap
+  section (e.g. `--profile=ts-node --templates --git --formatters`). `init` chains
+  `formatters` via its Phase 6.5. If the blueprint run was `--dry-run`, pass `--dry-run`
+  through. If `init` or `formatters` errors, **record the failure and continue** — then emit the
+  manual recovery command (`$formatters …`). Never report full success on partial failure.
+- **On (b)**: print the Derived Commands block and stop.
+
+### Output Summary
+
+```markdown
+## Blueprint Created
+
+**File**: `docs/blueprint.md`
+
+**Vision**: {one line}
+**Stack**: {profile + key frameworks}
+**Modules**: {count} — {list}
+
+### Bootstrap
+
+{One of: "Ran $init … (init: ok, formatters: ok)", the derived commands, or "Skipped".}
+
+### Next Steps
+
+- Reference `docs/blueprint.md` as the canonical project description in `AGENTS.md`.
+- Per module in the breakdown, run `$prp-spec` (or `$prp-prd` for fuzzy ones)
+  to produce a feature spec, then `$prp-plan` → `$prp-implement`.
+```
+
+---
+
+## Integration with ycc
+
+`blueprint` is the **charter altitude** — upstream of all feature work:
+
+```
+IDEA → $blueprint → docs/blueprint.md
+            └─Bootstrap→ $init [--profile --templates --git --formatters]
+                                 └─Phase 6.5→ $formatters [--ci --hooks --<stack>]
+       per-module → $prp-prd | $prp-spec → $prp-plan → $prp-implement
+```
+
+- `blueprint` answers "what is this whole software and how do we stand it up?" ONCE per project.
+- `prp-prd` / `prp-spec` answer "what is this one feature/increment?" — they live under
+  `docs/prps/` and are run repeatedly, seeded by the blueprint's module breakdown.
+- Each row of the Module / Component Breakdown is the natural seed for one downstream feature spec.
+
+## Success Criteria
+
+- **VISION_CLEAR**: One-sentence end-state and concrete target users.
+- **SCOPE_BOUNDED**: Explicit MVP, capabilities, and non-goals.
+- **STACK_DECIDED**: A valid `profile` value plus justified framework/datastore choices.
+- **DECOMPOSED**: Modules with responsibilities and a high-level data flow.
+- **BOOTSTRAP_ACTIONABLE**: The Bootstrap section yields a runnable `$init` command.
+- **HONEST**: Unknowns marked `TBD — needs research`, not invented.

--- a/.codex-plugin/ycc/skills/blueprint/references/bootstrap-mapping.md
+++ b/.codex-plugin/ycc/skills/blueprint/references/bootstrap-mapping.md
@@ -1,0 +1,69 @@
+# Bootstrap Mapping
+
+Canonical mapping from the blueprint's machine-readable **Bootstrap** section to
+`$init` and `$formatters` flags. This is the single source of truth shared by the
+`blueprint` GENERATE phase and any future `--from-spec` reader. Keep it in sync with the
+flag surfaces of `ycc/skills/init/SKILL.md` and `ycc/skills/formatters/SKILL.md`.
+
+## Key → Flag Table
+
+| Bootstrap key         | Values                                                          | `$init` flag            | `$formatters` flag                                       | Notes                                                                       |
+| --------------------- | --------------------------------------------------------------- | --------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `profile`             | `rust \| ts-node \| python \| go \| mixed \| empty`             | `--profile=<value>`         | `--profile=<value>`                                          | The only language vocabulary `init` accepts. Coerce out-of-vocab answers.   |
+| `secondary_languages` | comma list (e.g. `python, shell`)                               | (informs `mixed`)           | per-stack flags (below)                                      | Drives multi-stack gitignore / style activation.                            |
+| `package_manager`     | `pnpm \| npm \| yarn \| uv \| poetry \| pip \| cargo \| go mod` | —                           | —                                                            | Captured for the init "next steps" + formatters aliases; not a direct flag. |
+| `ci`                  | `yes \| no`                                                     | `--templates` (if yes)      | `--ci` (if yes)                                              | CI from day one.                                                            |
+| `autofix_ci`          | `yes \| no`                                                     | —                           | omit `--no-autofix` when `yes`; add `--no-autofix` when `no` | Only meaningful when `ci=yes`.                                              |
+| `formatter_stacks`    | subset of `ts, python, rust, go, docs, shell`                   | —                           | `--ts --python --rust --go --docs --shell`                   | One flag per enabled stack. Default follows `profile`.                      |
+| `github_templates`    | `yes \| no`                                                     | `--templates` (if yes)      | —                                                            | Issue + PR templates, labels, workflows.                                    |
+| `git_conventions`     | `yes \| no`                                                     | `--git` (if yes)            | `--hooks` (if yes)                                           | Conventional commits + pre-commit hooks.                                    |
+| `vendor_neutral`      | `yes \| no`                                                     | `--vendor-neutral` (if yes) | —                                                            | Also emit `.ai/rules/project.md`.                                           |
+
+## Profile Coercion Rules
+
+`init` only understands `rust | ts-node | python | go | mixed | empty`. Map common answers:
+
+| User answer                                 | Coerced `profile` |
+| ------------------------------------------- | ----------------- |
+| TypeScript, JavaScript, Node, Deno, Bun     | `ts-node`         |
+| Python                                      | `python`          |
+| Rust                                        | `rust`            |
+| Go, Golang                                  | `go`              |
+| Two+ primary languages of comparable weight | `mixed`           |
+| No code yet / undecided                     | `empty`           |
+
+Record any coercion in the blueprint's **Decisions Log** so the choice is auditable and the
+orchestrated `--profile=<value>` call cannot fail.
+
+## init Already Chains formatters
+
+`$init --formatters` invokes the `formatters` skill at its **Phase 6.5**, passing
+through `--dry-run` and `--force`. Therefore:
+
+- The single line `$init --profile=<p> --templates --git --formatters` is usually enough
+  to scaffold docs + GitHub + git + a baseline formatter bundle.
+- Emit a **separate** `$formatters …` line only when you need richer formatter options
+  that `init` does not forward — `--ci`, specific stack flags, or `--hooks`.
+
+## Worked Example
+
+Bootstrap values:
+
+```
+profile          = ts-node
+secondary_languages = python, shell
+package_manager  = pnpm
+ci               = yes
+autofix_ci       = yes
+formatter_stacks = ts, python, shell
+github_templates = yes
+git_conventions  = yes
+vendor_neutral   = no
+```
+
+Derived commands:
+
+```bash
+$init --profile=ts-node --templates --git --formatters
+$formatters --profile=ts-node --ts --python --shell --ci --hooks
+```

--- a/.cursor-plugin/skills/blueprint/SKILL.md
+++ b/.cursor-plugin/skills/blueprint/SKILL.md
@@ -1,0 +1,414 @@
+---
+name: blueprint
+description: Interactive, whole-project source-of-truth spec generator. Takes a raw software idea, interrogates it through a multi-gate process (Foundation → Grounding → Scope → Tech Stack → Architecture → Generate), and writes a durable project charter at docs/blueprint.md — vision, users, scope, tech-stack decision, architecture, modules, NFRs, milestones, risks. Its machine-readable Bootstrap section then drives project bootstrap (code init, CI, formatters) by orchestrating /init and /formatters. Use when the user asks to "create a project spec", "write a software spec", "whole-project spec", "source of truth spec", "scaffold/bootstrap a new software project from an idea", "project charter/blueprint", or says "/blueprint". Sits UPSTREAM of prp-prd/prp-spec — those are per-feature; this is the whole software.
+argument-hint: '[project idea] (blank = start with questions) [--update] [--dry-run]'
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - Edit
+  - Agent
+  - WebSearch
+  - WebFetch
+  - AskUserQuestion
+  - TodoWrite
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - Bash(test:*)
+  - Bash(mkdir:*)
+  - Bash(git:*)
+  - Bash(${CURSOR_PLUGIN_ROOT}/skills/init/scripts/profile-project.sh:*)
+---
+
+# Project Blueprint Generator
+
+> The whole-software charter. Sits at the top of the funnel — upstream of `prp-prd`,
+> `prp-spec`, and every other planning skill. Produces ONE durable source-of-truth spec
+> for an entire piece of software, then bootstraps the project from it.
+
+**Input**: `$ARGUMENTS`
+
+---
+
+## Your Role
+
+You are a principal engineer + product strategist who:
+
+- Starts from the PROBLEM and the desired end-state, not a tech wishlist
+- Makes the tech-stack decision explicit and justified — it has downstream cost
+- Decomposes a whole system into modules with clear responsibilities
+- Asks clarifying questions before assuming; acknowledges uncertainty honestly
+- Treats the blueprint as a living source of truth, not a one-shot document
+
+**Anti-pattern**: Do not fill sections with fluff. If information is missing, write
+`TBD — needs research` rather than inventing plausible-sounding requirements.
+
+---
+
+## Flags & Process Overview
+
+Parse from `$ARGUMENTS`:
+
+- `--update` — re-run over an existing `docs/blueprint.md`; diff-and-merge instead of overwrite.
+- `--dry-run` — walk the gates and show the spec preview, but do NOT write the file or
+  bootstrap. If set, also pass `--dry-run` through to any orchestrated `/init` call.
+
+```
+DETECT → INITIATE → FOUNDATION → GROUNDING → SCOPE → TECH STACK → ARCHITECTURE → GENERATE → HANDOFF
+```
+
+Each phase builds on previous answers. Grounding uses the `prp-researcher` agent for
+dual-mode (market + codebase) discovery. Every `[GATE]` means: present the questions via
+`AskUserQuestion`, then WAIT for the user before proceeding. Do not batch gates together.
+
+---
+
+## Phase 0: DETECT — Project Context
+
+Determine whether this is greenfield, an existing repo, or a re-run.
+
+1. Run the shared profiler (read its `key=value` output; do NOT reimplement profiling):
+
+   ```bash
+   ${CURSOR_PLUGIN_ROOT}/skills/init/scripts/profile-project.sh
+   ```
+
+   If the script is unavailable (non-Claude target / missing path), fall back gracefully:
+   `test -f docs/blueprint.md` and a quick `ls` to judge emptiness. Do not fail the run.
+
+2. Classify:
+   - **Greenfield** (`is_empty=true`): tech-stack phase is forward-looking; skip codebase grounding.
+   - **Existing repo**: grounding includes codebase mode; reconcile the _detected_ profile
+     against the _desired_ profile and flag any mismatch as a risk/decision.
+   - **Re-run** (`docs/blueprint.md` exists): if `--update`, do a structured refresh
+     (diff each section, merge, preserve user edits). Without `--update`, tell the user the
+     file exists and ask whether to refresh (`--update`) or abort. Never silently overwrite.
+
+---
+
+## Phase 1: INITIATE — What Are We Building?
+
+**If no input provided**, ask:
+
+> **What software do you want to build?**
+> Describe the product or system in a few sentences — what it does and who it's for.
+
+**If input provided**, confirm by restating:
+
+> I understand you want to build: `{restated understanding}`
+> Is this correct, or should I adjust?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 2: FOUNDATION — Vision & Problem
+
+Ask (present all at once):
+
+> **Foundation:**
+>
+> 1. **Vision**: In one sentence, what's the ideal end state if this succeeds wildly?
+> 2. **Target users**: Who is this for? Be specific — roles/segments, not just "users".
+> 3. **Problem**: What observable pain does it solve? Why do today's alternatives fail?
+> 4. **Why now**: What changed that makes this worth building now?
+> 5. **North star**: What single measure tells you it's working?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 3: GROUNDING — Market & Context
+
+Dispatch **`prp-researcher`** in **dual (market + codebase) mode** to investigate:
+
+- Comparable products/systems and how they're typically built (their stacks are useful
+  priors for the Tech Stack phase)
+- Common architectures, patterns, and anti-patterns in this space
+- Recent trends or shifts
+- If a codebase exists: relevant existing functionality, reusable patterns, constraints
+
+Instruct the researcher to return URL citations for market findings and `file:line`
+references for codebase findings.
+
+**Summarize to the user:**
+
+> **What I found:**
+>
+> - `{Market insight}`
+> - `{Common architecture / stack in this space}`
+> - `{Relevant existing code, if applicable}`
+>
+> Does this change or refine your thinking?
+
+**GATE** (light): brief pause — "continue" or adjustments.
+
+---
+
+## Phase 4: SCOPE — Boundaries & Success
+
+Ask:
+
+> **Scope & Success:**
+>
+> 1. **MVP**: What's the absolute minimum that proves this is worth building?
+> 2. **Capabilities (MoSCoW)**: What MUST be in v1? What SHOULD/COULD wait? (capability level, not feature list)
+> 3. **Non-goals**: What are you explicitly NOT building, even if asked?
+> 4. **Success criteria**: How will you know the whole project succeeded? (beyond the north star)
+> 5. **Constraints**: Time, budget, team size, regulatory, platform.
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 5: TECH STACK — Decisions That Drive Bootstrap
+
+> This phase is gated on its own because its answers are the ONLY ones that map 1:1 to
+> `/init` and `/formatters` flags. They must be unambiguous. Use the Phase 3
+> research findings as priors and recommend defaults, but let the user decide.
+
+Ask:
+
+> **Tech Stack:**
+>
+> 1. **Primary language**: one of `rust | ts-node | python | go | mixed | empty`
+>    (these are the values `/init` understands — pick the closest fit).
+> 2. **Secondary languages** (for mixed stacks): e.g. shell, python alongside ts.
+> 3. **Package manager**: e.g. pnpm/npm/yarn, uv/poetry/pip, cargo, go mod.
+> 4. **Key frameworks / runtime / datastore / deploy target** (captured as prose; not mapped to flags).
+> 5. **CI from day one?** (yes → `/formatters --ci`, `/init --templates`)
+> 6. **Formatter/lint stacks to enable** (defaults follow the language: ts/python/rust/go/docs/shell).
+> 7. **GitHub conventions**: issue + PR templates? (`--templates`)
+> 8. **Git conventions**: conventional commits + pre-commit hooks? (`--git`, `--hooks`)
+
+**Coercion rule**: if the primary-language answer is outside
+`rust | ts-node | python | go | mixed | empty`, coerce to the nearest valid value and record
+the coercion in the Decisions Log — this guarantees the orchestrated `--profile=` call cannot fail.
+
+See `${CURSOR_PLUGIN_ROOT}/skills/blueprint/references/bootstrap-mapping.md` for the full
+key→flag mapping used when generating the Bootstrap section.
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 6: ARCHITECTURE — Decomposition & Risks
+
+Ask:
+
+> **Architecture:**
+>
+> 1. **Modules/components**: What are the major parts of the system and what does each own?
+> 2. **Data flow**: How does data/control move through the system at a high level?
+> 3. **Non-functional requirements**: perf, availability, security posture, scale targets.
+> 4. **Milestones/phases**: What's the rough delivery sequence, and what depends on what?
+> 5. **Top risks**: What could derail this, and how would you mitigate it?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 7: GENERATE — Write the Blueprint
+
+**Output path**: `docs/blueprint.md` (fixed — there is exactly one per repo).
+
+If `--dry-run`, render the spec preview to the user and skip writing. Otherwise:
+
+```bash
+mkdir -p docs
+```
+
+If re-running with `--update`, merge into the existing file section-by-section, preserving
+user edits; otherwise write fresh.
+
+### Blueprint Template
+
+````markdown
+# Project Blueprint: {Project Name}
+
+## Vision
+
+{One sentence: the ideal end state.}
+
+## Target Users
+
+- **Primary**: {role/segment, context, trigger}
+- **Job to be done**: When {situation}, I want to {motivation}, so I can {outcome}.
+- **Non-users**: {who this is explicitly NOT for}
+
+## Problem & Why Now
+
+{The observable problem, why alternatives fail, and what changed to make this worth building.}
+
+## Scope
+
+### In Scope (MVP)
+
+| Priority | Capability   | Rationale        |
+| -------- | ------------ | ---------------- |
+| Must     | {capability} | {why essential}  |
+| Should   | {capability} | {why it matters} |
+| Could    | {capability} | {nice to have}   |
+
+### Out of Scope / Non-Goals
+
+- {non-goal} — {why}
+
+### Success Criteria
+
+- **North star**: {single measure}
+- {supporting criterion}
+
+## Tech Stack
+
+{Prose: primary + secondary languages, package manager, frameworks, datastore, deploy
+target — each with a one-line rationale. Note any reconciliation with a detected profile.}
+
+## Architecture
+
+### Module / Component Breakdown
+
+| Component | Responsibility | Depends On |
+| --------- | -------------- | ---------- |
+| {name}    | {what it owns} | {deps}     |
+
+### High-Level Data Flow
+
+{How data/control moves through the system.}
+
+## Non-Functional Requirements
+
+| NFR             | Target   | Rationale |
+| --------------- | -------- | --------- |
+| {perf/security} | {target} | {why}     |
+
+## Milestones / Phases
+
+| #   | Milestone | Description        | Status  | Depends |
+| --- | --------- | ------------------ | ------- | ------- |
+| 1   | {name}    | {what it delivers} | pending | -       |
+| 2   | {name}    | {what it delivers} | pending | 1       |
+
+## Risks
+
+| Risk   | Likelihood | Impact  | Mitigation      |
+| ------ | ---------- | ------- | --------------- |
+| {risk} | {H/M/L}    | {H/M/L} | {how to handle} |
+
+## Decisions Log
+
+| Decision   | Choice   | Alternatives         | Rationale      |
+| ---------- | -------- | -------------------- | -------------- |
+| {decision} | {choice} | {options considered} | {why this one} |
+
+## Bootstrap
+
+<!-- MACHINE-CONSUMABLE: drives /init and /formatters. -->
+<!-- See references/bootstrap-mapping.md for the canonical key→flag table. -->
+
+| Key                 | Value                                     | Maps to                               |
+| ------------------- | ----------------------------------------- | ------------------------------------- |
+| profile             | {rust\|ts-node\|python\|go\|mixed\|empty} | init/formatters `--profile=`          |
+| secondary_languages | {e.g. python, shell}                      | multi-stack gitignore/style           |
+| package_manager     | {pnpm\|uv\|cargo\|...}                    | init next-steps + formatters aliases  |
+| ci                  | {yes\|no}                                 | formatters `--ci`; init `--templates` |
+| autofix_ci          | {yes\|no}                                 | omit `--no-autofix` when yes          |
+| formatter_stacks    | {ts, python, shell}                       | formatters `--ts --python --shell`    |
+| github_templates    | {yes\|no}                                 | init `--templates`                    |
+| git_conventions     | {yes\|no}                                 | init `--git`; formatters `--hooks`    |
+| vendor_neutral      | {yes\|no}                                 | init `--vendor-neutral`               |
+
+### Derived Commands
+
+```bash
+{e.g. /init --profile=ts-node --templates --git --formatters}
+{e.g. /formatters --profile=ts-node --ts --python --shell --ci --hooks}
+```
+
+## Research Summary
+
+**Market Context**: {key findings}
+**Technical Context**: {key findings}
+
+---
+
+_Generated: {timestamp}_
+_Status: source of truth_
+````
+
+When filling the Bootstrap table and Derived Commands, follow
+`references/bootstrap-mapping.md`. Note that `/init --formatters` already chains
+`formatters` at its Phase 6.5, so the single `init` line is usually sufficient; emit the
+explicit `/formatters …` line only when richer formatter flags (`--ci`, specific stacks,
+`--hooks`) are wanted.
+
+---
+
+## Phase 8: HANDOFF — Bootstrap & Summary
+
+If `--dry-run`, skip orchestration; just print the summary and the Derived Commands.
+
+Otherwise ask via `AskUserQuestion`:
+
+> **Bootstrap this project now?**
+>
+> - **(a) Run it** — invoke `/init` (+ `formatters`) with the derived flags.
+> - **(b) Show commands** — print the derived commands; I'll run them myself.
+> - **(c) Skip** — just keep the blueprint.
+
+- **On (a)**: invoke the **`init`** skill, passing the derived flags from the Bootstrap
+  section (e.g. `--profile=ts-node --templates --git --formatters`). `init` chains
+  `formatters` via its Phase 6.5. If the blueprint run was `--dry-run`, pass `--dry-run`
+  through. If `init` or `formatters` errors, **record the failure and continue** — then emit the
+  manual recovery command (`/formatters …`). Never report full success on partial failure.
+- **On (b)**: print the Derived Commands block and stop.
+
+### Output Summary
+
+```markdown
+## Blueprint Created
+
+**File**: `docs/blueprint.md`
+
+**Vision**: {one line}
+**Stack**: {profile + key frameworks}
+**Modules**: {count} — {list}
+
+### Bootstrap
+
+{One of: "Ran /init … (init: ok, formatters: ok)", the derived commands, or "Skipped".}
+
+### Next Steps
+
+- Reference `docs/blueprint.md` as the canonical project description in `CLAUDE.md`.
+- Per module in the breakdown, run `/prp-spec` (or `/prp-prd` for fuzzy ones)
+  to produce a feature spec, then `/prp-plan` → `/prp-implement`.
+```
+
+---
+
+## Integration with ycc
+
+`blueprint` is the **charter altitude** — upstream of all feature work:
+
+```
+IDEA → /blueprint → docs/blueprint.md
+            └─Bootstrap→ /init [--profile --templates --git --formatters]
+                                 └─Phase 6.5→ /formatters [--ci --hooks --<stack>]
+       per-module → /prp-prd | /prp-spec → /prp-plan → /prp-implement
+```
+
+- `blueprint` answers "what is this whole software and how do we stand it up?" ONCE per project.
+- `prp-prd` / `prp-spec` answer "what is this one feature/increment?" — they live under
+  `docs/prps/` and are run repeatedly, seeded by the blueprint's module breakdown.
+- Each row of the Module / Component Breakdown is the natural seed for one downstream feature spec.
+
+## Success Criteria
+
+- **VISION_CLEAR**: One-sentence end-state and concrete target users.
+- **SCOPE_BOUNDED**: Explicit MVP, capabilities, and non-goals.
+- **STACK_DECIDED**: A valid `profile` value plus justified framework/datastore choices.
+- **DECOMPOSED**: Modules with responsibilities and a high-level data flow.
+- **BOOTSTRAP_ACTIONABLE**: The Bootstrap section yields a runnable `/init` command.
+- **HONEST**: Unknowns marked `TBD — needs research`, not invented.

--- a/.cursor-plugin/skills/blueprint/references/bootstrap-mapping.md
+++ b/.cursor-plugin/skills/blueprint/references/bootstrap-mapping.md
@@ -1,0 +1,69 @@
+# Bootstrap Mapping
+
+Canonical mapping from the blueprint's machine-readable **Bootstrap** section to
+`/init` and `/formatters` flags. This is the single source of truth shared by the
+`blueprint` GENERATE phase and any future `--from-spec` reader. Keep it in sync with the
+flag surfaces of `ycc/skills/init/SKILL.md` and `ycc/skills/formatters/SKILL.md`.
+
+## Key → Flag Table
+
+| Bootstrap key         | Values                                                          | `/init` flag            | `/formatters` flag                                       | Notes                                                                       |
+| --------------------- | --------------------------------------------------------------- | --------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `profile`             | `rust \| ts-node \| python \| go \| mixed \| empty`             | `--profile=<value>`         | `--profile=<value>`                                          | The only language vocabulary `init` accepts. Coerce out-of-vocab answers.   |
+| `secondary_languages` | comma list (e.g. `python, shell`)                               | (informs `mixed`)           | per-stack flags (below)                                      | Drives multi-stack gitignore / style activation.                            |
+| `package_manager`     | `pnpm \| npm \| yarn \| uv \| poetry \| pip \| cargo \| go mod` | —                           | —                                                            | Captured for the init "next steps" + formatters aliases; not a direct flag. |
+| `ci`                  | `yes \| no`                                                     | `--templates` (if yes)      | `--ci` (if yes)                                              | CI from day one.                                                            |
+| `autofix_ci`          | `yes \| no`                                                     | —                           | omit `--no-autofix` when `yes`; add `--no-autofix` when `no` | Only meaningful when `ci=yes`.                                              |
+| `formatter_stacks`    | subset of `ts, python, rust, go, docs, shell`                   | —                           | `--ts --python --rust --go --docs --shell`                   | One flag per enabled stack. Default follows `profile`.                      |
+| `github_templates`    | `yes \| no`                                                     | `--templates` (if yes)      | —                                                            | Issue + PR templates, labels, workflows.                                    |
+| `git_conventions`     | `yes \| no`                                                     | `--git` (if yes)            | `--hooks` (if yes)                                           | Conventional commits + pre-commit hooks.                                    |
+| `vendor_neutral`      | `yes \| no`                                                     | `--vendor-neutral` (if yes) | —                                                            | Also emit `.ai/rules/project.md`.                                           |
+
+## Profile Coercion Rules
+
+`init` only understands `rust | ts-node | python | go | mixed | empty`. Map common answers:
+
+| User answer                                 | Coerced `profile` |
+| ------------------------------------------- | ----------------- |
+| TypeScript, JavaScript, Node, Deno, Bun     | `ts-node`         |
+| Python                                      | `python`          |
+| Rust                                        | `rust`            |
+| Go, Golang                                  | `go`              |
+| Two+ primary languages of comparable weight | `mixed`           |
+| No code yet / undecided                     | `empty`           |
+
+Record any coercion in the blueprint's **Decisions Log** so the choice is auditable and the
+orchestrated `--profile=<value>` call cannot fail.
+
+## init Already Chains formatters
+
+`/init --formatters` invokes the `formatters` skill at its **Phase 6.5**, passing
+through `--dry-run` and `--force`. Therefore:
+
+- The single line `/init --profile=<p> --templates --git --formatters` is usually enough
+  to scaffold docs + GitHub + git + a baseline formatter bundle.
+- Emit a **separate** `/formatters …` line only when you need richer formatter options
+  that `init` does not forward — `--ci`, specific stack flags, or `--hooks`.
+
+## Worked Example
+
+Bootstrap values:
+
+```
+profile          = ts-node
+secondary_languages = python, shell
+package_manager  = pnpm
+ci               = yes
+autofix_ci       = yes
+formatter_stacks = ts, python, shell
+github_templates = yes
+git_conventions  = yes
+vendor_neutral   = no
+```
+
+Derived commands:
+
+```bash
+/init --profile=ts-node --templates --git --formatters
+/formatters --profile=ts-node --ts --python --shell --ci --hooks
+```

--- a/.opencode-plugin/commands/blueprint.md
+++ b/.opencode-plugin/commands/blueprint.md
@@ -1,0 +1,40 @@
+---
+description: 'Whole-project source-of-truth spec generator. Interrogates a raw software
+  idea through a multi-gate process and writes a durable project charter to docs/blueprint.md,
+  then bootstraps the project (init + formatters) from its Bootstrap section. Upstream
+  of prp-prd/prp-spec. Usage: [project idea] (blank = start with questions) [--update]
+  [--dry-run]'
+---
+
+# Blueprint Command
+
+Run the interactive whole-project blueprint workflow.
+
+**Load and follow the `blueprint` skill, passing through `$ARGUMENTS`.**
+
+The skill runs a multi-gate interactive flow:
+Detect → Initiate → Foundation → Grounding → Scope → Tech Stack → Architecture → Generate → Handoff.
+It dispatches the `prp-researcher` agent during grounding and writes the final charter to
+`docs/blueprint.md`. The charter's machine-readable **Bootstrap** section then drives project
+setup by orchestrating `/init` (which chains `/formatters`).
+
+```
+Usage: /blueprint [project idea] [--update] [--dry-run]
+
+Examples:
+  /blueprint                              # Start from scratch with questions
+  /blueprint a CLI that lints Terraform   # Start from a one-line idea
+  /blueprint --update                     # Refresh an existing docs/blueprint.md (merge)
+  /blueprint --dry-run my idea            # Walk the gates, preview the spec, write nothing
+
+Next steps after the blueprint is written:
+  /init --profile=<p> --templates --git --formatters   # Bootstrap (often run via Handoff)
+  /prp-spec <module>                                    # Per-module feature spec
+  /prp-plan → /prp-implement                        # Plan and build each module
+```
+
+## Where it sits
+
+`blueprint` is the **charter altitude** — run ONCE per project to define the whole software
+and stand it up. `prp-prd` / `prp-spec` are **feature altitude** — run repeatedly per module,
+seeded by the blueprint's module breakdown. Use `/plan` for quick conversational planning.

--- a/.opencode-plugin/skills/blueprint/SKILL.md
+++ b/.opencode-plugin/skills/blueprint/SKILL.md
@@ -1,0 +1,405 @@
+---
+name: blueprint
+description: Interactive, whole-project source-of-truth spec generator. Takes a raw
+  software idea, interrogates it through a multi-gate process (Foundation → Grounding
+  → Scope → Tech Stack → Architecture → Generate), and writes a durable project charter
+  at docs/blueprint.md — vision, users, scope, tech-stack decision, architecture,
+  modules, NFRs, milestones, risks. Its machine-readable Bootstrap section then drives
+  project bootstrap (code init, CI, formatters) by orchestrating /init and /formatters.
+  Use when the user asks to "create a project spec", "write a software spec", "whole-project
+  spec", "source of truth spec", "scaffold/bootstrap a new software project from an
+  idea", "project charter/blueprint", or says "/blueprint". Sits UPSTREAM of prp-prd/prp-spec
+  — those are per-feature; this is the whole software.
+---
+
+# Project Blueprint Generator
+
+> The whole-software charter. Sits at the top of the funnel — upstream of `prp-prd`,
+> `prp-spec`, and every other planning skill. Produces ONE durable source-of-truth spec
+> for an entire piece of software, then bootstraps the project from it.
+
+**Input**: `$ARGUMENTS`
+
+---
+
+## Your Role
+
+You are a principal engineer + product strategist who:
+
+- Starts from the PROBLEM and the desired end-state, not a tech wishlist
+- Makes the tech-stack decision explicit and justified — it has downstream cost
+- Decomposes a whole system into modules with clear responsibilities
+- Asks clarifying questions before assuming; acknowledges uncertainty honestly
+- Treats the blueprint as a living source of truth, not a one-shot document
+
+**Anti-pattern**: Do not fill sections with fluff. If information is missing, write
+`TBD — needs research` rather than inventing plausible-sounding requirements.
+
+---
+
+## Flags & Process Overview
+
+Parse from `$ARGUMENTS`:
+
+- `--update` — re-run over an existing `docs/blueprint.md`; diff-and-merge instead of overwrite.
+- `--dry-run` — walk the gates and show the spec preview, but do NOT write the file or
+  bootstrap. If set, also pass `--dry-run` through to any orchestrated `/init` call.
+
+```
+DETECT → INITIATE → FOUNDATION → GROUNDING → SCOPE → TECH STACK → ARCHITECTURE → GENERATE → HANDOFF
+```
+
+Each phase builds on previous answers. Grounding uses the `prp-researcher` agent for
+dual-mode (market + codebase) discovery. Every `[GATE]` means: present the questions via
+`ask the user`, then WAIT for the user before proceeding. Do not batch gates together.
+
+---
+
+## Phase 0: DETECT — Project Context
+
+Determine whether this is greenfield, an existing repo, or a re-run.
+
+1. Run the shared profiler (read its `key=value` output; do NOT reimplement profiling):
+
+   ```bash
+   ~/.config/opencode/skills/init/scripts/profile-project.sh
+   ```
+
+   If the script is unavailable (non-Claude target / missing path), fall back gracefully:
+   `test -f docs/blueprint.md` and a quick `ls` to judge emptiness. Do not fail the run.
+
+2. Classify:
+   - **Greenfield** (`is_empty=true`): tech-stack phase is forward-looking; skip codebase grounding.
+   - **Existing repo**: grounding includes codebase mode; reconcile the _detected_ profile
+     against the _desired_ profile and flag any mismatch as a risk/decision.
+   - **Re-run** (`docs/blueprint.md` exists): if `--update`, do a structured refresh
+     (diff each section, merge, preserve user edits). Without `--update`, tell the user the
+     file exists and ask whether to refresh (`--update`) or abort. Never silently overwrite.
+
+---
+
+## Phase 1: INITIATE — What Are We Building?
+
+**If no input provided**, ask:
+
+> **What software do you want to build?**
+> Describe the product or system in a few sentences — what it does and who it's for.
+
+**If input provided**, confirm by restating:
+
+> I understand you want to build: `{restated understanding}`
+> Is this correct, or should I adjust?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 2: FOUNDATION — Vision & Problem
+
+Ask (present all at once):
+
+> **Foundation:**
+>
+> 1. **Vision**: In one sentence, what's the ideal end state if this succeeds wildly?
+> 2. **Target users**: Who is this for? Be specific — roles/segments, not just "users".
+> 3. **Problem**: What observable pain does it solve? Why do today's alternatives fail?
+> 4. **Why now**: What changed that makes this worth building now?
+> 5. **North star**: What single measure tells you it's working?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 3: GROUNDING — Market & Context
+
+Dispatch **`prp-researcher`** in **dual (market + codebase) mode** to investigate:
+
+- Comparable products/systems and how they're typically built (their stacks are useful
+  priors for the Tech Stack phase)
+- Common architectures, patterns, and anti-patterns in this space
+- Recent trends or shifts
+- If a codebase exists: relevant existing functionality, reusable patterns, constraints
+
+Instruct the researcher to return URL citations for market findings and `file:line`
+references for codebase findings.
+
+**Summarize to the user:**
+
+> **What I found:**
+>
+> - `{Market insight}`
+> - `{Common architecture / stack in this space}`
+> - `{Relevant existing code, if applicable}`
+>
+> Does this change or refine your thinking?
+
+**GATE** (light): brief pause — "continue" or adjustments.
+
+---
+
+## Phase 4: SCOPE — Boundaries & Success
+
+Ask:
+
+> **Scope & Success:**
+>
+> 1. **MVP**: What's the absolute minimum that proves this is worth building?
+> 2. **Capabilities (MoSCoW)**: What MUST be in v1? What SHOULD/COULD wait? (capability level, not feature list)
+> 3. **Non-goals**: What are you explicitly NOT building, even if asked?
+> 4. **Success criteria**: How will you know the whole project succeeded? (beyond the north star)
+> 5. **Constraints**: Time, budget, team size, regulatory, platform.
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 5: TECH STACK — Decisions That Drive Bootstrap
+
+> This phase is gated on its own because its answers are the ONLY ones that map 1:1 to
+> `/init` and `/formatters` flags. They must be unambiguous. Use the Phase 3
+> research findings as priors and recommend defaults, but let the user decide.
+
+Ask:
+
+> **Tech Stack:**
+>
+> 1. **Primary language**: one of `rust | ts-node | python | go | mixed | empty`
+>    (these are the values `/init` understands — pick the closest fit).
+> 2. **Secondary languages** (for mixed stacks): e.g. shell, python alongside ts.
+> 3. **Package manager**: e.g. pnpm/npm/yarn, uv/poetry/pip, cargo, go mod.
+> 4. **Key frameworks / runtime / datastore / deploy target** (captured as prose; not mapped to flags).
+> 5. **CI from day one?** (yes → `/formatters --ci`, `/init --templates`)
+> 6. **Formatter/lint stacks to enable** (defaults follow the language: ts/python/rust/go/docs/shell).
+> 7. **GitHub conventions**: issue + PR templates? (`--templates`)
+> 8. **Git conventions**: conventional commits + pre-commit hooks? (`--git`, `--hooks`)
+
+**Coercion rule**: if the primary-language answer is outside
+`rust | ts-node | python | go | mixed | empty`, coerce to the nearest valid value and record
+the coercion in the Decisions Log — this guarantees the orchestrated `--profile=` call cannot fail.
+
+See `~/.config/opencode/skills/blueprint/references/bootstrap-mapping.md` for the full
+key→flag mapping used when generating the Bootstrap section.
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 6: ARCHITECTURE — Decomposition & Risks
+
+Ask:
+
+> **Architecture:**
+>
+> 1. **Modules/components**: What are the major parts of the system and what does each own?
+> 2. **Data flow**: How does data/control move through the system at a high level?
+> 3. **Non-functional requirements**: perf, availability, security posture, scale targets.
+> 4. **Milestones/phases**: What's the rough delivery sequence, and what depends on what?
+> 5. **Top risks**: What could derail this, and how would you mitigate it?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 7: GENERATE — Write the Blueprint
+
+**Output path**: `docs/blueprint.md` (fixed — there is exactly one per repo).
+
+If `--dry-run`, render the spec preview to the user and skip writing. Otherwise:
+
+```bash
+mkdir -p docs
+```
+
+If re-running with `--update`, merge into the existing file section-by-section, preserving
+user edits; otherwise write fresh.
+
+### Blueprint Template
+
+````markdown
+# Project Blueprint: {Project Name}
+
+## Vision
+
+{One sentence: the ideal end state.}
+
+## Target Users
+
+- **Primary**: {role/segment, context, trigger}
+- **Job to be done**: When {situation}, I want to {motivation}, so I can {outcome}.
+- **Non-users**: {who this is explicitly NOT for}
+
+## Problem & Why Now
+
+{The observable problem, why alternatives fail, and what changed to make this worth building.}
+
+## Scope
+
+### In Scope (MVP)
+
+| Priority | Capability   | Rationale        |
+| -------- | ------------ | ---------------- |
+| Must     | {capability} | {why essential}  |
+| Should   | {capability} | {why it matters} |
+| Could    | {capability} | {nice to have}   |
+
+### Out of Scope / Non-Goals
+
+- {non-goal} — {why}
+
+### Success Criteria
+
+- **North star**: {single measure}
+- {supporting criterion}
+
+## Tech Stack
+
+{Prose: primary + secondary languages, package manager, frameworks, datastore, deploy
+target — each with a one-line rationale. Note any reconciliation with a detected profile.}
+
+## Architecture
+
+### Module / Component Breakdown
+
+| Component | Responsibility | Depends On |
+| --------- | -------------- | ---------- |
+| {name}    | {what it owns} | {deps}     |
+
+### High-Level Data Flow
+
+{How data/control moves through the system.}
+
+## Non-Functional Requirements
+
+| NFR             | Target   | Rationale |
+| --------------- | -------- | --------- |
+| {perf/security} | {target} | {why}     |
+
+## Milestones / Phases
+
+| #   | Milestone | Description        | Status  | Depends |
+| --- | --------- | ------------------ | ------- | ------- |
+| 1   | {name}    | {what it delivers} | pending | -       |
+| 2   | {name}    | {what it delivers} | pending | 1       |
+
+## Risks
+
+| Risk   | Likelihood | Impact  | Mitigation      |
+| ------ | ---------- | ------- | --------------- |
+| {risk} | {H/M/L}    | {H/M/L} | {how to handle} |
+
+## Decisions Log
+
+| Decision   | Choice   | Alternatives         | Rationale      |
+| ---------- | -------- | -------------------- | -------------- |
+| {decision} | {choice} | {options considered} | {why this one} |
+
+## Bootstrap
+
+<!-- MACHINE-CONSUMABLE: drives /init and /formatters. -->
+<!-- See references/bootstrap-mapping.md for the canonical key→flag table. -->
+
+| Key                 | Value                                     | Maps to                               |
+| ------------------- | ----------------------------------------- | ------------------------------------- |
+| profile             | {rust\|ts-node\|python\|go\|mixed\|empty} | init/formatters `--profile=`          |
+| secondary_languages | {e.g. python, shell}                      | multi-stack gitignore/style           |
+| package_manager     | {pnpm\|uv\|cargo\|...}                    | init next-steps + formatters aliases  |
+| ci                  | {yes\|no}                                 | formatters `--ci`; init `--templates` |
+| autofix_ci          | {yes\|no}                                 | omit `--no-autofix` when yes          |
+| formatter_stacks    | {ts, python, shell}                       | formatters `--ts --python --shell`    |
+| github_templates    | {yes\|no}                                 | init `--templates`                    |
+| git_conventions     | {yes\|no}                                 | init `--git`; formatters `--hooks`    |
+| vendor_neutral      | {yes\|no}                                 | init `--vendor-neutral`               |
+
+### Derived Commands
+
+```bash
+{e.g. /init --profile=ts-node --templates --git --formatters}
+{e.g. /formatters --profile=ts-node --ts --python --shell --ci --hooks}
+```
+
+## Research Summary
+
+**Market Context**: {key findings}
+**Technical Context**: {key findings}
+
+---
+
+_Generated: {timestamp}_
+_Status: source of truth_
+````
+
+When filling the Bootstrap table and Derived Commands, follow
+`references/bootstrap-mapping.md`. Note that `/init --formatters` already chains
+`formatters` at its Phase 6.5, so the single `init` line is usually sufficient; emit the
+explicit `/formatters …` line only when richer formatter flags (`--ci`, specific stacks,
+`--hooks`) are wanted.
+
+---
+
+## Phase 8: HANDOFF — Bootstrap & Summary
+
+If `--dry-run`, skip orchestration; just print the summary and the Derived Commands.
+
+Otherwise ask via `ask the user`:
+
+> **Bootstrap this project now?**
+>
+> - **(a) Run it** — invoke `/init` (+ `formatters`) with the derived flags.
+> - **(b) Show commands** — print the derived commands; I'll run them myself.
+> - **(c) Skip** — just keep the blueprint.
+
+- **On (a)**: invoke the **`init`** skill, passing the derived flags from the Bootstrap
+  section (e.g. `--profile=ts-node --templates --git --formatters`). `init` chains
+  `formatters` via its Phase 6.5. If the blueprint run was `--dry-run`, pass `--dry-run`
+  through. If `init` or `formatters` errors, **record the failure and continue** — then emit the
+  manual recovery command (`/formatters …`). Never report full success on partial failure.
+- **On (b)**: print the Derived Commands block and stop.
+
+### Output Summary
+
+```markdown
+## Blueprint Created
+
+**File**: `docs/blueprint.md`
+
+**Vision**: {one line}
+**Stack**: {profile + key frameworks}
+**Modules**: {count} — {list}
+
+### Bootstrap
+
+{One of: "Ran /init … (init: ok, formatters: ok)", the derived commands, or "Skipped".}
+
+### Next Steps
+
+- Reference `docs/blueprint.md` as the canonical project description in `AGENTS.md`.
+- Per module in the breakdown, run `/prp-spec` (or `/prp-prd` for fuzzy ones)
+  to produce a feature spec, then `/prp-plan` → `/prp-implement`.
+```
+
+---
+
+## Integration with ycc
+
+`blueprint` is the **charter altitude** — upstream of all feature work:
+
+```
+IDEA → /blueprint → docs/blueprint.md
+            └─Bootstrap→ /init [--profile --templates --git --formatters]
+                                 └─Phase 6.5→ /formatters [--ci --hooks --<stack>]
+       per-module → /prp-prd | /prp-spec → /prp-plan → /prp-implement
+```
+
+- `blueprint` answers "what is this whole software and how do we stand it up?" ONCE per project.
+- `prp-prd` / `prp-spec` answer "what is this one feature/increment?" — they live under
+  `docs/prps/` and are run repeatedly, seeded by the blueprint's module breakdown.
+- Each row of the Module / Component Breakdown is the natural seed for one downstream feature spec.
+
+## Success Criteria
+
+- **VISION_CLEAR**: One-sentence end-state and concrete target users.
+- **SCOPE_BOUNDED**: Explicit MVP, capabilities, and non-goals.
+- **STACK_DECIDED**: A valid `profile` value plus justified framework/datastore choices.
+- **DECOMPOSED**: Modules with responsibilities and a high-level data flow.
+- **BOOTSTRAP_ACTIONABLE**: The Bootstrap section yields a runnable `/init` command.
+- **HONEST**: Unknowns marked `TBD — needs research`, not invented.

--- a/.opencode-plugin/skills/blueprint/references/bootstrap-mapping.md
+++ b/.opencode-plugin/skills/blueprint/references/bootstrap-mapping.md
@@ -1,0 +1,69 @@
+# Bootstrap Mapping
+
+Canonical mapping from the blueprint's machine-readable **Bootstrap** section to
+`/init` and `/formatters` flags. This is the single source of truth shared by the
+`blueprint` GENERATE phase and any future `--from-spec` reader. Keep it in sync with the
+flag surfaces of `.opencode-plugin/skills/init/SKILL.md` and `.opencode-plugin/skills/formatters/SKILL.md`.
+
+## Key → Flag Table
+
+| Bootstrap key         | Values                                                          | `/init` flag            | `/formatters` flag                                       | Notes                                                                       |
+| --------------------- | --------------------------------------------------------------- | --------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `profile`             | `rust \| ts-node \| python \| go \| mixed \| empty`             | `--profile=<value>`         | `--profile=<value>`                                          | The only language vocabulary `init` accepts. Coerce out-of-vocab answers.   |
+| `secondary_languages` | comma list (e.g. `python, shell`)                               | (informs `mixed`)           | per-stack flags (below)                                      | Drives multi-stack gitignore / style activation.                            |
+| `package_manager`     | `pnpm \| npm \| yarn \| uv \| poetry \| pip \| cargo \| go mod` | —                           | —                                                            | Captured for the init "next steps" + formatters aliases; not a direct flag. |
+| `ci`                  | `yes \| no`                                                     | `--templates` (if yes)      | `--ci` (if yes)                                              | CI from day one.                                                            |
+| `autofix_ci`          | `yes \| no`                                                     | —                           | omit `--no-autofix` when `yes`; add `--no-autofix` when `no` | Only meaningful when `ci=yes`.                                              |
+| `formatter_stacks`    | subset of `ts, python, rust, go, docs, shell`                   | —                           | `--ts --python --rust --go --docs --shell`                   | One flag per enabled stack. Default follows `profile`.                      |
+| `github_templates`    | `yes \| no`                                                     | `--templates` (if yes)      | —                                                            | Issue + PR templates, labels, workflows.                                    |
+| `git_conventions`     | `yes \| no`                                                     | `--git` (if yes)            | `--hooks` (if yes)                                           | Conventional commits + pre-commit hooks.                                    |
+| `vendor_neutral`      | `yes \| no`                                                     | `--vendor-neutral` (if yes) | —                                                            | Also emit `.ai/rules/project.md`.                                           |
+
+## Profile Coercion Rules
+
+`init` only understands `rust | ts-node | python | go | mixed | empty`. Map common answers:
+
+| User answer                                 | Coerced `profile` |
+| ------------------------------------------- | ----------------- |
+| TypeScript, JavaScript, Node, Deno, Bun     | `ts-node`         |
+| Python                                      | `python`          |
+| Rust                                        | `rust`            |
+| Go, Golang                                  | `go`              |
+| Two+ primary languages of comparable weight | `mixed`           |
+| No code yet / undecided                     | `empty`           |
+
+Record any coercion in the blueprint's **Decisions Log** so the choice is auditable and the
+orchestrated `--profile=<value>` call cannot fail.
+
+## init Already Chains formatters
+
+`/init --formatters` invokes the `formatters` skill at its **Phase 6.5**, passing
+through `--dry-run` and `--force`. Therefore:
+
+- The single line `/init --profile=<p> --templates --git --formatters` is usually enough
+  to scaffold docs + GitHub + git + a baseline formatter bundle.
+- Emit a **separate** `/formatters …` line only when you need richer formatter options
+  that `init` does not forward — `--ci`, specific stack flags, or `--hooks`.
+
+## Worked Example
+
+Bootstrap values:
+
+```
+profile          = ts-node
+secondary_languages = python, shell
+package_manager  = pnpm
+ci               = yes
+autofix_ci       = yes
+formatter_stacks = ts, python, shell
+github_templates = yes
+git_conventions  = yes
+vendor_neutral   = no
+```
+
+Derived commands:
+
+```bash
+/init --profile=ts-node --templates --git --formatters
+/formatters --profile=ts-node --ts --python --shell --ci --hooks
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A single Claude Code plugin (`ycc`) bundling workflow orchestration, parallel pl
 
 <!-- BEGIN:GENERATED-COUNTS -->
 
-The source plugin ships **47 skills**, **46 slash commands** (most skills have a matching command), and **54 agents**.
+The source plugin ships **48 skills**, **47 slash commands** (most skills have a matching command), and **54 agents**.
 
 <!-- END:GENERATED-COUNTS -->
 
@@ -17,6 +17,7 @@ The source plugin ships **47 skills**, **46 slash commands** (most skills have a
 | Command / Skill            | Purpose                                                                                                                                                                                 |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/ycc:ask`                 | Ask questions about the codebase without making changes - get guidance, impact analysis, or comparisons                                                                                 |
+| `/ycc:blueprint`           | Whole-project source-of-truth spec generator.                                                                                                                                           |
 | `/ycc:bundle-author`       | Scaffold new source-of-truth content in the ycc bundle (skill, optional matching command and agent)                                                                                     |
 | `/ycc:bundle-release`      | Prepare a ycc bundle release — preflight, bump, regenerate, validate, draft notes (no auto-commit)                                                                                      |
 | `/ycc:clean`               | Orchestrate parallel cleanup agents to find and remove unnecessary project files                                                                                                        |

--- a/docs/inventory.json
+++ b/docs/inventory.json
@@ -5,6 +5,10 @@
       "description": "This skill should be used when the user asks questions about the codebase without requesting changes, such as \"how does X work?\", \"where is Y implemented?\", \"explain this code\", \"walk me through X\", \"what does this do?\", \"what would I need to change for X?\", \"if I change X what breaks?\", \"compare how A and B handle X\", or any exploratory question about code structure, architecture, or implementation. Also triggered by the /ask command."
     },
     {
+      "name": "blueprint",
+      "description": "Interactive, whole-project source-of-truth spec generator. Takes a raw software idea, interrogates it through a multi-gate process (Foundation \u2192 Grounding \u2192 Scope \u2192 Tech Stack \u2192 Architecture \u2192 Generate), and writes a durable project charter at docs/blueprint.md \u2014 vision, users, scope, tech-stack decision, architecture, modules, NFRs, milestones, risks. Its machine-readable Bootstrap section then drives project bootstrap (code init, CI, formatters) by orchestrating /ycc:init and /ycc:formatters. Use when the user asks to \"create a project spec\", \"write a software spec\", \"whole-project spec\", \"source of truth spec\", \"scaffold/bootstrap a new software project from an idea\", \"project charter/blueprint\", or says \"/blueprint\". Sits UPSTREAM of prp-prd/prp-spec \u2014 those are per-feature; this is the whole software."
+    },
+    {
       "name": "bundle-author",
       "description": "This skill should be used when the user asks to \"scaffold a new ycc skill\", \"add a skill to the bundle\", \"extend ycc\", \"create a new command under ycc\", \"add an agent to ycc\", or when the user wants to author new source-of-truth content in the ycc/ bundle (skills, commands, agents). Contributor workflow \u2014 not a generic plugin scaffolder. Respects the source-of-truth / regenerated-bundle split."
     },
@@ -193,6 +197,10 @@
     {
       "name": "ask",
       "description": "Ask questions about the codebase without making changes - get guidance, impact analysis, or comparisons"
+    },
+    {
+      "name": "blueprint",
+      "description": "Whole-project source-of-truth spec generator. Interrogates a raw software idea through a multi-gate process and writes a durable project charter to docs/blueprint.md, then bootstraps the project (init + formatters) from its Bootstrap section. Upstream of prp-prd/prp-spec."
     },
     {
       "name": "bundle-author",
@@ -594,8 +602,8 @@
     }
   ],
   "counts": {
-    "skills": 47,
-    "commands": 46,
+    "skills": 48,
+    "commands": 47,
     "agents": 54
   },
   "parity": {

--- a/ycc/commands/blueprint.md
+++ b/ycc/commands/blueprint.md
@@ -1,0 +1,53 @@
+---
+description: Whole-project source-of-truth spec generator. Interrogates a raw software idea through a multi-gate process and writes a durable project charter to docs/blueprint.md, then bootstraps the project (init + formatters) from its Bootstrap section. Upstream of prp-prd/prp-spec.
+argument-hint: '[project idea] (blank = start with questions) [--update] [--dry-run]'
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - Edit
+  - Agent
+  - WebSearch
+  - WebFetch
+  - AskUserQuestion
+  - TodoWrite
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - Bash(test:*)
+  - Bash(mkdir:*)
+  - Bash(git:*)
+---
+
+# Blueprint Command
+
+Run the interactive whole-project blueprint workflow.
+
+**Load and follow the `ycc:blueprint` skill, passing through `$ARGUMENTS`.**
+
+The skill runs a multi-gate interactive flow:
+Detect → Initiate → Foundation → Grounding → Scope → Tech Stack → Architecture → Generate → Handoff.
+It dispatches the `ycc:prp-researcher` agent during grounding and writes the final charter to
+`docs/blueprint.md`. The charter's machine-readable **Bootstrap** section then drives project
+setup by orchestrating `/ycc:init` (which chains `/ycc:formatters`).
+
+```
+Usage: /ycc:blueprint [project idea] [--update] [--dry-run]
+
+Examples:
+  /ycc:blueprint                              # Start from scratch with questions
+  /ycc:blueprint a CLI that lints Terraform   # Start from a one-line idea
+  /ycc:blueprint --update                     # Refresh an existing docs/blueprint.md (merge)
+  /ycc:blueprint --dry-run my idea            # Walk the gates, preview the spec, write nothing
+
+Next steps after the blueprint is written:
+  /ycc:init --profile=<p> --templates --git --formatters   # Bootstrap (often run via Handoff)
+  /ycc:prp-spec <module>                                    # Per-module feature spec
+  /ycc:prp-plan → /ycc:prp-implement                        # Plan and build each module
+```
+
+## Where it sits
+
+`blueprint` is the **charter altitude** — run ONCE per project to define the whole software
+and stand it up. `prp-prd` / `prp-spec` are **feature altitude** — run repeatedly per module,
+seeded by the blueprint's module breakdown. Use `/ycc:plan` for quick conversational planning.

--- a/ycc/skills/blueprint/SKILL.md
+++ b/ycc/skills/blueprint/SKILL.md
@@ -1,0 +1,414 @@
+---
+name: blueprint
+description: Interactive, whole-project source-of-truth spec generator. Takes a raw software idea, interrogates it through a multi-gate process (Foundation → Grounding → Scope → Tech Stack → Architecture → Generate), and writes a durable project charter at docs/blueprint.md — vision, users, scope, tech-stack decision, architecture, modules, NFRs, milestones, risks. Its machine-readable Bootstrap section then drives project bootstrap (code init, CI, formatters) by orchestrating /ycc:init and /ycc:formatters. Use when the user asks to "create a project spec", "write a software spec", "whole-project spec", "source of truth spec", "scaffold/bootstrap a new software project from an idea", "project charter/blueprint", or says "/blueprint". Sits UPSTREAM of prp-prd/prp-spec — those are per-feature; this is the whole software.
+argument-hint: '[project idea] (blank = start with questions) [--update] [--dry-run]'
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - Edit
+  - Agent
+  - WebSearch
+  - WebFetch
+  - AskUserQuestion
+  - TodoWrite
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - Bash(test:*)
+  - Bash(mkdir:*)
+  - Bash(git:*)
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/init/scripts/profile-project.sh:*)
+---
+
+# Project Blueprint Generator
+
+> The whole-software charter. Sits at the top of the funnel — upstream of `prp-prd`,
+> `prp-spec`, and every other planning skill. Produces ONE durable source-of-truth spec
+> for an entire piece of software, then bootstraps the project from it.
+
+**Input**: `$ARGUMENTS`
+
+---
+
+## Your Role
+
+You are a principal engineer + product strategist who:
+
+- Starts from the PROBLEM and the desired end-state, not a tech wishlist
+- Makes the tech-stack decision explicit and justified — it has downstream cost
+- Decomposes a whole system into modules with clear responsibilities
+- Asks clarifying questions before assuming; acknowledges uncertainty honestly
+- Treats the blueprint as a living source of truth, not a one-shot document
+
+**Anti-pattern**: Do not fill sections with fluff. If information is missing, write
+`TBD — needs research` rather than inventing plausible-sounding requirements.
+
+---
+
+## Flags & Process Overview
+
+Parse from `$ARGUMENTS`:
+
+- `--update` — re-run over an existing `docs/blueprint.md`; diff-and-merge instead of overwrite.
+- `--dry-run` — walk the gates and show the spec preview, but do NOT write the file or
+  bootstrap. If set, also pass `--dry-run` through to any orchestrated `/ycc:init` call.
+
+```
+DETECT → INITIATE → FOUNDATION → GROUNDING → SCOPE → TECH STACK → ARCHITECTURE → GENERATE → HANDOFF
+```
+
+Each phase builds on previous answers. Grounding uses the `ycc:prp-researcher` agent for
+dual-mode (market + codebase) discovery. Every `[GATE]` means: present the questions via
+`AskUserQuestion`, then WAIT for the user before proceeding. Do not batch gates together.
+
+---
+
+## Phase 0: DETECT — Project Context
+
+Determine whether this is greenfield, an existing repo, or a re-run.
+
+1. Run the shared profiler (read its `key=value` output; do NOT reimplement profiling):
+
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/skills/init/scripts/profile-project.sh
+   ```
+
+   If the script is unavailable (non-Claude target / missing path), fall back gracefully:
+   `test -f docs/blueprint.md` and a quick `ls` to judge emptiness. Do not fail the run.
+
+2. Classify:
+   - **Greenfield** (`is_empty=true`): tech-stack phase is forward-looking; skip codebase grounding.
+   - **Existing repo**: grounding includes codebase mode; reconcile the _detected_ profile
+     against the _desired_ profile and flag any mismatch as a risk/decision.
+   - **Re-run** (`docs/blueprint.md` exists): if `--update`, do a structured refresh
+     (diff each section, merge, preserve user edits). Without `--update`, tell the user the
+     file exists and ask whether to refresh (`--update`) or abort. Never silently overwrite.
+
+---
+
+## Phase 1: INITIATE — What Are We Building?
+
+**If no input provided**, ask:
+
+> **What software do you want to build?**
+> Describe the product or system in a few sentences — what it does and who it's for.
+
+**If input provided**, confirm by restating:
+
+> I understand you want to build: `{restated understanding}`
+> Is this correct, or should I adjust?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 2: FOUNDATION — Vision & Problem
+
+Ask (present all at once):
+
+> **Foundation:**
+>
+> 1. **Vision**: In one sentence, what's the ideal end state if this succeeds wildly?
+> 2. **Target users**: Who is this for? Be specific — roles/segments, not just "users".
+> 3. **Problem**: What observable pain does it solve? Why do today's alternatives fail?
+> 4. **Why now**: What changed that makes this worth building now?
+> 5. **North star**: What single measure tells you it's working?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 3: GROUNDING — Market & Context
+
+Dispatch **`ycc:prp-researcher`** in **dual (market + codebase) mode** to investigate:
+
+- Comparable products/systems and how they're typically built (their stacks are useful
+  priors for the Tech Stack phase)
+- Common architectures, patterns, and anti-patterns in this space
+- Recent trends or shifts
+- If a codebase exists: relevant existing functionality, reusable patterns, constraints
+
+Instruct the researcher to return URL citations for market findings and `file:line`
+references for codebase findings.
+
+**Summarize to the user:**
+
+> **What I found:**
+>
+> - `{Market insight}`
+> - `{Common architecture / stack in this space}`
+> - `{Relevant existing code, if applicable}`
+>
+> Does this change or refine your thinking?
+
+**GATE** (light): brief pause — "continue" or adjustments.
+
+---
+
+## Phase 4: SCOPE — Boundaries & Success
+
+Ask:
+
+> **Scope & Success:**
+>
+> 1. **MVP**: What's the absolute minimum that proves this is worth building?
+> 2. **Capabilities (MoSCoW)**: What MUST be in v1? What SHOULD/COULD wait? (capability level, not feature list)
+> 3. **Non-goals**: What are you explicitly NOT building, even if asked?
+> 4. **Success criteria**: How will you know the whole project succeeded? (beyond the north star)
+> 5. **Constraints**: Time, budget, team size, regulatory, platform.
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 5: TECH STACK — Decisions That Drive Bootstrap
+
+> This phase is gated on its own because its answers are the ONLY ones that map 1:1 to
+> `/ycc:init` and `/ycc:formatters` flags. They must be unambiguous. Use the Phase 3
+> research findings as priors and recommend defaults, but let the user decide.
+
+Ask:
+
+> **Tech Stack:**
+>
+> 1. **Primary language**: one of `rust | ts-node | python | go | mixed | empty`
+>    (these are the values `/ycc:init` understands — pick the closest fit).
+> 2. **Secondary languages** (for mixed stacks): e.g. shell, python alongside ts.
+> 3. **Package manager**: e.g. pnpm/npm/yarn, uv/poetry/pip, cargo, go mod.
+> 4. **Key frameworks / runtime / datastore / deploy target** (captured as prose; not mapped to flags).
+> 5. **CI from day one?** (yes → `/ycc:formatters --ci`, `/ycc:init --templates`)
+> 6. **Formatter/lint stacks to enable** (defaults follow the language: ts/python/rust/go/docs/shell).
+> 7. **GitHub conventions**: issue + PR templates? (`--templates`)
+> 8. **Git conventions**: conventional commits + pre-commit hooks? (`--git`, `--hooks`)
+
+**Coercion rule**: if the primary-language answer is outside
+`rust | ts-node | python | go | mixed | empty`, coerce to the nearest valid value and record
+the coercion in the Decisions Log — this guarantees the orchestrated `--profile=` call cannot fail.
+
+See `${CLAUDE_PLUGIN_ROOT}/skills/blueprint/references/bootstrap-mapping.md` for the full
+key→flag mapping used when generating the Bootstrap section.
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 6: ARCHITECTURE — Decomposition & Risks
+
+Ask:
+
+> **Architecture:**
+>
+> 1. **Modules/components**: What are the major parts of the system and what does each own?
+> 2. **Data flow**: How does data/control move through the system at a high level?
+> 3. **Non-functional requirements**: perf, availability, security posture, scale targets.
+> 4. **Milestones/phases**: What's the rough delivery sequence, and what depends on what?
+> 5. **Top risks**: What could derail this, and how would you mitigate it?
+
+**GATE**: Wait for the user.
+
+---
+
+## Phase 7: GENERATE — Write the Blueprint
+
+**Output path**: `docs/blueprint.md` (fixed — there is exactly one per repo).
+
+If `--dry-run`, render the spec preview to the user and skip writing. Otherwise:
+
+```bash
+mkdir -p docs
+```
+
+If re-running with `--update`, merge into the existing file section-by-section, preserving
+user edits; otherwise write fresh.
+
+### Blueprint Template
+
+````markdown
+# Project Blueprint: {Project Name}
+
+## Vision
+
+{One sentence: the ideal end state.}
+
+## Target Users
+
+- **Primary**: {role/segment, context, trigger}
+- **Job to be done**: When {situation}, I want to {motivation}, so I can {outcome}.
+- **Non-users**: {who this is explicitly NOT for}
+
+## Problem & Why Now
+
+{The observable problem, why alternatives fail, and what changed to make this worth building.}
+
+## Scope
+
+### In Scope (MVP)
+
+| Priority | Capability   | Rationale        |
+| -------- | ------------ | ---------------- |
+| Must     | {capability} | {why essential}  |
+| Should   | {capability} | {why it matters} |
+| Could    | {capability} | {nice to have}   |
+
+### Out of Scope / Non-Goals
+
+- {non-goal} — {why}
+
+### Success Criteria
+
+- **North star**: {single measure}
+- {supporting criterion}
+
+## Tech Stack
+
+{Prose: primary + secondary languages, package manager, frameworks, datastore, deploy
+target — each with a one-line rationale. Note any reconciliation with a detected profile.}
+
+## Architecture
+
+### Module / Component Breakdown
+
+| Component | Responsibility | Depends On |
+| --------- | -------------- | ---------- |
+| {name}    | {what it owns} | {deps}     |
+
+### High-Level Data Flow
+
+{How data/control moves through the system.}
+
+## Non-Functional Requirements
+
+| NFR             | Target   | Rationale |
+| --------------- | -------- | --------- |
+| {perf/security} | {target} | {why}     |
+
+## Milestones / Phases
+
+| #   | Milestone | Description        | Status  | Depends |
+| --- | --------- | ------------------ | ------- | ------- |
+| 1   | {name}    | {what it delivers} | pending | -       |
+| 2   | {name}    | {what it delivers} | pending | 1       |
+
+## Risks
+
+| Risk   | Likelihood | Impact  | Mitigation      |
+| ------ | ---------- | ------- | --------------- |
+| {risk} | {H/M/L}    | {H/M/L} | {how to handle} |
+
+## Decisions Log
+
+| Decision   | Choice   | Alternatives         | Rationale      |
+| ---------- | -------- | -------------------- | -------------- |
+| {decision} | {choice} | {options considered} | {why this one} |
+
+## Bootstrap
+
+<!-- MACHINE-CONSUMABLE: drives /ycc:init and /ycc:formatters. -->
+<!-- See references/bootstrap-mapping.md for the canonical key→flag table. -->
+
+| Key                 | Value                                     | Maps to                               |
+| ------------------- | ----------------------------------------- | ------------------------------------- |
+| profile             | {rust\|ts-node\|python\|go\|mixed\|empty} | init/formatters `--profile=`          |
+| secondary_languages | {e.g. python, shell}                      | multi-stack gitignore/style           |
+| package_manager     | {pnpm\|uv\|cargo\|...}                    | init next-steps + formatters aliases  |
+| ci                  | {yes\|no}                                 | formatters `--ci`; init `--templates` |
+| autofix_ci          | {yes\|no}                                 | omit `--no-autofix` when yes          |
+| formatter_stacks    | {ts, python, shell}                       | formatters `--ts --python --shell`    |
+| github_templates    | {yes\|no}                                 | init `--templates`                    |
+| git_conventions     | {yes\|no}                                 | init `--git`; formatters `--hooks`    |
+| vendor_neutral      | {yes\|no}                                 | init `--vendor-neutral`               |
+
+### Derived Commands
+
+```bash
+{e.g. /ycc:init --profile=ts-node --templates --git --formatters}
+{e.g. /ycc:formatters --profile=ts-node --ts --python --shell --ci --hooks}
+```
+
+## Research Summary
+
+**Market Context**: {key findings}
+**Technical Context**: {key findings}
+
+---
+
+_Generated: {timestamp}_
+_Status: source of truth_
+````
+
+When filling the Bootstrap table and Derived Commands, follow
+`references/bootstrap-mapping.md`. Note that `/ycc:init --formatters` already chains
+`ycc:formatters` at its Phase 6.5, so the single `init` line is usually sufficient; emit the
+explicit `/ycc:formatters …` line only when richer formatter flags (`--ci`, specific stacks,
+`--hooks`) are wanted.
+
+---
+
+## Phase 8: HANDOFF — Bootstrap & Summary
+
+If `--dry-run`, skip orchestration; just print the summary and the Derived Commands.
+
+Otherwise ask via `AskUserQuestion`:
+
+> **Bootstrap this project now?**
+>
+> - **(a) Run it** — invoke `/ycc:init` (+ `formatters`) with the derived flags.
+> - **(b) Show commands** — print the derived commands; I'll run them myself.
+> - **(c) Skip** — just keep the blueprint.
+
+- **On (a)**: invoke the **`ycc:init`** skill, passing the derived flags from the Bootstrap
+  section (e.g. `--profile=ts-node --templates --git --formatters`). `init` chains
+  `ycc:formatters` via its Phase 6.5. If the blueprint run was `--dry-run`, pass `--dry-run`
+  through. If `init` or `formatters` errors, **record the failure and continue** — then emit the
+  manual recovery command (`/ycc:formatters …`). Never report full success on partial failure.
+- **On (b)**: print the Derived Commands block and stop.
+
+### Output Summary
+
+```markdown
+## Blueprint Created
+
+**File**: `docs/blueprint.md`
+
+**Vision**: {one line}
+**Stack**: {profile + key frameworks}
+**Modules**: {count} — {list}
+
+### Bootstrap
+
+{One of: "Ran /ycc:init … (init: ok, formatters: ok)", the derived commands, or "Skipped".}
+
+### Next Steps
+
+- Reference `docs/blueprint.md` as the canonical project description in `CLAUDE.md`.
+- Per module in the breakdown, run `/ycc:prp-spec` (or `/ycc:prp-prd` for fuzzy ones)
+  to produce a feature spec, then `/ycc:prp-plan` → `/ycc:prp-implement`.
+```
+
+---
+
+## Integration with ycc
+
+`blueprint` is the **charter altitude** — upstream of all feature work:
+
+```
+IDEA → /ycc:blueprint → docs/blueprint.md
+            └─Bootstrap→ /ycc:init [--profile --templates --git --formatters]
+                                 └─Phase 6.5→ /ycc:formatters [--ci --hooks --<stack>]
+       per-module → /ycc:prp-prd | /ycc:prp-spec → /ycc:prp-plan → /ycc:prp-implement
+```
+
+- `blueprint` answers "what is this whole software and how do we stand it up?" ONCE per project.
+- `prp-prd` / `prp-spec` answer "what is this one feature/increment?" — they live under
+  `docs/prps/` and are run repeatedly, seeded by the blueprint's module breakdown.
+- Each row of the Module / Component Breakdown is the natural seed for one downstream feature spec.
+
+## Success Criteria
+
+- **VISION_CLEAR**: One-sentence end-state and concrete target users.
+- **SCOPE_BOUNDED**: Explicit MVP, capabilities, and non-goals.
+- **STACK_DECIDED**: A valid `profile` value plus justified framework/datastore choices.
+- **DECOMPOSED**: Modules with responsibilities and a high-level data flow.
+- **BOOTSTRAP_ACTIONABLE**: The Bootstrap section yields a runnable `/ycc:init` command.
+- **HONEST**: Unknowns marked `TBD — needs research`, not invented.

--- a/ycc/skills/blueprint/references/bootstrap-mapping.md
+++ b/ycc/skills/blueprint/references/bootstrap-mapping.md
@@ -1,0 +1,69 @@
+# Bootstrap Mapping
+
+Canonical mapping from the blueprint's machine-readable **Bootstrap** section to
+`/ycc:init` and `/ycc:formatters` flags. This is the single source of truth shared by the
+`blueprint` GENERATE phase and any future `--from-spec` reader. Keep it in sync with the
+flag surfaces of `ycc/skills/init/SKILL.md` and `ycc/skills/formatters/SKILL.md`.
+
+## Key → Flag Table
+
+| Bootstrap key         | Values                                                          | `/ycc:init` flag            | `/ycc:formatters` flag                                       | Notes                                                                       |
+| --------------------- | --------------------------------------------------------------- | --------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `profile`             | `rust \| ts-node \| python \| go \| mixed \| empty`             | `--profile=<value>`         | `--profile=<value>`                                          | The only language vocabulary `init` accepts. Coerce out-of-vocab answers.   |
+| `secondary_languages` | comma list (e.g. `python, shell`)                               | (informs `mixed`)           | per-stack flags (below)                                      | Drives multi-stack gitignore / style activation.                            |
+| `package_manager`     | `pnpm \| npm \| yarn \| uv \| poetry \| pip \| cargo \| go mod` | —                           | —                                                            | Captured for the init "next steps" + formatters aliases; not a direct flag. |
+| `ci`                  | `yes \| no`                                                     | `--templates` (if yes)      | `--ci` (if yes)                                              | CI from day one.                                                            |
+| `autofix_ci`          | `yes \| no`                                                     | —                           | omit `--no-autofix` when `yes`; add `--no-autofix` when `no` | Only meaningful when `ci=yes`.                                              |
+| `formatter_stacks`    | subset of `ts, python, rust, go, docs, shell`                   | —                           | `--ts --python --rust --go --docs --shell`                   | One flag per enabled stack. Default follows `profile`.                      |
+| `github_templates`    | `yes \| no`                                                     | `--templates` (if yes)      | —                                                            | Issue + PR templates, labels, workflows.                                    |
+| `git_conventions`     | `yes \| no`                                                     | `--git` (if yes)            | `--hooks` (if yes)                                           | Conventional commits + pre-commit hooks.                                    |
+| `vendor_neutral`      | `yes \| no`                                                     | `--vendor-neutral` (if yes) | —                                                            | Also emit `.ai/rules/project.md`.                                           |
+
+## Profile Coercion Rules
+
+`init` only understands `rust | ts-node | python | go | mixed | empty`. Map common answers:
+
+| User answer                                 | Coerced `profile` |
+| ------------------------------------------- | ----------------- |
+| TypeScript, JavaScript, Node, Deno, Bun     | `ts-node`         |
+| Python                                      | `python`          |
+| Rust                                        | `rust`            |
+| Go, Golang                                  | `go`              |
+| Two+ primary languages of comparable weight | `mixed`           |
+| No code yet / undecided                     | `empty`           |
+
+Record any coercion in the blueprint's **Decisions Log** so the choice is auditable and the
+orchestrated `--profile=<value>` call cannot fail.
+
+## init Already Chains formatters
+
+`/ycc:init --formatters` invokes the `ycc:formatters` skill at its **Phase 6.5**, passing
+through `--dry-run` and `--force`. Therefore:
+
+- The single line `/ycc:init --profile=<p> --templates --git --formatters` is usually enough
+  to scaffold docs + GitHub + git + a baseline formatter bundle.
+- Emit a **separate** `/ycc:formatters …` line only when you need richer formatter options
+  that `init` does not forward — `--ci`, specific stack flags, or `--hooks`.
+
+## Worked Example
+
+Bootstrap values:
+
+```
+profile          = ts-node
+secondary_languages = python, shell
+package_manager  = pnpm
+ci               = yes
+autofix_ci       = yes
+formatter_stacks = ts, python, shell
+github_templates = yes
+git_conventions  = yes
+vendor_neutral   = no
+```
+
+Derived commands:
+
+```bash
+/ycc:init --profile=ts-node --templates --git --formatters
+/ycc:formatters --profile=ts-node --ts --python --shell --ci --hooks
+```


### PR DESCRIPTION
## Summary

Adds a new interactive `blueprint` skill (`/ycc:blueprint`) at the whole-software / project-charter altitude — the one tier `ycc` was missing. It takes a raw product idea, interrogates it through a multi-gate process, writes a durable source-of-truth spec to `docs/blueprint.md`, and then bootstraps the project from that spec by orchestrating `/ycc:init` (which chains `/ycc:formatters`).

Closes #102

## Changes

- **New skill** `ycc/skills/blueprint/SKILL.md` — 9-phase interactive flow (Detect → Initiate → Foundation → Grounding → Scope → **Tech Stack** → Architecture → Generate → Handoff), mirroring `prp-prd`'s gate discipline. Reuses `ycc:prp-researcher` for grounding; no new agent.
- **Reference** `ycc/skills/blueprint/references/bootstrap-mapping.md` — canonical Bootstrap-key → `init`/`formatters` flag table plus profile-coercion rules, kept in one place.
- **Command** `ycc/commands/blueprint.md` — paired slash-command loader (satisfies `validate-ycc-commands.sh` pairing).
- **Regenerated bundles** for Cursor / Codex / opencode, plus `docs/inventory.json` and `README.md` (via `./scripts/sync.sh`).

Design highlights: Tech Stack is its own gated phase because its answers are the only ones that map 1:1 to `init`/`formatters` flags (coerced to `init`'s profile vocabulary so the orchestrated call can't fail). Handoff uses orchestrate-with-emit-fallback — **zero changes to `init`/`formatters`**.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] `./scripts/sync.sh` regenerates all bundles cleanly (48 skills / 47 commands; `blueprint` present in `docs/inventory.json`)
- [x] `./scripts/validate.sh` full sweep passes (skill↔command pairing, per-target validators, JSON, install coverage)
- [x] `npm run lint:modified` clean after auto-fix
- [ ] Live `/ycc:blueprint` interactive smoke test — requires an interactive session; not run here

## Reviewer Notes

- This is plugin content (source-of-truth under `ycc/` + regenerated bundles). No app code or root `CLAUDE.md` changes.
- A `--from-spec` flag on `init`/`formatters` (read the spec directly) was deliberately deferred to a possible phase 2 to keep blast radius zero.