### PR TITLE
feat(ycc): add visual-plan and visual-recap skills with --visual flag

### DIFF
--- a/.codex-plugin/ycc/.mcp.json
+++ b/.codex-plugin/ycc/.mcp.json
@@ -4,6 +4,13 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "envFile": "${userHome}/.config/env/github-env-mcp"
+    },
+    "plan": {
+      "command": "npx",
+      "args": ["-y", "@agent-native/core@0.59.1", "mcp"],
+      "env": {
+        "AGENT_NATIVE_PLANS_MODE": "local-files"
+      }
     }
   }
 }

--- a/.codex-plugin/ycc/shared/references/agent-native-setup.md
+++ b/.codex-plugin/ycc/shared/references/agent-native-setup.md
@@ -1,0 +1,102 @@
+# Agent-Native Runtime — Shared Setup Contract
+
+Reference for ycc skills that drive the Agent-Native visual-planning runtime — currently
+`~/.codex/plugins/ycc/skills/visual-plan/SKILL.md` and
+`~/.codex/plugins/ycc/skills/visual-recap/SKILL.md`. Both skills cite this doc so the install
+pin, the auth/reconnect flow, the connector names, the localhost bridge, and the egress
+policy stay convergent. Fix them here, not per skill (DRY).
+
+The pinned version below was resolved with `npm view @agent-native/core version` at authoring
+time. Re-resolve and re-pin before a release if the runtime has advanced — never substitute a
+floating `latest` dist-tag into committed content.
+
+---
+
+## Install (pinned)
+
+Install a skill from the Agent-Native core CLI with an **explicit pinned version**:
+
+```
+npx -y @agent-native/core@0.59.1 skills add <skill>
+```
+
+- The pin (`0.59.1`) is the version resolved via `npm view @agent-native/core version`.
+- Never commit a floating `latest` dist-tag — the block vocabulary and CLI surface drift
+  between releases, so an unpinned install can silently change behavior. Pin, verify, then bump
+  deliberately.
+
+## Reconnect / auth (one-time per client)
+
+Authorize the runtime against the hosted Plans origin once per client. This is a one-time
+step per machine/client, not per skill run:
+
+```
+npx -y @agent-native/core@0.59.1 reconnect https://plan.agent-native.com --client [claude-code|codex|all]
+```
+
+- `--client all` reconnects every detected client at once.
+- Re-run only when credentials are revoked or the client is reinstalled.
+
+## MCP connector
+
+The runtime exposes an MCP connector named **`plan`**. The legacy alias **`agent-native-plans`**
+still resolves to the same connector — accept either name when detecting an existing
+connection, but prefer `plan` in new guidance.
+
+## Local-only operation
+
+For local-only operation (no hosted calls, no auth required), set:
+
+```
+AGENT_NATIVE_PLANS_MODE=local-files
+```
+
+In this mode the runtime reads and writes plans on the local filesystem only; it does not
+contact `plan.agent-native.com`.
+
+## Localhost bridge
+
+To preview a plan locally, use the `plan local` bridge commands against the plan directory:
+
+```
+plan local check --dir plans/<slug>
+plan local serve --dir plans/<slug> --open
+```
+
+- `check` validates the plan files under `plans/<slug>` without serving.
+- `serve` binds **127.0.0.1** on an **ephemeral, CLI-chosen port** and opens the preview with
+  `--open`.
+- The bridge performs **no DB writes** and sends **nothing to any server** — it is a purely
+  local render of the on-disk plan.
+
+## Block vocabulary (resolve at USE TIME)
+
+> GOTCHA: The MDX block vocabulary drifts upstream between releases. Do **not** trust any
+> hardcoded component/block list in skill bodies or in this doc.
+
+At the runtime-author step (use time, not authoring time), fetch the live block catalog:
+
+- Hosted/connected: call the **`get-plan-blocks`** MCP tool.
+- Offline / `local-files` fallback: run `plan blocks --out <path>` to dump the current catalog.
+
+Always render plan MDX against the freshly-fetched block list, never a list memorized in a
+skill.
+
+## Egress policy
+
+Hosted upload is **OFF by default** and **consent-gated**:
+
+- No plan content leaves the machine unless the operator passes an explicit `--share` flag
+  that names the destination host `plan.agent-native.com`.
+- All hosted egress MUST be routed through
+  `~/.codex/plugins/ycc/shared/scripts/visual-egress-guard.sh` so the consent check
+  and destination allowlist are enforced in one place.
+- Localhost bridge usage (above) is not egress: it stays on 127.0.0.1 and writes nothing
+  remote.
+
+## Hosted Plans app
+
+- Hosted origin: `https://plan.agent-native.com`.
+- Create tools return **absolute, shareable URLs** under that origin.
+- Plans backed by a **private repo are org-gated** — only members of the owning org can open
+  the shared URL.

--- a/.codex-plugin/ycc/shared/references/visual-mode.md
+++ b/.codex-plugin/ycc/shared/references/visual-mode.md
@@ -1,0 +1,152 @@
+# Visual Mode — Canonical Reference
+
+Used by `prp-plan`, `plan`, `parallel-plan`, and `plan-workflow`
+to expose a uniform `--visual` decorator. This file documents the **single
+`--visual` contract** shared by all four planning skills: when it runs, how it
+composes with other flags, how `--dry-run` short-circuits it, and the hand-off
+to `visual-plan`. Individual skills own their own flag plumbing and the path
+where they write a plan; the shared **invariant** lives here.
+
+`--visual` is a **terminal decorator step**, not a dispatch mode. It does not
+change how a plan is researched, dispatched, or written — it only runs once,
+**after** the plan exists and has been validated, to produce a visual rendering
+of that plan.
+
+See [worktree-strategy.md](./worktree-strategy.md) for where plan artifacts live
+and [agent-team-dispatch.md](./agent-team-dispatch.md) for the team lifecycle
+that `--team` layers on top of planning.
+
+---
+
+## 0. Default Behavior
+
+`--visual` is **off by default** on all four planning skills. When omitted, the
+skill behaves exactly as it does today and writes no visual output.
+
+| Skill               | Writes a plan artifact by default?   | `--visual` target                         |
+| ------------------- | ------------------------------------ | ----------------------------------------- |
+| `prp-plan`      | yes — `docs/prps/plans/*.plan.md`    | the written plan file                     |
+| `parallel-plan` | yes — feature-dir `parallel-plan.md` | the written plan file                     |
+| `plan-workflow` | yes — feature-dir `parallel-plan.md` | the written plan file                     |
+| `plan`          | **no** — plan kept in-chat           | a plan file `--visual` is forced to write |
+
+The plan path differs per skill (and `plan` writes none by default). The
+contract therefore never hardcodes `docs/prps/plans`; it passes whatever
+absolute plan path the skill produced to `visual-plan` and lets that skill
+derive its output directory. See §3 (hand-off) and §4 (`plan` special case).
+
+---
+
+## 1. Timing — runs AFTER write AND validation
+
+`--visual` is the **last** step of a planning run. The order is fixed:
+
+1. Research / dispatch / plan generation (unchanged by `--visual`).
+2. Write the plan artifact to its skill-specific path.
+3. **Validate** the plan per the skill's existing rules.
+4. **Only then** run the `--visual` decorator step.
+
+If steps 1–3 do not complete (research aborts, write fails, or validation
+fails), the `--visual` step does **not** run. There is nothing valid to
+visualize, so the skill reports the upstream failure and stops.
+
+`--visual` never re-orders, re-runs, or substitutes for any earlier phase.
+
+---
+
+## 2. Composition with other flags
+
+`--visual` is **orthogonal** to and **composes with** the dispatch/runtime
+flags. It is applied once, at the end, regardless of which of these are present:
+
+| Flag            | Interaction with `--visual`                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| `--parallel`    | Independent. Parallel dispatch finishes, plan is written + validated, then `--visual` runs once. |
+| `--team`        | Independent. Team lifecycle completes first; `--visual` decorates the final plan.                |
+| `--enhanced`    | Independent. Enhancement affects plan content; `--visual` renders the enhanced result.           |
+| `--no-worktree` | Independent. Worktree opt-out does not affect whether or how `--visual` runs.                    |
+| `--dry-run`     | **Short-circuits** `--visual` (see §2.1).                                                        |
+
+Because `--visual` is a terminal decorator, the combination
+`--parallel --team --visual` (etc.) means: do the parallel/team planning, write
+
+- validate the plan, then run the single `--visual` step on the result.
+
+### 2.1 `--dry-run` short-circuit
+
+When `--dry-run` is present, `--visual` is **short-circuited**: the skill prints
+
+```
+visual generation would run
+```
+
+and does **not** generate anything and does **not** invoke `visual-plan`.
+`--dry-run` always wins over `--visual`; no visual artifacts, directories, or
+links are produced in a dry run.
+
+---
+
+## 3. Hand-off to `visual-plan`
+
+When `--visual` runs for real (not `--dry-run`), the planning skill invokes:
+
+```
+visual-plan <absolute-plan-path>
+```
+
+passing the **absolute path** of the plan file it wrote and validated.
+
+Contract for `visual-plan`:
+
+- **Accept ANY plan path.** It must not assume `docs/prps/plans` or any other
+  fixed location. The plan path is supplied by the caller and may live anywhere
+  (e.g. `docs/prps/plans/<name>.plan.md`, a feature-dir `parallel-plan.md`, or a
+  forced-write file from `plan`).
+- **Derive `visual/` relative to the given plan path.** The output directory is
+  a `visual/` sibling of the plan file — i.e. `<dirname of plan>/visual/` —
+  computed from the path it was handed, never hardcoded.
+- **Print the resulting link to stdout.** Exactly one of:
+  - a hosted shareable URL, or
+  - a localhost preview `http://127.0.0.1:PORT/...`, or
+  - `local files only` when no server/host is available.
+- **NEVER re-run research or dispatch.** It only consumes an existing plan.
+- **NEVER edit the plan file.** It reads the plan and writes only into the
+  derived `visual/` directory; the plan artifact is left byte-for-byte intact.
+
+The planning skill surfaces whatever link `visual-plan` prints; it does not
+re-derive the path itself.
+
+---
+
+## 4. `$plan --visual` special case — force a write FIRST
+
+`plan` writes **no** artifact by default (the plan stays in-chat). There is
+therefore nothing on disk to visualize. When `--visual` is passed to
+`plan`:
+
+1. `plan` **MUST force a plan-file write first**, producing an absolute plan
+   path on disk (this write happens even though it would normally be skipped).
+2. That forced write is then validated like any other plan.
+3. Only after a valid file exists does `plan` hand the absolute path to
+   `visual-plan <absolute-plan-path>`.
+
+Without the forced write there is no input for `visual-plan`, so the
+force-write rule is mandatory — not optional — for `plan --visual`. Under
+`--dry-run` this is moot: the §2.1 short-circuit applies and `plan` prints
+`visual generation would run` without forcing any write.
+
+---
+
+## 5. NAMING_CONVENTION
+
+In-body references to skill assets use the plugin-root variable, e.g.:
+
+- `~/.codex/plugins/ycc/skills/visual-plan/SKILL.md`
+- `~/.codex/plugins/ycc/skills/plan/SKILL.md`
+- `~/.codex/plugins/ycc/skills/prp-plan/SKILL.md`
+- `~/.codex/plugins/ycc/skills/parallel-plan/SKILL.md`
+- `~/.codex/plugins/ycc/skills/plan-workflow/SKILL.md`
+
+The hand-off is always expressed as the skill invocation
+`visual-plan <absolute-plan-path>`, with `<absolute-plan-path>` resolved by
+the calling skill to a real, absolute path on disk.

--- a/.codex-plugin/ycc/shared/scripts/visual-egress-guard.sh
+++ b/.codex-plugin/ycc/shared/scripts/visual-egress-guard.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+#
+# visual-egress-guard.sh — pre-upload guard for hosted visual-plan egress.
+#
+# Runs BEFORE any MDX/diff payload leaves the machine for a hosted service
+# (e.g. plan.agent-native.com). It enforces three independent gates:
+#   1. Secret/denylist scan of the payload (mirrors clean/validate-safety.sh).
+#   2. Public-remote check — refuses when the repo's resolved remote is the
+#      private Forgejo origin or any non-public host (never hardcodes a host
+#      beyond the public allowlist; the remote URL comes from `git remote
+#      get-url`).
+#   3. Explicit consent — a consent token naming the destination host must be
+#      supplied before egress is permitted.
+#
+# Usage:
+#   visual-egress-guard.sh --payload <path> [--remote <name>] \
+#       [--destination <host>] [--consent <host>]
+#
+# Arguments:
+#   --payload <path>        File or directory to scan before upload (required).
+#   --remote <name>         Remote whose URL gates publicity (default: tracked
+#                           upstream's remote, else "origin").
+#   --destination <host>    Hosted egress destination (default: plan.agent-native.com).
+#   --consent <host>        Explicit consent token; MUST equal --destination.
+#
+# Exit codes:
+#   0 - All gates passed; hosted egress is permitted
+#   1 - Usage / missing required argument
+#   2 - Secret/denylist hit found in the payload (egress aborted)
+#   3 - Resolved remote is non-public (private Forgejo / non-allowlisted host)
+#   4 - Missing or mismatched consent token
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging helpers (stdout = results, stderr = diagnostics)
+# ---------------------------------------------------------------------------
+
+_error() {
+  echo "visual-egress-guard.sh: error: $*" >&2
+}
+
+_info() {
+  echo "visual-egress-guard.sh: $*" >&2
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  visual-egress-guard.sh --payload <path> [--remote <name>] \
+      [--destination <host>] [--consent <host>]
+
+Arguments:
+  --payload <path>      File or directory to scan before upload (required).
+  --remote <name>       Remote whose URL gates publicity (default: upstream's
+                        remote, else "origin").
+  --destination <host>  Hosted egress destination (default: plan.agent-native.com).
+  --consent <host>      Explicit consent token; MUST equal --destination.
+
+Exit codes: 0 ok | 1 usage | 2 secret hit | 3 non-public remote | 4 no consent
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Denylist — mirrors clean/validate-safety.sh PROTECTED/SECURITY patterns.
+# ---------------------------------------------------------------------------
+
+declare -a PROTECTED=(
+  ".env"
+  ".env.*"
+  "*.pem"
+  "*.key"
+  "*.p12"
+  "*.pfx"
+  "*.crt"
+  "id_rsa"
+  "id_ed25519"
+  "credentials.json"
+  "secrets.json"
+)
+
+# Non-public host detection. A host is treated as non-public (egress refused)
+# when it is the known-private Forgejo origin, sits on a private/tailnet TLD, is
+# a loopback/RFC1918 address, or is an unqualified single-label hostname. Any
+# other fully-qualified public host is allowed. This deliberately avoids
+# hardcoding a public vendor host: publicity is inferred, privacy is matched.
+#
+# The known-private host defaults to the Forgejo origin and may be overridden
+# via VISUAL_EGRESS_PRIVATE_HOST for other deployments.
+PRIVATE_HOST="${VISUAL_EGRESS_PRIVATE_HOST:-git.azules-celsius.ts.net}"
+
+declare -a PRIVATE_SUFFIXES=(
+  ".ts.net"
+  ".local"
+  ".internal"
+  ".lan"
+  ".home.arpa"
+  ".localdomain"
+)
+
+DEFAULT_DESTINATION="plan.agent-native.com"
+
+# ---------------------------------------------------------------------------
+# Argument parsing (strict case-based flag handling)
+# ---------------------------------------------------------------------------
+
+PAYLOAD=""
+REMOTE_NAME=""
+DESTINATION="$DEFAULT_DESTINATION"
+CONSENT=""
+
+require_value() {
+  if [[ $# -lt 2 || -z "$2" ]]; then
+    _error "flag $1 requires a value"
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --payload)
+      require_value "$@"
+      PAYLOAD="$2"
+      shift 2
+      ;;
+    --remote)
+      require_value "$@"
+      REMOTE_NAME="$2"
+      shift 2
+      ;;
+    --destination)
+      require_value "$@"
+      DESTINATION="$2"
+      shift 2
+      ;;
+    --consent)
+      require_value "$@"
+      CONSENT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      _error "unexpected positional argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$PAYLOAD" ]]; then
+  _error "--payload is required"
+  usage
+  exit 1
+fi
+
+if [[ ! -e "$PAYLOAD" ]]; then
+  _error "payload not found: $PAYLOAD"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Gate 1: secret / denylist scan (exit 2 on hit)
+# ---------------------------------------------------------------------------
+
+# Convert a denylist glob into a path-anchored extended regex.
+glob_to_regex() {
+  local g="$1"
+  g="${g//./\\.}"        # escape literal dots
+  g="${g//\*/[^/ ]*}"    # '*' matches a run of non-slash, non-space chars
+  printf '(^|[ /])%s($|[ /])' "$g"
+}
+
+SECRET_HITS=0
+for pattern in "${PROTECTED[@]}"; do
+  regex="$(glob_to_regex "$pattern")"
+
+  # (a) Protected path referenced in payload content (e.g. diff headers).
+  if grep -rInE -- "$regex" "$PAYLOAD" >/dev/null 2>&1; then
+    _error "denylist hit (content): pattern '$pattern' present in payload"
+    SECRET_HITS=$((SECRET_HITS + 1))
+  fi
+
+  # (b) An actual protected file inside the payload tree.
+  if [[ -d "$PAYLOAD" ]]; then
+    if find "$PAYLOAD" -type f -name "$pattern" -print -quit 2>/dev/null | grep -q .; then
+      _error "denylist hit (file): '$pattern' file exists under payload"
+      SECRET_HITS=$((SECRET_HITS + 1))
+    fi
+  else
+    # shellcheck disable=SC2053
+    if [[ "$(basename "$PAYLOAD")" == $pattern ]]; then
+      _error "denylist hit (file): payload basename matches '$pattern'"
+      SECRET_HITS=$((SECRET_HITS + 1))
+    fi
+  fi
+done
+
+if [[ "$SECRET_HITS" -gt 0 ]]; then
+  _error "aborting: ${SECRET_HITS} secret/denylist hit(s) — payload is unsafe to upload"
+  exit 2
+fi
+_info "secret scan clean"
+
+# ---------------------------------------------------------------------------
+# Gate 2: public-remote check (exit 3 when non-public)
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository; cannot verify remote publicity"
+  exit 3
+fi
+
+# Default the remote name to the tracked upstream's remote, else "origin".
+if [[ -z "$REMOTE_NAME" ]]; then
+  UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+  if [[ -n "$UPSTREAM" && "$UPSTREAM" == */* ]]; then
+    REMOTE_NAME="${UPSTREAM%%/*}"
+  else
+    REMOTE_NAME="origin"
+  fi
+fi
+
+REMOTE_URL="$(git remote get-url "$REMOTE_NAME" 2>/dev/null || true)"
+if [[ -z "$REMOTE_URL" ]]; then
+  _error "could not resolve URL for remote '$REMOTE_NAME'"
+  exit 3
+fi
+
+# Extract the host from any common git URL form without hardcoding a host.
+remote_host() {
+  local url="$1"
+  url="${url#*://}"   # drop scheme:// if present
+  url="${url#*@}"     # drop user@ if present
+  url="${url%%[:/]*}" # host is up to the first ':' or '/'
+  printf '%s' "$url"
+}
+
+HOST="$(remote_host "$REMOTE_URL")"
+HOST="$(printf '%s' "$HOST" | tr '[:upper:]' '[:lower:]')"
+
+# Decide whether a host is public. Privacy is matched explicitly; anything not
+# matched as private but shaped like a public FQDN is treated as public.
+is_public_host() {
+  local host="$1"
+
+  # Known-private origin.
+  [[ "$host" == "$PRIVATE_HOST" ]] && return 1
+
+  # Loopback / RFC1918 literals.
+  case "$host" in
+    localhost|127.*|10.*|192.168.*) return 1 ;;
+    172.1[6-9].*|172.2[0-9].*|172.3[01].*) return 1 ;;
+  esac
+
+  # Private / internal / tailnet suffixes.
+  local suffix
+  for suffix in "${PRIVATE_SUFFIXES[@]}"; do
+    [[ "$host" == *"$suffix" ]] && return 1
+  done
+
+  # Unqualified single-label hostnames are not public.
+  [[ "$host" != *.* ]] && return 1
+
+  return 0
+}
+
+if ! is_public_host "$HOST"; then
+  _error "refusing hosted egress: remote '$REMOTE_NAME' host '$HOST' is not public"
+  _error "private/internal remotes (e.g. the Forgejo origin) must not upload to ${DESTINATION}"
+  exit 3
+fi
+_info "remote '$REMOTE_NAME' host '$HOST' is public"
+
+# ---------------------------------------------------------------------------
+# Gate 3: explicit consent (exit 4 when missing/mismatched)
+# ---------------------------------------------------------------------------
+
+if [[ -z "$CONSENT" ]]; then
+  _error "missing consent: pass --consent ${DESTINATION} to authorize hosted egress"
+  exit 4
+fi
+
+if [[ "$CONSENT" != "$DESTINATION" ]]; then
+  _error "consent mismatch: --consent '$CONSENT' does not name destination '${DESTINATION}'"
+  exit 4
+fi
+_info "consent confirmed for destination '${DESTINATION}'"
+
+# ---------------------------------------------------------------------------
+# All gates passed -> result on stdout
+# ---------------------------------------------------------------------------
+
+echo "egress-permitted destination=${DESTINATION} remote=${REMOTE_NAME} host=${HOST}"
+exit 0

--- a/.codex-plugin/ycc/shared/scripts/visual-recap-collect.sh
+++ b/.codex-plugin/ycc/shared/scripts/visual-recap-collect.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# visual-recap-collect.sh — remote-agnostic local diff collector for visual recap.
+#
+# Collects a diff bundle using ONLY local git refs so it behaves identically on
+# any remote (public GitHub or the private Forgejo). It NEVER calls a vendor PR
+# API and NEVER hardcodes a remote host or branch name.
+#
+# Usage:
+#   visual-recap-collect.sh [<base>..<head> | <branch>]
+#
+# Arguments:
+#   (none)            Collect the working-tree diff (git diff HEAD).
+#   <base>..<head>    Collect git diff <base>...<head> (explicit two endpoints).
+#   <branch>          Treat <branch> as head; compute base via `git merge-base`
+#                     against the tracked upstream (resolved from @{upstream}).
+#
+# Base resolution NEVER hardcodes a trunk branch: the upstream is resolved with
+#   git rev-parse --abbrev-ref --symbolic-full-name @{upstream}
+# and falls back gracefully to merge-base against HEAD when no upstream is set.
+#
+# Output:
+#   - Diff bundle written under docs/prps/reviews/visual/<slug>/
+#       diff.patch     full unified diff (local refs only)
+#       files.txt      changed-file name list
+#       metadata.txt   range/base/head/remote provenance
+#   - Results (bundle path + summary) on stdout.
+#   - All errors and progress notes on stderr.
+#
+# Exit codes:
+#   0 - Bundle collected successfully
+#   1 - Usage / git / I/O failure
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging helpers (stdout = results, stderr = diagnostics)
+# ---------------------------------------------------------------------------
+
+_error() {
+  echo "visual-recap-collect.sh: error: $*" >&2
+}
+
+_info() {
+  echo "visual-recap-collect.sh: $*" >&2
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  visual-recap-collect.sh [<base>..<head> | <branch>]
+
+Arguments:
+  (none)            Collect the working-tree diff (git diff HEAD).
+  <base>..<head>    Collect git diff <base>...<head>.
+  <branch>          Use <branch> as head; base = merge-base(@{upstream}, <branch>).
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing (strict case-based flag handling)
+# ---------------------------------------------------------------------------
+
+RANGE_ARG=""
+
+set_range_arg() {
+  if [[ -z "$RANGE_ARG" ]]; then
+    RANGE_ARG="$1"
+  else
+    _error "unexpected positional argument: $1"
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        set_range_arg "$1"
+        shift
+      done
+      break
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      set_range_arg "$1"
+      shift
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Git context
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository"
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+CURRENT_BRANCH="$(git branch --show-current || true)"
+
+# Resolve the tracked upstream without ever hardcoding a trunk branch name.
+resolve_upstream() {
+  git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true
+}
+
+# Resolve the remote URL for the given remote name (never hardcode a host).
+remote_url_for() {
+  local name="$1"
+  git remote get-url "$name" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Range / mode resolution
+# ---------------------------------------------------------------------------
+
+MODE=""
+BASE_REF=""
+HEAD_REF=""
+RANGE_LABEL=""
+
+if [[ -z "$RANGE_ARG" ]]; then
+  # Default: working-tree diff against HEAD.
+  MODE="worktree"
+  HEAD_REF="HEAD"
+  RANGE_LABEL="working-tree"
+elif [[ "$RANGE_ARG" == *".."* ]]; then
+  MODE="range"
+  BASE_REF="${RANGE_ARG%%..*}"
+  HEAD_REF="${RANGE_ARG##*..}"
+  if [[ -z "$BASE_REF" || -z "$HEAD_REF" ]]; then
+    _error "malformed range '$RANGE_ARG'; expected <base>..<head>"
+    exit 1
+  fi
+  RANGE_LABEL="${BASE_REF}...${HEAD_REF}"
+else
+  MODE="branch"
+  HEAD_REF="$RANGE_ARG"
+  if ! git rev-parse --verify --quiet "${HEAD_REF}^{commit}" >/dev/null; then
+    _error "not a valid ref: $HEAD_REF"
+    exit 1
+  fi
+  UPSTREAM="$(resolve_upstream)"
+  if [[ -n "$UPSTREAM" ]]; then
+    _info "tracked upstream: $UPSTREAM"
+    BASE_REF="$(git merge-base "$UPSTREAM" "$HEAD_REF" 2>/dev/null || true)"
+  fi
+  if [[ -z "$BASE_REF" ]]; then
+    _info "no upstream merge-base; falling back to merge-base against HEAD"
+    BASE_REF="$(git merge-base HEAD "$HEAD_REF" 2>/dev/null || true)"
+  fi
+  if [[ -z "$BASE_REF" ]]; then
+    _error "could not compute a merge-base for '$HEAD_REF'"
+    exit 1
+  fi
+  RANGE_LABEL="${BASE_REF}...${HEAD_REF}"
+fi
+
+# ---------------------------------------------------------------------------
+# Slug derivation (filesystem-safe; lowercase alnum + dashes)
+# ---------------------------------------------------------------------------
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -e 's#[^a-z0-9]\+#-#g' -e 's#^-\+##' -e 's#-\+$##'
+}
+
+case "$MODE" in
+  worktree)
+    SLUG_SOURCE="${CURRENT_BRANCH:-detached-head}"
+    ;;
+  range)
+    SLUG_SOURCE="${BASE_REF}-to-${HEAD_REF}"
+    ;;
+  branch)
+    SLUG_SOURCE="$HEAD_REF"
+    ;;
+esac
+
+SLUG="$(slugify "$SLUG_SOURCE")"
+if [[ -z "$SLUG" ]]; then
+  SLUG="recap"
+fi
+
+# ---------------------------------------------------------------------------
+# Collect the diff (LOCAL refs only — identical on GitHub and Forgejo)
+# ---------------------------------------------------------------------------
+
+OUT_DIR="docs/prps/reviews/visual/${SLUG}"
+mkdir -p "$OUT_DIR"
+
+DIFF_FILE="${OUT_DIR}/diff.patch"
+FILES_FILE="${OUT_DIR}/files.txt"
+META_FILE="${OUT_DIR}/metadata.txt"
+
+if [[ "$MODE" == "worktree" ]]; then
+  git diff HEAD >"$DIFF_FILE" || { _error "git diff failed"; exit 1; }
+  git diff --name-only HEAD >"$FILES_FILE" || { _error "git diff --name-only failed"; exit 1; }
+else
+  # Three-dot diff against the merge-base of base and head.
+  git diff "${BASE_REF}...${HEAD_REF}" >"$DIFF_FILE" || { _error "git diff failed"; exit 1; }
+  git diff --name-only "${BASE_REF}...${HEAD_REF}" >"$FILES_FILE" || { _error "git diff --name-only failed"; exit 1; }
+fi
+
+# Remote provenance: record every remote URL via `git remote get-url` so the
+# bundle is auditable without hardcoding any host.
+{
+  echo "generated-by: visual-recap-collect.sh"
+  echo "mode: ${MODE}"
+  echo "range: ${RANGE_LABEL}"
+  echo "base: ${BASE_REF:-<working-tree>}"
+  echo "head: ${HEAD_REF}"
+  echo "current-branch: ${CURRENT_BRANCH:-<detached>}"
+  echo "slug: ${SLUG}"
+  echo "remotes:"
+  while IFS= read -r _rname; do
+    [[ -z "$_rname" ]] && continue
+    echo "  - ${_rname}: $(remote_url_for "$_rname")"
+  done < <(git remote)
+} >"$META_FILE"
+
+CHANGED_COUNT="$(grep -c . "$FILES_FILE" 2>/dev/null)" || CHANGED_COUNT=0
+
+# ---------------------------------------------------------------------------
+# Results -> stdout
+# ---------------------------------------------------------------------------
+
+echo "$OUT_DIR"
+_info "collected ${CHANGED_COUNT} changed file(s) for range '${RANGE_LABEL}'"
+_info "bundle: ${OUT_DIR}/{diff.patch,files.txt,metadata.txt}"
+
+exit 0

--- a/.codex-plugin/ycc/skills/parallel-plan/SKILL.md
+++ b/.codex-plugin/ycc/skills/parallel-plan/SKILL.md
@@ -54,13 +54,14 @@ Parse arguments (flags first, then the feature name):
 - **--team**: Optional. (Codex runtime only; not available in bundle invocations) Deploy the analysis and validation stages as teammates under a shared `create an agent group`/`the task tracker` with coordinated shutdown. Default is standalone parallel sub-agents via the `Task` tool. Cursor and Codex bundles lack team tools — do not pass `--team` there.
 - **--worktree**: Optional. (legacy — now default; safe to omit) Worktree annotations are emitted by default. Accepted as a silent no-op so existing pipelines continue to work.
 - **--no-worktree**: Optional. Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.
+- **--visual**: Optional. Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`.
 - **--dry-run**: Show what would be created without making changes. With `--team`, also prints the team name and teammate roster.
 - **feature-name**: Required. Matches directory name in `${PLANS_DIR}`.
 
 If no feature name provided, abort with usage instructions:
 
 ```
-Usage: /parallel-plan [--team] [--no-worktree] [feature-name] [--dry-run]
+Usage: /parallel-plan [--team] [--no-worktree] [--visual] [feature-name] [--dry-run]
 
 Examples:
   /parallel-plan user-authentication
@@ -69,7 +70,18 @@ Examples:
   /parallel-plan --team --dry-run user-authentication
   /parallel-plan user-authentication                     # worktree annotations included by default
   /parallel-plan --no-worktree user-authentication       # skip worktree annotations
+  /parallel-plan --visual user-authentication            # also render the plan as a visual artifact
 ```
+
+---
+
+## Visual mode
+
+`--visual` follows the canonical contract at `~/.codex/plugins/ycc/shared/references/visual-mode.md`. It is a **terminal decorator**, not a dispatch mode: it does not change how the plan is researched, dispatched, or written, and composes orthogonally with `--team` and `--no-worktree`.
+
+When `VISUAL_MODE` is set and not `--dry-run`, after the final phase (plan written in Phase 4, validated in Phase 6 Step 21) the skill invokes `visual-plan <absolute-plan-path>` on the **actual written plan path** — the absolute path of `${feature_dir}/parallel-plan.md`. The bootstrap invocation lives in Step 21.5.
+
+When `--dry-run` is also present, `--visual` is short-circuited (see Step 4): the skill prints `visual generation would run` and generates no artifact, directory, or link.
 
 ---
 
@@ -91,7 +103,8 @@ Extract from `$ARGUMENTS`:
 1. **--team**: Boolean flag. Set `AGENT_TEAM_MODE=true` if present, else `false`.
 2. **--dry-run**: Boolean flag. Set `DRY_RUN=true` if present, else `false`.
 3. **--no-worktree / --worktree**: Default `WORKTREE_MODE=true`. Set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default).
-4. **feature-name**: First non-flag argument (required).
+4. **--visual**: Boolean flag. Set `VISUAL_MODE=true` if present, else `false`.
+5. **feature-name**: First non-flag argument (required).
 
 ```bash
 # Default ON; pass --no-worktree to opt out. --worktree accepted as legacy no-op.
@@ -101,7 +114,15 @@ case " $ARGUMENTS " in
 esac
 ARGUMENTS="${ARGUMENTS//--no-worktree/}"
 ARGUMENTS="${ARGUMENTS//--worktree/}"  # legacy no-op
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
+
+`--visual` is orthogonal — it composes with `--team`/`--no-worktree` and runs after the plan is written and validated. `--dry-run` short-circuits it (prints intent only); see Step 4 and the `## Visual mode` section.
 
 **Compatibility note**: When this skill is invoked from a Cursor or Codex bundle, `--team` must not be used (those bundles ship without team tools).
 
@@ -187,6 +208,14 @@ Teammates:      6 across 2 batches
 ```
 
 Do **not** call `create an agent group`, `record the task`, `Agent`, `Task`, `send follow-up instructions`, or `close the agent group` in dry-run mode.
+
+If `VISUAL_MODE=true`, the `--visual` step is **short-circuited** by `--dry-run`: print intent ONLY and generate no visual artifact (`--dry-run` always wins over `--visual`):
+
+```
+visual generation would run
+```
+
+Do **not** invoke `visual-plan` or create any `visual/` directory or link in dry-run mode.
 
 **STOP HERE** - do not write files or deploy agents.
 
@@ -523,6 +552,21 @@ Run the validation script:
 ```
 
 Report any structural issues found.
+
+### Step 21.5: Visual Artifact (if `--visual`)
+
+If `VISUAL_MODE=false`, skip this step entirely.
+
+This step runs **only after** the plan has been written (Step 14) and validated (Step 21). Follow the canonical contract at `~/.codex/plugins/ycc/shared/references/visual-mode.md`. `--visual` is a terminal decorator: it never re-runs research, dispatch, or plan generation.
+
+- If `DRY_RUN=true`, this step was already short-circuited in Step 4 (printed `visual generation would run`); do **not** generate anything here.
+- Otherwise, when `VISUAL_MODE=true` and not `--dry-run`, invoke `visual-plan` on the **actual written plan path** (the absolute path of `${feature_dir}/parallel-plan.md`):
+
+```
+visual-plan <absolute-path-to-${feature_dir}/parallel-plan.md>
+```
+
+Surface whatever link `visual-plan` prints (hosted shareable URL with `--share`, localhost preview, or `local files only`). Do not re-derive the output path — `visual-plan` derives `visual/` relative to the plan path and leaves the plan file byte-for-byte intact.
 
 ### Step 22: Clean Up Team (if `--team`)
 

--- a/.codex-plugin/ycc/skills/plan-workflow/SKILL.md
+++ b/.codex-plugin/ycc/skills/plan-workflow/SKILL.md
@@ -43,12 +43,13 @@ Parse arguments (flags first, then the feature name):
 - **--dry-run**: Show execution plan without running. With `--team`, also prints the team name and teammate roster.
 - **--worktree**: Optional. (legacy — now default; safe to omit) Worktree annotations are emitted in the generated `parallel-plan.md` by default. Accepted as a silent no-op so existing pipelines continue to work.
 - **--no-worktree**: Optional. Opt out of worktree annotations in the generated `parallel-plan.md`. No effect when `--research-only` is passed (no plan file is generated). Honored with `--plan-only`.
+- **--visual**: Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`.
 - **feature-name**: Required. Directory name in `${PLANS_DIR}/`
 
 If no feature name provided, abort with usage instructions:
 
 ```
-Usage: /plan-workflow [--team] [options] [feature-name]
+Usage: /plan-workflow [--team] [options] [--visual] [feature-name]
 
 Options:
   --team            (Codex runtime only; not available in bundle invocations) Dispatch stages as agent team (default: standalone sub-agents)
@@ -59,6 +60,7 @@ Options:
   --dry-run         Show execution plan without running
   --worktree        (legacy — now default; safe to omit) Worktree annotations emitted by default
   --no-worktree     Opt out of worktree annotations in the generated parallel-plan.md
+  --visual          Render the finished plan as a visual artifact via visual-plan (local-files by default; hosted link requires --share)
 
 Examples:
   /plan-workflow user-authentication
@@ -69,7 +71,26 @@ Examples:
   /plan-workflow --team --dry-run new-feature
   /plan-workflow add-billing-dashboard                 # worktree annotations included by default
   /plan-workflow --no-worktree add-billing-dashboard   # skip worktree annotations
+  /plan-workflow --visual add-billing-dashboard        # render the finished plan as a visual artifact
 ```
+
+---
+
+## Visual mode
+
+See `~/.codex/plugins/ycc/shared/references/visual-mode.md` for the canonical `--visual` contract shared by all planning skills.
+
+`--visual` is a **terminal decorator step**, not a dispatch mode. It is orthogonal to and composes with `--team`, `--optimized`, and `--no-worktree`, and runs once at the very end.
+
+When `VISUAL_MODE=true` and `--dry-run` is **not** set, after the final phase (the plan has been written and validated) the workflow invokes:
+
+```
+visual-plan <absolute-plan-path>
+```
+
+where `<absolute-plan-path>` is the **actual written plan path** — the feature-dir plan at `${feature_dir}/parallel-plan.md` resolved in Phase 0 — **not** a hardcoded `docs/prps/plans` path. `visual-plan` derives its `visual/` output directory relative to that plan path.
+
+When `--dry-run` is set, `--visual` is **short-circuited**: print `visual generation would run` and do not invoke `visual-plan`. `--research-only` produces no plan file, so `--visual` has nothing to render and does not run.
 
 ---
 
@@ -91,9 +112,16 @@ case " $ARGUMENTS " in
 esac
 ARGUMENTS="${ARGUMENTS//--no-worktree/}"
 ARGUMENTS="${ARGUMENTS//--worktree/}"  # legacy no-op
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
-4. **feature-name**: First non-flag argument (required).
+4. **--visual**: Boolean flag. Set `VISUAL_MODE=true` if present, else `false`. Terminal decorator — see [## Visual mode](#visual-mode).
+5. **feature-name**: First non-flag argument (required).
 
 Validate the feature name:
 
@@ -607,6 +635,26 @@ After validators complete:
 If `AGENT_TEAM_MODE=false`, skip this step — standalone sub-agents return on their own.
 
 Otherwise, send shutdown requests to all validation teammates.
+
+---
+
+## Phase 9.5: Visual Mode (if --visual)
+
+If `VISUAL_MODE=false`, skip this phase entirely.
+
+This step runs only after the plan has been written (Phase 8) and validated (Phases 8–9). It never re-orders, re-runs, or substitutes for any earlier phase. See `~/.codex/plugins/ycc/shared/references/visual-mode.md`.
+
+### Step 32.5: Render Visual Artifact
+
+- If `--dry-run` is set, print `visual generation would run` and **STOP** this phase (the §2.1 short-circuit — no visual artifacts are produced).
+- If `--research-only` was used, no plan file was generated; skip this phase.
+- Otherwise, invoke `visual-plan` on the **actual written plan path** (the feature-dir plan resolved in Phase 0, not a hardcoded `docs/prps/plans` path):
+
+```
+visual-plan "${feature_dir}/parallel-plan.md"
+```
+
+`visual-plan` derives its `visual/` output directory relative to the supplied plan path and prints the resulting link (hosted URL, localhost preview, or `local files only`). Surface that link in the Phase 10 summary; do not re-derive the path yourself, and do not edit the plan file.
 
 ---
 

--- a/.codex-plugin/ycc/skills/plan/SKILL.md
+++ b/.codex-plugin/ycc/skills/plan/SKILL.md
@@ -32,6 +32,7 @@ Create a comprehensive implementation plan before writing any code. This is the 
 | `--dry-run`     | Valid with `--team` (prints team-coordinated roster) or `--enhanced` (prints standalone or team roster depending on whether `--team` is also present). Prints the roster, then exits without spawning any agents.                                                                                                                                                                                                                                                                                                                                                                                  |
 | `--worktree`    | (legacy — now default; safe to omit) Previously required to emit worktree annotations; the annotations are now emitted by default. Accepted as a silent no-op so existing pipelines continue to work.                                                                                                                                                                                                                                                                                                                                                                                              |
 | `--no-worktree` | Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `--visual`      | Force-write the plan to a file, then render it as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`.                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 **Flag interaction**:
 
@@ -60,7 +61,7 @@ Use this skill when:
 
 ### Step 1 — Parse flags and the user's request
 
-**Flag parsing**: Extract `--parallel`, `--team`, `--enhanced`, `--dry-run`, `--no-worktree`, and `--worktree` from `$ARGUMENTS` before processing. Strip them out. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `ENHANCED_MODE=true|false`, `DRY_RUN=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). The remaining text is the user's request.
+**Flag parsing**: Extract `--parallel`, `--team`, `--enhanced`, `--dry-run`, `--no-worktree`, `--worktree`, and `--visual` from `$ARGUMENTS` before processing. Strip them out. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `ENHANCED_MODE=true|false`, `DRY_RUN=true|false`, `VISUAL_MODE=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). The remaining text is the user's request.
 
 ```bash
 # Default ON; pass --no-worktree to opt out. --worktree accepted as legacy no-op.
@@ -76,6 +77,12 @@ case " $ARGUMENTS " in
   *" --enhanced "*) ENHANCED_MODE=true ;;
 esac
 ARGUMENTS="${ARGUMENTS//--enhanced/}"
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
 **Validation**:
@@ -84,6 +91,7 @@ ARGUMENTS="${ARGUMENTS//--enhanced/}"
 - If `DRY_RUN=true` and both `AGENT_TEAM_MODE=false` and `ENHANCED_MODE=false` → abort with: `--dry-run requires --team or --enhanced (no-op for the single-agent path).`
 - If `--team` is invoked from a Cursor or Codex bundle, abort with the existing compatibility message: `--team requires team tools, which Cursor/Codex bundles do not ship. Use --parallel instead.`
 - `--enhanced` alone is supported in every bundle: Path C uses parallel `Agent` calls without team tools. Only the `--enhanced --team` combination requires Codex; in Cursor or Codex, abort with: `--enhanced --team requires team tools, which Cursor/Codex bundles do not ship. Drop --team to use the standalone 5-persona path.`
+- `--visual` is orthogonal and runs after the plan is produced. Because `$plan` writes no file by default, `--visual` forces a plan-file write first. `--dry-run` short-circuits it (prints intent only).
 
 Read the stripped `$ARGUMENTS`. If it references a file path, read that file for context. If the request is ambiguous, ask a single focused clarifying question **before** dispatching.
 
@@ -517,6 +525,50 @@ Valid user responses:
 **Team-mode re-dispatch note**: Path B's team is `close the agent group`d in Step B.8 _before_ the user sees the plan. Any re-dispatch from this step creates a **new** team (same name is fine — the old one no longer exists) with a fresh set of teammates. Do not attempt to send messages to teammates from the prior team.
 
 **Path C re-dispatch note**: Path C never created a team, so there is no teardown to worry about. Any re-dispatch from this step simply fires a fresh batch of 5 parallel `Agent` calls (no `team_name=`).
+
+---
+
+### Step 5 — Visual rendering (if `VISUAL_MODE=true`)
+
+This step runs **only after** the user confirms the plan in Step 4 (it is the terminal decorator step). It never re-orders or substitutes for any earlier phase.
+
+- **If `DRY_RUN=true`**: print `visual generation would run` and skip — do not force any write and do not invoke `visual-plan`. (`--dry-run` already exits earlier at the dispatch gate; this is the no-op contract for the combination.)
+- **Otherwise**:
+  1. **Force-write the plan to a file.** `$plan` keeps the plan in-chat and writes no artifact by default, so there is nothing on disk to visualize. Write the confirmed plan verbatim to a concrete path. Default location: `docs/prps/plans/<slug>.plan.md`, where `<slug>` is the user's request sanitized to kebab-case (same scheme as Path B §B.1: lowercase, non-`[a-z0-9-]` → `-`, collapse runs, trim, truncate to 20 chars, fallback `untitled`). Create the directory first (`mkdir -p docs/prps/plans`). Resolve the path to an **absolute** path.
+  2. **Invoke** `visual-plan <absolute-plan-path>` with the absolute path written in the previous step.
+  3. **Surface the link** that `visual-plan` prints (hosted URL, localhost preview, or `local files only`). Do not re-derive the output directory yourself.
+
+See the canonical contract for the full force-write-first rule and `--dry-run` short-circuit:
+
+```
+~/.codex/plugins/ycc/shared/references/visual-mode.md
+```
+
+---
+
+## Visual mode
+
+`--visual` is the single, shared visual decorator described in
+`~/.codex/plugins/ycc/shared/references/visual-mode.md`. It is a
+**terminal decorator step** — it does not change how the plan is researched,
+dispatched, or relayed. It runs once, last, on the confirmed plan.
+
+**FORCE-WRITE-FIRST (mandatory for `$plan`)**: unlike the other planning
+skills, `$plan` writes **no** plan artifact by default — the plan stays
+in-chat. There is therefore nothing on disk to visualize. When `VISUAL_MODE` is
+set (and **not** `--dry-run`), the skill MUST:
+
+1. **Write the otherwise-inline plan to a concrete file path first.** Default:
+   `docs/prps/plans/<slug>.plan.md` (absolute path; directory created if
+   missing). This forced write happens even though it would normally be skipped.
+2. **Then invoke** `visual-plan <absolute-plan-path>` with that absolute
+   path.
+
+Without the forced write there is no input for `visual-plan`, so the
+force-write is required, not optional. Under `--dry-run` this is moot: the
+skill prints `visual generation would run` and forces no write (see §2.1 and §4
+of the canonical reference). `visual-plan` derives its `visual/` output
+directory relative to the plan path it is handed and never edits the plan file.
 
 ---
 

--- a/.codex-plugin/ycc/skills/prp-plan/SKILL.md
+++ b/.codex-plugin/ycc/skills/prp-plan/SKILL.md
@@ -34,6 +34,7 @@ Extract flags from `$ARGUMENTS`:
 | `--no-worktree` | Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.                                                                                                                                                                                            |
 | `--dry-run`     | Only valid with `--team`. Prints the team name and teammate roster, then exits without spawning any teammates.                                                                                                                                                                                                               |
 | `--enhanced`    | Enhanced research mode: grow the research fan-out from 3 to 7 specialized researchers (api/business/tech/ux/security/practices/recommendations — same coverage as feature-research). Output is still a single PRP-compliant plan file. Composes with --parallel (default), --team (Codex runtime only; not available in bundle invocations), and --no-worktree. |
+| `--visual`      | Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted shareable link requires `--share`.                                                                                                                                                                   |
 
 Strip the flags. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `DRY_RUN=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). Remaining text is the feature description or PRD path.
 
@@ -51,6 +52,12 @@ case " $ARGUMENTS " in
   *" --enhanced "*) ENHANCED_MODE=true ;;
 esac
 ARGUMENTS="${ARGUMENTS//--enhanced/}"
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
 **Validation**:
@@ -59,6 +66,7 @@ ARGUMENTS="${ARGUMENTS//--enhanced/}"
 - `--dry-run` requires `--team`. If `DRY_RUN=true` and `AGENT_TEAM_MODE=false` → abort with: `--dry-run requires --team.`
 - `--no-worktree` is **orthogonal** to `--parallel` and `--team` — it may be combined freely with either flag or used alone to suppress annotations.
 - If `--enhanced` is passed without `--parallel` or `--team`, default to standalone sub-agent dispatch (Path B equivalent at width 7). If `--enhanced --team` is invoked from a Cursor or Codex bundle, abort with the same compatibility message used today for plain `--team`. If `--dry-run` is passed, it requires `--team` (same constraint as today); `--enhanced --dry-run` alone is invalid.
+- `--visual` is orthogonal — it composes with `--parallel`/`--team`/`--enhanced`/`--no-worktree` and runs after the plan is written and validated. `--dry-run` short-circuits it (prints intent only).
 
 **Compatibility note**: When this skill is invoked from a Cursor or Codex bundle, `--team` must not be used (those bundles ship without team tools). Use `--parallel` instead.
 
@@ -385,6 +393,23 @@ Include a brief note in the report: "Plan validated with N warning(s) — see va
 
 ---
 
+## Phase 7 — VISUALIZE (optional)
+
+This step runs after the plan is written (Phase 6) and validated (Phase 6.5), regardless of the dispatch path taken (`--parallel`, `--team`, or sequential):
+
+- If `VISUAL_MODE=true` and `--dry-run` is NOT set, invoke `visual-plan <plan-path>` — passing the absolute path of the just-written `docs/prps/plans/{name}.plan.md` — and capture its printed link.
+- If `--dry-run` is set, print `visual generation would run` and skip the invocation.
+
+---
+
+## Visual mode
+
+This skill exposes the shared `--visual` decorator. The canonical contract lives at `~/.codex/plugins/ycc/shared/references/visual-mode.md` — follow it for composition, timing, and hand-off rules.
+
+When `VISUAL_MODE` is set and `--dry-run` is NOT, the skill invokes `visual-plan <absolute-plan-path>` AFTER Phase 6, passing the just-written `.plan.md` path (the file written in Phase 6 and validated in Phase 6.5). `visual-plan` derives its own `visual/` output directory from that path and prints the resulting link; the skill surfaces that link in the Report block. When `--dry-run` is set, print `visual generation would run` and skip — no visual artifacts, directories, or links are produced.
+
+---
+
 ## Output
 
 ### Update PRD (if input was a PRD)
@@ -408,6 +433,8 @@ Update the phase status from `pending` to `in-progress` and add the plan file pa
 - **Research Dispatch**: [Sequential | Parallel sub-agents | Agent team | Enhanced (7 researchers)]
 - **Execution Mode**: [Sequential | Parallel (N batches, max width X)]
 - **Worktree Mode**: [Enabled (default) — plan includes ## Worktree Setup (single feature worktree — **Parent**: line only) | Disabled via --no-worktree]
+- **Visual Artifact**: [Generated via visual-plan | n/a (--visual not set)]
+- **Visual Link**: [hosted URL | http://127.0.0.1:PORT/... | local files only | n/a (--visual not set)]
 
 > Next step: Run `$prp-implement docs/prps/plans/{name}.plan.md` to execute this plan.
 ```

--- a/.codex-plugin/ycc/skills/visual-plan/SKILL.md
+++ b/.codex-plugin/ycc/skills/visual-plan/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: visual-plan
+description: Turn an existing text plan into a rich, interactive visual plan — diagrams,
+  file maps, annotated code, open questions, and an optional UI/prototype review surface.
+  Read-only with respect to the plan file. Use when the user asks to "make this plan
+  visual", "render a visual plan", "create a wireframe/canvas for this plan", "visualize
+  the implementation plan", says "/visual-plan", or when a planning skill hands off
+  via the shared `--visual` decorator.
+---
+
+# Visual Plan (Agent-Native Plans)
+
+Turn an ordinary text plan into a structured, reviewable visual plan. Build the
+plan a reader would normally skim in Markdown, but as a scannable document with
+editable blocks mixed in: inline diagrams, annotated code, open questions, and
+an optional top visual review surface (wireframe canvas, live prototype, or both
+in tabs). Architecture and backend plans stay document-only; UI and product
+plans start with the top canvas/prototype.
+
+`visual-plan` is the packaged entry point (slash command `/visual-plan`). It
+**consumes an existing plan** handed to it — it does not research, dispatch, or
+re-plan. The runtime is the Agent-Native Plans CLI/MCP connector; its install
+pin, auth/reconnect flow, connector names, localhost bridge, block-catalog
+lookup, and egress policy are defined ONCE in
+`~/.codex/plugins/ycc/shared/references/agent-native-setup.md`. Read
+that file for any setup/auth/serve/egress detail rather than memorizing it here.
+
+## Contract (read first)
+
+This skill is the hand-off target of the shared `--visual` decorator. The full
+contract lives in `~/.codex/plugins/ycc/shared/references/visual-mode.md`.
+The non-negotiable invariants:
+
+- **Accept ANY plan path.** Never assume `docs/prps/plans` or any fixed
+  location. The plan path is supplied by the caller and may live anywhere.
+- **Derive `visual/` relative to the given plan path.** Output goes into a
+  `visual/` sibling of the plan file — `<dirname of plan>/visual/` — computed
+  from the path handed in, never hardcoded.
+- **NEVER edit the plan file.** Read it; write only into the derived `visual/`
+  directory. The plan artifact stays byte-for-byte intact.
+- **NEVER re-run research or dispatch.** Only consume the existing plan.
+- **Print exactly one resulting link to stdout** — a hosted shareable URL, a
+  localhost preview `http://127.0.0.1:PORT/...`, or `local files only`.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- **`<path/to/plan.md>`** (required positional) — absolute or repo-relative path
+  to the source plan. Read it; derive `visual/` from its directory.
+- **`--share`** (optional, **consent flag**) — the explicit, named opt-in to
+  hosted egress (destination `plan.agent-native.com`). Without it, the skill
+  runs in **local-files** mode and nothing leaves the machine. See **Egress &
+  consent** below.
+
+## Mode selection (auto)
+
+Choose the review surface from the source plan's content — do not add visual
+chrome by default:
+
+- **UI-first** — work is primarily product UI; review should start with screens.
+  Top canvas is the primary surface (`create-ui-plan`).
+- **prototype-first** — review should start with a functional live prototype;
+  interaction is the main question (`create-prototype-plan`).
+- **design-first** — review needs full-fidelity branded screens
+  (`create-plan-design`).
+- **visual-intake** — only when the user explicitly asks for a questionnaire
+  before planning (`create-visual-questions`). Never run it as `/visual-plan`
+  preflight.
+- **document-only** — architecture, backend, data, refactor, or API plans get NO
+  top canvas; inline `diagram` blocks sit next to the relevant prose
+  (`create-visual-plan`).
+
+When the source plan is already a Codex / Codex / Markdown / pasted plan,
+use it as `planText` and build the review surface from it instead of starting
+over. Preserve its useful intent and codebase facts; publish a clean standalone
+proposal (no "this revision changes…" framing).
+
+## Block vocabulary — resolve at USE TIME
+
+> The MDX block vocabulary drifts upstream between releases. Do NOT author from a
+> memorized tag list — not from this skill, not from the references.
+
+At author time (use time), fetch the live block catalog FIRST:
+
+- Hosted / connected: call the **`get-plan-blocks`** MCP tool.
+- Offline / `local-files`: run `plan blocks --out <path>` (per
+  `agent-native-setup.md`) and read that file.
+
+Render plan MDX against the freshly-fetched list. The references in this skill
+describe block _families_ and quality bars; the catalog is the authority on
+exact tag names, required fields, and prop shapes.
+
+## Core workflow
+
+1. **Read the source plan.** Read the file at the given path (read-only). Derive
+   the output dir with the thin helper (it computes the `visual/` sibling per the
+   contract and never hardcodes a location):
+
+   ```
+   OUT="$(~/.codex/plugins/ycc/skills/visual-plan/scripts/derive-visual-dir.sh <plan> --mkdir)"
+   ```
+
+   Gather the plan's exact text — do not invent source content.
+
+2. **Resolve blocks.** Call `get-plan-blocks` (or the offline `plan blocks`
+   fallback) for the authoritative catalog before authoring any MDX.
+3. **Create the plan** with the mode-matched create tool (see Mode selection),
+   passing the source as `planText`. For UI/product plans, compose the top canvas
+   first with the primary wireframes and annotated states, then write the
+   document body with native blocks. For non-visual plans, skip the top surface
+   and place `diagram` / `code` / `annotated-code` / `table` blocks next to the
+   relevant prose.
+4. **Emit files** into the derived `visual/` dir: `plan.mdx` plus, when a canvas
+   is used, `canvas.mdx` (and `prototype.mdx` for prototype plans). These are the
+   portable source artifacts (per `visual-mode.md`).
+5. **Surface the link.** Print exactly one link to stdout (see Contract). In
+   local-files mode this is the localhost bridge URL from `plan local serve`
+   (127.0.0.1, ephemeral port) or `local files only` if no server is available.
+   With `--share`, it is the hosted shareable URL returned by the create tool.
+6. **Read feedback** with `get-plan-feedback` before editing, after review, and
+   before the final response. Treat anchor details and resolver intent as the
+   source of truth for what each comment points at.
+7. **Apply changes** with `update-visual-plan`, preferring targeted
+   `contentPatches`: `patch-wireframe-html`, `patch-diagram-html`, `update-block`,
+   `replace-blocks`, `update-rich-text`, plus `read-visual-plan-source` /
+   `patch-visual-plan-source` for source-control-friendly MDX edits. Treat the
+   top-level `content` payload as a full replacement, never a partial merge — if a
+   full replacement is unavoidable, read the complete source first and carry
+   forward every existing block and surface.
+
+## Quality references — read before authoring
+
+These are provider-neutral quality bars. Read the relevant one IN FULL before
+authoring; do not paraphrase from memory:
+
+- `~/.codex/plugins/ycc/skills/visual-plan/references/document-quality.md` — the
+  plan-document quality bar and block families.
+- `~/.codex/plugins/ycc/skills/visual-plan/references/canvas.md` — canvas /
+  artboard / annotation mechanics and patch ops.
+- `~/.codex/plugins/ycc/skills/visual-plan/references/wireframe.md` — the HTML
+  wireframe quality bar (`.wf-*` tokens, surfaces, icons, skeletons).
+- `~/.codex/plugins/ycc/skills/visual-plan/references/exemplar.md` — a worked
+  example plus the anti-patterns to avoid.
+
+## Planning is read-only
+
+Make NO source edits while building or reviewing the visual plan, and never edit
+the input plan file. Begin editing code only after the user approves the
+direction. The plan is the approval gate: surface it, name which files/areas the
+work touches, and request sign-off.
+
+## Egress & consent (default OFF)
+
+Hosted upload is **OFF by default** and **consent-gated**. The full policy lives
+in `~/.codex/plugins/ycc/shared/references/agent-native-setup.md`;
+the operational rules for this skill:
+
+- **Default = `local-files`.** Set `AGENT_NATIVE_PLANS_MODE=local-files`. In this
+  mode the runtime reads/writes plan files locally and never contacts
+  `plan.agent-native.com`. Preview via the localhost bridge
+  (`plan local serve --dir <OUT> --open`), which binds 127.0.0.1 on an ephemeral
+  port, performs no DB writes, and sends nothing remote — this is **not** egress.
+- **`--share` is the only opt-in.** It names the destination host
+  `plan.agent-native.com`. Only when the operator passes `--share` may any plan
+  content leave the machine.
+- **Route all hosted egress through the guard.** Before any MDX/diff payload is
+  uploaded, run:
+
+  ```
+  ~/.codex/plugins/ycc/shared/scripts/visual-egress-guard.sh \
+    --payload <OUT> --destination plan.agent-native.com \
+    --consent plan.agent-native.com
+  ```
+
+  The guard scans the payload for secrets, refuses non-public/private remotes,
+  and requires a consent token matching the destination. If it exits non-zero,
+  STOP — do not upload; report the gate that failed.
+
+## Setup, auth, and the localhost bridge
+
+Do not duplicate install/reconnect/serve commands here. For the pinned install
+version, the one-time per-client reconnect, the `plan` MCP connector (legacy
+alias `agent-native-plans`), local-files mode, and the localhost bridge
+(`plan local check` / `plan local serve`), read
+`~/.codex/plugins/ycc/shared/references/agent-native-setup.md`. If a
+Plans tool returns `needs auth` / `Unauthorized` / `Session terminated`, stop and
+give the user the reconnect step from that reference — never reinstall from
+scratch to fix auth, and never fall back to inline chat-only plan output.
+
+## Output
+
+Exactly one of the following is printed to stdout, per the `visual-mode.md`
+contract:
+
+- a hosted shareable URL under `https://plan.agent-native.com` (only with
+  `--share`, after the egress guard passes), or
+- a localhost preview `http://127.0.0.1:PORT/...` (default local-files mode), or
+- `local files only` when no server/host is available.
+
+The calling planning skill surfaces whatever link this skill prints.

--- a/.codex-plugin/ycc/skills/visual-plan/references/canvas.md
+++ b/.codex-plugin/ycc/skills/visual-plan/references/canvas.md
@@ -1,0 +1,121 @@
+# Canvas & artboard placement — single source of truth
+
+The canonical guide for how the visual-plan canvas works: artboard placement,
+lane layout, annotations, patching, and emitted files. Read it in full before
+authoring or editing any canvas/artboard content; do not author canvas layouts
+from memory. Resolve exact block/component tag names against the live catalog
+(`get-plan-blocks` or the offline `plan blocks` dump).
+
+---
+
+## Canvas block families
+
+A plan canvas is composed from these block families (resolve exact tag names and
+props via the catalog):
+
+- **`<DesignBoard>`** — the canvas root that holds the artboards and annotations.
+- **`<Section>`** — groups related artboards into a labeled region/lane.
+- **`<Artboard>`** — a single fixed-footprint frame; its size/aspect is locked by
+  `surface` (see `wireframe.md`). Carries an `html` wireframe or references a
+  wireframe block via `blockId`.
+- **`<Screen>`** — a product screen surface inside the board (a UI state under
+  review).
+- **`<Annotation>`** — a plain-text designer note anchored to a frame by
+  `targetId` + `placement`.
+- **`<Connector>`** — an arrow between neighboring steps of a real sequence.
+
+## Emitted files
+
+- `plan.mdx` — frontmatter plus markdown/document blocks (the plan body).
+- `canvas.mdx` — the `<DesignBoard>` / `<Section>` / `<Artboard>` / `<Screen>` /
+  `<Annotation>` / `<Connector>` tree.
+- `prototype.mdx` — present only for prototype plans (the functional flow).
+
+JSON is the canonical runtime shape; MDX is the repo-friendly authoring/export
+surface. Both live under the derived `visual/` directory.
+
+## The coordinate rule
+
+The `surface` locks each artboard's footprint and aspect — **never** set artboard
+width/height and **never** use coordinates inside the wireframe HTML. Board-level
+artboard `x`/`y` IS allowed when it creates clear lanes. Let canvas
+auto-placement handle simple one-row boards. Sizing is always via `surface`, not
+explicit pixels.
+
+## Lay out mixed canvases in lanes
+
+When a canvas contains broad `browser` / `desktop` frames plus compact `mobile`,
+`popover`, or `panel` surfaces, do not put everything in one horizontal strip.
+Use board-level artboard `x`/`y` to reserve lanes with generous empty space: main
+flow on one row, compact surfaces in their own column or row, loading/error
+states in a lower row. Keep at least **96px** between rendered artboard rectangles
+plus room for annotation gutters. Connect only neighboring steps; never draw a
+long connector that skips across unrelated frames. Before handoff, inspect the
+top canvas at default zoom and move any frame whose label, connector, or
+annotation crosses another frame.
+
+## Annotations are designer notes on the artboard
+
+When a top canvas is present, sprinkle Figma-style notes near the frames they
+explain: a short heading, supporting text, and bullets — plain text layers, never
+bordered or shadowed cards, and never a box around a frame. The renderer spaces
+notes away from frames, so place each note by the frame it describes. Use an
+arrow (`<Connector>`) only to point at one specific control or transition; for a
+broad frame-level note, write text beside the frame with no connector.
+
+**Do not create overlapping annotations.** Anchor each ordinary note to the frame
+it explains with `targetId` + `placement` (top/right/bottom/left), and omit
+`type` or use `type: "note"`. The renderer parks notes in a gutter beside the
+frame and lays them out automatically. Do not use `type: "callout"`,
+`type: "text"`, `type: "arrow"`, x/y, or points for ordinary notes; those are
+freeform review-markup layers reserved for intentional markup in open canvas
+space. Connectors are for real sequences only — never fake "Step 1 → Step 2"
+lines between independent states.
+
+## Patching
+
+Edit one wireframe, canvas annotation, diagram, or block with targeted
+`contentPatches` rather than regenerating the whole plan:
+
+- `patch-wireframe-html` — edit the HTML of one artboard's wireframe.
+- `patch-diagram-html` — edit the HTML/SVG of one diagram.
+- `update-block` / `replace-blocks` — replace a block by stable id.
+- `update-canvas-annotation` — edit one annotation.
+- `read-visual-plan-source` / `patch-visual-plan-source` — granular MDX AST
+  patches by stable block, artboard, annotation, component, or wireframe-node id
+  when working from exported source files.
+- `update-rich-text` — prose edits (agents use this or source patches; humans
+  edit prose inline in the browser).
+
+`contentPatches` are part of the public MCP action schema, so every host can make
+surgical edits. **Never** send a partial top-level `content` object as a shortcut
+to add a canvas, frame, or block: `content` is a full structured replacement, so
+omitted blocks or surfaces disappear. If a full replacement is truly unavoidable,
+read the complete source/JSON first, include every existing block and surface in
+the new payload, and verify the source/export immediately after the update.
+
+## Never emit a titled artboard with no interior wireframe content
+
+Every artboard must carry an `html` wireframe or reference a wireframe block via
+`blockId`; when using `blockId`, the referenced wireframe block must remain in the
+plan. If you remove a duplicate wireframe from the document body, first move its
+`data` inline onto the corresponding canvas frame. A label-only frame or a frame
+pointing at a deleted block renders empty and is rejected at parse time. If you
+only have a title, write it as a section header or annotation, not an empty
+artboard.
+
+## UI mockups belong in the top visual review area
+
+Static UI/product visuals live on the canvas; multi-step UI flows get both canvas
+wireframes and a `prototype`. When the user asks for a mockup, UI state, loading
+state, layout, screen, or visual comparison, make the canvas the primary home for
+that static visual. Architecture/code diagrams stay inline in the document
+(`document-quality.md` owns that rule) unless the user explicitly asks for a
+spatial board. A skeleton/loading mockup also lives in a canvas artboard — never
+move a mockup out of the canvas into a `custom-html` document block.
+
+For abstract product concepts, use the canvas to create the first "I get it"
+moment: one real app state near the top showing how the concept appears to a
+user, followed by separate annotations or diagrams for mechanics. Do not make the
+first artboard a hybrid of app UI and architecture notes; the app screen should be
+inspectable as product UI on its own.

--- a/.codex-plugin/ycc/skills/visual-plan/references/document-quality.md
+++ b/.codex-plugin/ycc/skills/visual-plan/references/document-quality.md
@@ -1,0 +1,169 @@
+# Plan document quality — single source of truth
+
+The canonical quality bar for the plan document below the canvas: how it reads,
+which block families to use, how open questions are surfaced, and the pre-handoff
+check. Read it in full before authoring the plan document. Resolve exact tag
+names and field shapes against the live catalog (`get-plan-blocks`, or the
+offline `plan blocks` dump) — the families below are the bar, the catalog is the
+authority.
+
+---
+
+**The document is a serious technical plan, not marketing.** Write it the way a
+strong implementation plan reads: outcome-first, prose-first, self-contained, and
+specific. State the objective and what "done" means, the scope and non-goals, the
+proposed approach with key decisions and their rationale, ordered steps that name
+real files / symbols / actions / data shapes, the risks, and a closing
+verification step (tests, build, or a checkable behavior). Replace vague prose
+with specifics; never ship a step like "make it work." No hero art, gradients,
+logos, nav bars, slogans, value props, giant landing-page headings, or marketing
+cards unless the user explicitly asks.
+
+**Every published plan must stand alone.** Even when revising an existing plan,
+the output is a plan to do the work, not a changelog of the conversation. Do not
+write phrases like "preserve the previous plan", "do not drop the old idea", "as
+discussed above", "this revision", "unlike the prior version", or "correction
+from the earlier plan". Fold the right decisions into the plan as normal
+objective, architecture, scope, and roadmap prose. A reviewer who opens the plan
+from a link with no chat history should understand it. Avoid negative framing
+that only makes sense against absent context ("not the old mode", "not just X")
+unless the contrast is defined in the plan and genuinely helps; state the
+positive model directly.
+
+**Make abstract plans instantly legible.** If the idea is broad, strategic, or
+intended for a third-party reviewer, put one concrete product snapshot near the
+top before dense architecture, mode tables, manifests, or roadmaps. For
+UI-capable concepts, that snapshot is usually a top-canvas app state plus a short
+paragraph that says what the user sees and what changes under the hood. Then put
+mechanics, data flow, sync boundaries, and implementation detail in separate
+diagrams or document sections.
+
+**Preserve the user's level of abstraction.** A motivating use case is not
+automatically the architecture. When the prompt describes a broader framework,
+product mode, or reusable primitive, separate the reusable core from specific
+apps, providers, customers, scripts, or launch examples. Use the concrete example
+to make the plan understandable, then make clear which parts are core, which are
+app-specific adapters, and which are future examples.
+
+**When top visuals exist, they and the document never duplicate each other.** For
+UI work, the UI story lives in the top visual surface: canvas artboards for static
+inspection, plus prototype tabs when the flow should be functional. The document
+carries the technical depth the visuals cannot show — concrete file/symbol maps,
+API and data contracts, code snippets, migration or implementation phases, risks,
+and validation. For architecture/code reviews, invert that: the document is the
+visual surface, and each recommendation carries its own nearby inline `diagram`
+block plus file evidence. Repeat a wireframe in the document only for a genuinely
+new detail view or comparison. Skip the visual surface entirely for non-visual
+work and write a clean rich document.
+
+## Block families (resolve exact tags via `get-plan-blocks`)
+
+Use the right block, and make it carry substance:
+
+- **`rich-text`** — plan prose with real bold/italic/code/links and nested lists.
+- **`annotated-code`** — the file map: for a load-bearing file, prefer the
+  annotated walkthrough over a bare `code` block. Carry the real,
+  syntax-highlighted code AND anchor short margin notes to the lines that
+  actually change (the new action, the changed schema, the wiring point). Each
+  annotation is `{ lines: "12" | "12-18"; label?; note }`; keep a few high-signal
+  notes per file, not one per line. Highlight only files worth reading.
+- **`code`** — a throwaway snippet with nothing to call out. When more than one
+  file matters, group blocks in a vertical `tabs` block rather than a bespoke
+  container.
+- **`tabs`** — multiple states, directions, or comparisons. A tab that reveals
+  only prose usually means the plan is under-specified — include a relevant visual
+  unless the tab is intentionally document-only.
+- **`columns`** — side-by-side before/after or current/target comparisons where
+  each side needs real nested blocks; label the columns clearly.
+- **`diagram`** — two-dimensional architecture, dependency, data-flow, or state
+  relationships, only when it clarifies something real. See **Diagram primitives**
+  below.
+- **`table`** — scannable structured data.
+- **`checklist`** — copy the catalog example verbatim: items need `id` and
+  `label`.
+- **`callout`** — for a decision you have committed to, use `tone="decision"`
+  (optionally with a `columns` block weighing the options). Use other tones for
+  concise assumptions or risks in the relevant section.
+- **`question-form`** — the bottom-only Open Questions block (see below).
+- **`custom-html`** — a bounded escape hatch only (see below).
+
+## Decisions
+
+- If the reviewer must still pick between a genuinely-open either/or, put it in
+  the bottom Open Questions `question-form` as a `single` question — one option
+  per real alternative, each with a short detail and `recommended: true` on the
+  one you would choose. Do not also restate the same choice elsewhere.
+- If you have already committed to an approach, state it as settled prose or a
+  `callout` with `tone="decision"` — never as a confusing mid-document form for a
+  question you have already answered.
+
+## Diagram primitives
+
+For architecture/code diagrams, prefer `data.html` / `data.css` with semantic
+HTML and inline SVG so the diagram can use panels, layers, matrices, arrows,
+annotations, and responsive layout directly. Author with renderer-owned
+primitives: `.diagram-panel`, `.diagram-card`, `.diagram-node`, `.diagram-box`,
+`.diagram-pill`, `.diagram-muted`, and `[data-rough]` for sketchy mode. They map
+to the theme variables `--wf-ink`, `--wf-muted`, `--wf-line`, `--wf-paper`,
+`--wf-card`, `--wf-accent`, `--wf-accent-soft`, `--wf-warn`, and `--wf-ok`, and
+switch to the sketch font plus rough.js outlines in sketchy mode.
+
+- Do NOT set `font-family` and do NOT hard-code hex, rgb, or hsl colors in
+  diagram HTML or CSS.
+- Prefer standard two-dimensional layouts — paired before/after panels, layered
+  diagrams, swimlanes, dependency maps, matrices, or grouped regions; do not
+  default to left-to-right chains, and use a line only when the relationship is
+  truly a sequence.
+- Leave room for the sketch font: keep labels short, give nodes generous width,
+  and place boundary/annotation labels in unused space — labels must not overlap
+  nodes, connectors, or each other.
+- For small text/SVG changes to an existing HTML diagram, use **`patch-diagram-html`**
+  with a unique `find`/`replace` snippet instead of resending the whole
+  `data.html` string. Use legacy `nodes` / `edges` only for small previews or
+  truly sequential flows.
+
+## Open questions live at the bottom as a form
+
+Surface answerable unresolved decisions in a final `question-form` block titled
+"Open Questions" so the renderer presents it as a distinct section. That bottom
+form is the ONLY place that enumerates the open questions: never add a second
+"Open Questions" heading, list, or recap of the same questions earlier in the
+document. A one-line pointer in the overview prose ("a few decisions are still
+open — see Open Questions below") is fine.
+
+- Use `single` or `multi` for clear choices, `freeform` for constraints,
+  `recommended: true` for the default you would pick. `single`/`multi` questions
+  always render a write-in field, so never add an explicit "Other" option
+  yourself; set `allowOther: false` only when a free-text answer makes no sense.
+- Copy the catalog example verbatim for required fields: each question needs
+  `id`, `title`, and `mode`; each option needs `id` and `label`.
+- Keep non-answerable assumptions or risks as concise `callout` blocks in the
+  relevant section. Never bury a questions/decisions wall inside the plan
+  narrative, and never ask the same question twice.
+
+For complex plans, do not end without an open-question audit. If architecture,
+scope, UX, data shape, rollout, provider mapping, or ownership still depends on a
+choice, either commit to a recommendation with rationale or add it to the bottom
+form with a recommended default.
+
+## `custom-html` is a bounded escape hatch only
+
+A single complete fragment inside a block, never `html`/`head`/`body`/`script`
+tags, never a generic placeholder, density demo, or proof that custom HTML works.
+Prefer native blocks for normal plans. For architecture/code reviews, use
+`diagram` `data.html` / `data.css` for rich local HTML/SVG diagrams instead of
+`custom-html`. For UI/product work, `custom-html` is never the primary home for a
+requested mockup, UI state, or visual comparison.
+
+## Verification must exercise the real workflow
+
+The final verification section should go beyond typecheck/unit tests when the
+plan changes UI, local files, sync, providers, browser behavior, or multi-app
+flows. Include at least one end-to-end smoke that matches the user journey — a
+fresh repo/folder, real manifest or data fixture, browser interaction, save/sync
+action, and an on-disk or database assertion. Name the command or manual browser
+path when it is known.
+
+**Before handoff, open the plan and check it.** Fix overlap, excessive
+whitespace, clipped fragments, misleading inactive controls, poor contrast, and
+unreadable diagrams before asking for approval.

--- a/.codex-plugin/ycc/skills/visual-plan/references/exemplar.md
+++ b/.codex-plugin/ycc/skills/visual-plan/references/exemplar.md
@@ -1,0 +1,113 @@
+# Good vs. bad exemplar — single source of truth
+
+The canonical worked example of a great plan (and the anti-patterns to avoid).
+Read it alongside `document-quality.md` and `canvas.md` before authoring a plan;
+it is the bar these plans must clear. Resolve exact block tags against the live
+catalog (`get-plan-blocks` / offline `plan blocks` dump) before emitting MDX.
+
+---
+
+## A worked example — UI-first plan MDX
+
+The following sketch shows the _shape_ of a strong UI-first plan: a top canvas
+with one real `desktop` artboard, plain-text designer notes off the frame, then a
+serious document below it. Treat the tags as families — confirm exact names/props
+against the catalog.
+
+```mdx
+---
+title: Inbox triage redesign
+mode: ui-first
+---
+
+{/* canvas.mdx — the top review surface */}
+
+<DesignBoard>
+  <Section label="Triage view">
+    <Artboard id="inbox-default" surface="desktop" label="Inbox — default">
+      {/* data.html is a real flex layout: a sidebar of links
+          (Inbox 12, Today 4, Done), a main column headed "Today",
+          accent .wf-pill filters, a muted "OVERDUE" section label,
+          and .wf-card task rows with real titles, due dates, and a
+          button.primary — styled only via bare elements, helper
+          classes, and --wf-* tokens. */}
+    </Artboard>
+    <Annotation targetId="inbox-default" placement="right">
+      Overdue items float to the top; the primary action stays in the header so triage never scrolls.
+    </Annotation>
+  </Section>
+</DesignBoard>
+
+{/* plan.mdx — the document body */}
+<rich-text>
+
+## Objective
+
+Cut inbox triage from many clicks to one. "Done" means an overdue item
+can be deferred or completed from the row without opening it.
+</rich-text>
+
+<tabs>
+  {/* one `code` / `annotated-code` block per load-bearing file:
+      the new defer action, the changed query, the row component */}
+</tabs>
+
+<callout tone="decision">
+  Defer writes a `snoozedUntil` timestamp rather than moving the row to a separate table — see the columns block for the
+  two options weighed.
+</callout>
+
+<question-form title="Open Questions">
+  {/* single/multi questions for genuinely-open decisions, each option
+      with id + label, recommended: true on the default */}
+</question-form>
+```
+
+If the task also changes a multi-step completion flow, the same top area gains a
+Prototype tab whose screens reuse the canvas labels and states.
+
+## GOOD — the bar
+
+- **UI-first todo/inbox plan.** A canvas `desktop` artboard whose `data.html` is a
+  real flex layout (sidebar links, a "Today" heading, accent `.wf-pill` filters, a
+  muted `OVERDUE` label, `.wf-card` task rows with real titles/dates and a
+  `button.primary`), styled only through bare elements, helper classes, and
+  `--wf-*` tokens. Plain-text designer notes sit spaced off the frame, pointing
+  only at controls that need explanation. Below it, a strong document: objective
+  and done-criteria, a few `code` blocks (grouped in a vertical `tabs` block when
+  more than one) showing the real shape of load-bearing files, a `callout` with
+  `tone="decision"` stating the chosen approach with a `columns` block weighing the
+  two real options, and a validation step — none of it repeating the canvas.
+- **Broad product-architecture plan.** Opens with a plain recommendation and one
+  concrete app state before the abstraction. The first canvas artboard is pure
+  product UI that matches the current app shell; nearby notes explain the
+  user-visible delta. A separate `diagram` below shows the mechanics. The document
+  separates the reusable core from app/provider adapters and examples, covers
+  contracts and schema shape, roadmap, non-goals, a bottom Open Questions form, and
+  a verification section with at least one realistic end-to-end smoke.
+- **Backend architecture review.** No top canvas. The document opens with context
+  and a legend, then repeats recommendation cards: title, confidence/category
+  badges, a monospace grid of real file paths, one inline two-dimensional
+  before/after or layered architecture `diagram` (using space to show boundaries
+  and ownership, not a default left-to-right chain), and terse
+  Problem/Solution/Why bullets in the codebase's vocabulary. Ends with a top
+  recommendation and a bottom `question-form` only if the next direction is
+  genuinely open.
+
+## BAD — never produce this
+
+- A `data.html` with hard-coded hex colors, a `font-family`, or fixed pixel
+  width/height.
+- Gray placeholder bars "insinuating" text on a non-skeleton frame.
+- A forced `desktop` + `mobile` pair for a popover.
+- Floating bordered annotation cards hugging the frames.
+- A multi-step UI flow with only static frames and no prototype tab.
+- A mockup escaped into a document `custom-html` block.
+- A marketing-style document with a hero heading and value props that just
+  restates what the canvas already shows.
+- An architecture-only plan forced into a top canvas of labeled boxes with
+  overlapping text, where the real code evidence lives elsewhere.
+- A product wireframe that mixes a real screen with repo names, file-contract
+  arrows, architecture explanations, or a made-up permanent inspector.
+- A plan that describes itself as a revision of a prior conversation instead of a
+  standalone proposal.

--- a/.codex-plugin/ycc/skills/visual-plan/references/wireframe.md
+++ b/.codex-plugin/ycc/skills/visual-plan/references/wireframe.md
@@ -1,0 +1,210 @@
+# HTML wireframe quality — single source of truth
+
+The canonical quality bar for HTML wireframe content. Read it in full before
+authoring ANY wireframe; do not author wireframes from memory or paraphrase these
+rules per mode.
+
+---
+
+**A wireframe is an HTML mockup. The renderer owns the look; you write the
+content.** Set `data.html` to a self-contained, semantic HTML fragment of the
+screen and set `data.surface`. The renderer owns the surface footprint/aspect, the
+dark/light theme, the hand-drawn font, and the sketch overlay — you never write
+`<style>` / `<link>` / `<font>` tags or any width/height/coordinates. You write
+real HTML layout and real product content; the renderer styles and roughens it.
+
+**A wireframe block's data is an HTML screen plus a surface:**
+
+```json
+{
+  "surface": "browser",
+  "html": "<div style=\"display:flex;flex-direction:column;gap:10px;padding:16px;height:100%\"><h1>Sign in</h1><p class=\"wf-muted\">Use your work email to continue.</p><div class=\"wf-card\" style=\"display:flex;flex-direction:column;gap:10px\"><label>Email<input value=\"jane@acme.co\" /></label><label>Password<input value=\"********\" /></label><label style=\"display:flex;align-items:center;gap:8px\"><input type=\"checkbox\" checked /> Remember me</label><button class=\"primary\">Sign in</button></div><a href=\"#\">Forgot password?</a></div>"
+}
+```
+
+**Write PLAIN semantic HTML and let the renderer style it.** Bare elements
+(`h1`/`h2`/`h3`, `p`, `button`, `input`, `label`, `a`, `hr`) are auto-themed — no
+classes needed. Helper classes carry the rest:
+
+- `.wf-card` / `.wf-box` — a bordered, padded container (a panel, a list item).
+- `.wf-pill` / `.wf-chip` — a rounded tag or filter; add `.accent` for the
+  accent-filled variant.
+- `.wf-muted` — secondary/muted text.
+- `button.primary` or any element with `[data-primary]` — the accent-filled
+  primary button.
+
+**No decorative shadows around mockups.** Do not put `box-shadow`,
+`filter: drop-shadow(...)`, Tailwind `shadow-*` classes, or other fake depth on a
+wireframe frame, root container, `.wf-card` / `.wf-box`, or canvas artboard.
+Mockups should read as flat, bordered surfaces; use spacing, borders, labels, and
+annotations for separation. Only show a shadow when the real product UI already
+has it and it is essential to the change being reviewed.
+
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker with
+`[data-icon]` (e.g. `<span data-icon="search"></span>`). The renderer replaces it
+with a Tabler-style SVG and the `.wf-icon` class sizes it to the surrounding text.
+Supported names and aliases include: `mail`/`email`, `lock`/`password`, `search`,
+`plus`/`add`, `x`/`close`, `check`, `chevronDown`, `chevronUp`, `chevronLeft`,
+`chevronRight`, `dots`/`more`, `chevron`/`caret`/`dropdown` (down chevron), `user`,
+`settings`, `calendar`, `bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do
+not put visible words like "email", "lock", "search", "chevron", or "more" where
+the product UI would show an icon; use text only when it is a real label a user
+would read.
+
+**Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips
+these on light/dark, so referencing tokens is what keeps a mockup correct in both
+themes. For any inline border, background, or text color, reference a token:
+`style="border:1.4px solid var(--wf-line)"`. The tokens are `--wf-ink` (text),
+`--wf-muted` (secondary text), `--wf-line` (borders/dividers), `--wf-paper` (page
+background), `--wf-card` (container surface), `--wf-accent` / `--wf-accent-fg` /
+`--wf-accent-soft` (brand action), `--wf-warn`, `--wf-ok`, and `--wf-radius`.
+**Never hard-code a hex (or rgb/hsl) color and never set `font-family`** — the
+renderer owns the sketch/clean font.
+
+**Lay out with inline `style` flex/grid.** You write the real layout —
+`display:flex; flex-direction:column; gap:10px; padding:16px` — and the renderer
+never repositions anything. Compose the actual product: reproduce the current
+screen, then show the modification. Real labels, real counts, real dates, real
+button text grounded in the screen you read; not lorem or gray bars.
+
+**Surface presets — match the real footprint, never default to desktop+mobile.**
+Pick the `surface` that matches what the user will actually see:
+
+- `browser`: a web page that needs a browser chrome frame around it.
+- `desktop`: a full desktop app page or app shell.
+- `mobile`: a phone screen, only when the work is genuinely mobile.
+- `popover`: a small floating menu, dropdown, or inline popover.
+- `panel`: a side panel, inspector, or sidebar widget.
+
+A sidebar popover renders as a small surface, not a desktop page and a phone
+frame. Do not emit `desktop` + `mobile` variants unless responsive behavior
+actually changes the layout.
+
+**Model the actual component shell for small surfaces.** A rendered UI change
+belongs in a wireframe; reserve `diagram` for architecture, dependency, state, or
+data-flow relationships. Popovers, dropdown menus, command palettes, and context
+menus use `surface: "popover"` unless the surrounding page placement is the point
+of the change. Dialogs, sheets, inspectors, sidebars, and long property panels use
+the matching `panel` / `desktop` surface. Show the real chrome: trigger/anchor
+when it matters, title/header row, top-right actions, separators, fields, options,
+selected states, body content, and visible footer actions.
+
+**Modify, don't redesign.** When the task changes an existing screen, reproduce
+the current screen's real layout and footprint FIRST, then change only the delta
+and call it out with a single annotation. Do not restack the page into a new
+layout. For net-new surfaces, compose from the real app shell.
+
+**Keep product screens pure.** A product wireframe shows the app state a user
+would actually see. Do not embed file contracts, architecture arrows, repo pills,
+mode explanations, or implementation callouts inside the screen just to explain
+the plan. Put those in canvas annotations, a separate diagram, or the document
+body.
+
+**Zoom in on sub-surfaces, don't redraw the page.** For a small sub-surface (a
+popover, menu, dialog, toast), show the full screen once, then add a small
+separate artboard whose `html` contains ONLY that sub-surface — do not re-draw the
+whole page around it, and do not scale a duplicate up. Pick the matching `surface`
+(e.g. `popover`) so the footprint is right; never widen a popover to page width.
+
+**Loading / skeleton states.** Set `data.skeleton: true` on the wireframe and fill
+the `html` with neutral, textless placeholder geometry — boxes and bars built as
+`<div>`s with `background:var(--wf-line)` and explicit heights/widths, no labels
+or copy. The renderer drops borders, sketch, and color into the skeleton register
+automatically. Never escape to a `custom-html` document block to fake a loader.
+
+**Editing an existing mockup.** To change one element, text, or color, call
+`update-visual-plan` with
+`contentPatches: [{ op: "patch-wireframe-html", blockId, edits: [{ find, replace }] }]`.
+Each `find` is a unique snippet of the current html (read it first); set
+`all: true` on an edit to replace every occurrence. The result is re-sanitized.
+
+**Treat the wireframe border as part of the visible design.** Always wrap HTML
+wireframe content in a root container with real inner padding before drawing
+cards, fields, pills, labels, or controls. Use at least 14-16px of padding,
+`box-sizing: border-box`, `height: 100%`, and `gap` between child rows so the
+first row never sits flush against the screen border.
+
+**Lay out children safely so they never collide.** Use HTML flex/grid with `gap`,
+`min-width: 0`, and sensible overflow. Avoid negative margins, absolute
+positioning, or fixed child widths that can collide across light/dark, sketch/clean,
+or zoom levels.
+
+**Do not wrap intentionally single-line labels.** For toolbars, tab rails,
+breadcrumbs, chip/filter rows, branch and file names, and code filenames — any
+deliberately single-line row — put `white-space: nowrap` on the row (and
+`overflow: hidden; text-overflow: ellipsis` on labels that can grow). Use
+horizontally scrollable or clipped rails for overflow.
+
+**Fill the frame; keep labels short.** Each artboard is a fixed-size surface —
+compose enough realistic HTML to fill it top to bottom with even vertical rhythm;
+never leave a large empty band. On desktop/app-shell sidebars, let the nav stack
+flex to fill (`flex:1`) and add any persistent bottom action/status after it. On
+mobile, flow real rows down the whole screen rather than a header floating above a
+gap. Keep every label short enough to sit on one line within its column.
+
+**Persistent chrome bars span the full frame width.** Top bars, app headers,
+toolbars, and bottom tab/nav bars are full-width chrome, not centered content. Lay
+each one out as a single flex row that fills the frame
+(`style="display:flex;align-items:center;width:100%"`) and push trailing actions to
+the right edge with a flex spacer (`<div style="flex:1"></div>`) between the
+leading and trailing groups — never center a bar inside a narrow block, and never
+let it collapse to the width of its contents.
+
+**Pin bottom bars to the bottom of the frame.** For mobile tab bars, footers, and
+any persistent bottom action row, make the frame itself a flex column at
+`height:100%` (`style="display:flex;flex-direction:column;height:100%"`), give the
+scrolling body `flex:1`, and place the bar as the LAST child (or set
+`margin-top:auto`). The bar then sits flush at the bottom instead of floating with
+an empty band beneath it.
+
+**Before / after must be comparable.** When showing a state change, preserve the
+unchanged controls in both states so the reviewer can see exactly what moved or
+appeared; do not show an added control as a generic box floating elsewhere. Place
+the new/changed affordance where the implementation puts it. Use the same frame
+size, scale, outer padding, border radius, and visual density on both sides unless
+the change itself alters those properties.
+
+**Name the states with the column header, never inside the frame.** For
+document-body wireframes, put the two states in a `columns` block and set each
+column's `label` to `Before` and `After` — the renderer draws that label as a
+heading above each frame. Do NOT bake a `Before`/`After` pill, title, or heading
+into the wireframe `html`. On a canvas, place the two state artboards as neighbors
+with frame labels — never encode Before/After inside the html.
+
+**Let the surface choose side-by-side vs. stacked.** For document-body wireframes,
+the `columns` renderer lays narrow surfaces (`mobile`, `popover`, `panel`) out
+side by side, and automatically stacks wide surfaces (`desktop`, `browser`)
+vertically at full document width so a large frame is never crushed into a
+half-width column. Author both wireframes with the real `surface` and matching
+`Before`/`After` column labels.
+
+**Good example — a contacts list, surface `browser`.** A small, real screen
+composed from the helper classes and tokens, layout in inline flex, no fonts or
+hex colors:
+
+```html
+<div style="display:flex;flex-direction:column;gap:12px;padding:16px;height:100%">
+  <div style="display:flex;align-items:center;justify-content:space-between">
+    <h1>Contacts</h1>
+    <button class="primary">New contact</button>
+  </div>
+  <div style="display:flex;gap:6px">
+    <span class="wf-pill accent">All 128</span>
+    <span class="wf-pill">Favorites</span>
+    <span class="wf-pill">Archived</span>
+  </div>
+  <div class="wf-card" style="display:flex;flex-direction:column;gap:0;padding:0">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-bottom:1.4px solid var(--wf-line)">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Jane Cooper</strong><br /><small>jane@acme.co</small></div>
+      <span class="wf-pill">Lead</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Marcus Lee</strong><br /><small>marcus@globex.io</small></div>
+      <span class="wf-pill">Customer</span>
+    </div>
+  </div>
+</div>
+```

--- a/.codex-plugin/ycc/skills/visual-plan/scripts/derive-visual-dir.sh
+++ b/.codex-plugin/ycc/skills/visual-plan/scripts/derive-visual-dir.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# derive-visual-dir.sh — compute the visual/ output directory for a plan path.
+#
+# The visual-plan contract (skills/_shared/references/visual-mode.md) requires
+# the output to live in a `visual/` sibling of the input plan file, derived from
+# the path handed in — never hardcoded. This thin wrapper performs that single
+# derivation so the skill never improvises the path.
+#
+# Usage:
+#   derive-visual-dir.sh <path/to/plan.md> [--mkdir]
+#
+# Arguments:
+#   <path/to/plan.md>   Source plan path (absolute or relative). Must exist.
+#   --mkdir             Create the derived directory if it does not exist.
+#
+# Output:
+#   The derived visual/ directory path on stdout.
+#
+# Exit codes:
+#   0 - Derived (and created, if --mkdir) successfully
+#   1 - Usage error or plan path missing
+#
+set -euo pipefail
+
+_error() {
+  echo "derive-visual-dir.sh: error: $*" >&2
+}
+
+PLAN_PATH=""
+DO_MKDIR=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mkdir)
+      DO_MKDIR=1
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: derive-visual-dir.sh <path/to/plan.md> [--mkdir]" >&2
+      exit 0
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      exit 1
+      ;;
+    *)
+      if [[ -n "$PLAN_PATH" ]]; then
+        _error "unexpected extra argument: $1"
+        exit 1
+      fi
+      PLAN_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$PLAN_PATH" ]]; then
+  _error "a plan path is required"
+  echo "Usage: derive-visual-dir.sh <path/to/plan.md> [--mkdir]" >&2
+  exit 1
+fi
+
+if [[ ! -f "$PLAN_PATH" ]]; then
+  _error "plan file not found: $PLAN_PATH"
+  exit 1
+fi
+
+PLAN_DIR="$(cd "$(dirname "$PLAN_PATH")" && pwd)"
+OUT_DIR="${PLAN_DIR}/visual"
+
+if [[ "$DO_MKDIR" -eq 1 ]]; then
+  mkdir -p "$OUT_DIR"
+fi
+
+echo "$OUT_DIR"
+exit 0

--- a/.codex-plugin/ycc/skills/visual-recap/SKILL.md
+++ b/.codex-plugin/ycc/skills/visual-recap/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: visual-recap
+description: Turn a finished change — a git range, branch, or working-tree diff —
+  into a LOCAL-ONLY interactive visual recap (annotated diffs, file map, schema/API
+  deltas, diagrams, wireframes) under docs/prps/reviews/visual/, previewed in the
+  browser via the localhost bridge. Use when the user asks to "recap this branch",
+  "show what changed visually", "visual recap", "review the diff visually", or says
+  "/visual-recap". Never uploads code to a hosted service; remote-agnostic (identical
+  on the public GitHub remote and the private Forgejo origin).
+---
+
+# Visual Recap (LOCAL-ONLY)
+
+`/visual-recap` builds a visual plan **from** a diff, not toward one. It is the
+reverse of forward planning: instead of describing the change you are about to
+make, you describe the change that was just made, at a higher altitude than
+line-by-line review. Schema, API, file, and architecture changes become the same
+`data-model`, `api-endpoint`, `file-tree`, and `diagram` blocks a forward plan
+would use, only now they summarize work that exists. A reviewer scans the shape
+of the change before spending attention on the literal lines.
+
+## LOCAL-ONLY mandate — read this first
+
+> This ycc port **inverts** the upstream BuilderIO `visual-recap` skill. Upstream
+> ALWAYS publishes the recap to the hosted Agent-Native Plan database and FORBIDS
+> inline output ("a recap's entire value is the hosted plan"). **This skill does the
+> opposite.** It is permanently pinned to local-files mode and MUST NOT regress to
+> any hosted Plan create tool.
+
+Hard rules for this skill:
+
+- **`AGENT_NATIVE_PLANS_MODE=local-files` is always set.** Export it before running
+  any runtime command. The recap never writes to the hosted Plan database.
+- **NEVER call a hosted Plan create/publish tool.** The hosted recap-create tool,
+  `create-visual-plan`, `import-visual-plan-source`, `update-visual-plan`,
+  `patch-visual-plan-source`, `get-plan-feedback`, `export-visual-plan`, and
+  `set-resource-visibility` are all **disabled** in this skill. They are listed only
+  to be explicitly excluded — do not invoke them.
+- **The ONLY permitted network call is `get-plan-blocks`** (schema-only block catalog;
+  offline fallback `plan blocks --out`). It carries no recap content. Everything else
+  stays on this machine.
+- **The deliverable is local MDX** under `docs/prps/reviews/visual/<slug>/`, served via
+  the localhost bridge (`plan local serve --open`, 127.0.0.1, ephemeral port). There is
+  no hosted link and no shareable URL.
+- **Diffs are sourced through the shared collector**
+  `~/.codex/plugins/ycc/shared/scripts/visual-recap-collect.sh`, which uses
+  local git refs only — so it behaves identically against the public `github` remote and
+  the private Forgejo `origin` (no vendor PR API, no hardcoded host or trunk branch).
+
+For the pinned `@agent-native/*` install, the `plan` MCP connector (legacy alias
+`agent-native-plans`), the localhost-bridge command surface, and the hosted-egress
+policy, read — do not duplicate —
+`~/.codex/plugins/ycc/shared/references/agent-native-setup.md`.
+
+## When to use
+
+Build a recap when a change is large, multi-file, or touches schema, API contracts,
+or architecture, and a reviewer would benefit from seeing the change mapped to
+structured blocks before reading the raw diff. Skip it for small, single-file, or
+obvious diffs — a recap is review overhead, and a tiny change reviews faster as plain
+diff.
+
+## Phase 0 — Collect the diff (remote-agnostic, local refs only)
+
+Set local-files mode, then drive the shared collector with `$ARGUMENTS`:
+
+```bash
+export AGENT_NATIVE_PLANS_MODE=local-files
+
+# (none)         → working-tree diff vs HEAD
+# <base>..<head> → explicit range
+# <branch>       → branch as head; base = merge-base against tracked upstream
+BUNDLE_DIR="$(~/.codex/plugins/ycc/shared/scripts/visual-recap-collect.sh $ARGUMENTS)"
+```
+
+The collector writes a bundle under `docs/prps/reviews/visual/<slug>/`:
+
+- `diff.patch` — full unified diff (local refs only)
+- `files.txt` — changed-file name list
+- `metadata.txt` — range / base / head / remote provenance (every remote URL via
+  `git remote get-url`, never a hardcoded host)
+
+`$BUNDLE_DIR` (printed on stdout) is the slug directory the recap MDX is written into.
+Read `diff.patch` and `files.txt` to ground every block. **Print the resolved
+range and remote provenance from `metadata.txt` before authoring** so it is obvious
+which refs the recap covers.
+
+## Phase 1 — Scope the work unit
+
+Default scope is the whole change in the collected range, not only the most recent
+edit. Separate the changes that belong to this work unit from unrelated pre-existing
+dirty work. If the scope is genuinely ambiguous, state the assumption or ask a concise
+question before authoring.
+
+Make a short surface/state inventory from the diff before writing any block: changed
+routes, components, popovers/dialogs, role/access states, empty/error/loading states,
+and shared abstractions. The final recap must either represent each meaningful item
+with a block or intentionally omit it as tiny/redundant/not-user-visible.
+
+## Phase 2 — Fetch the block catalog (the one permitted network call)
+
+> GOTCHA: The MDX block vocabulary drifts upstream between releases. Do NOT author
+> from memorized JSX tags — they silently produce wrong tags that error on import.
+
+Before writing any structured MDX, fetch the live block catalog:
+
+- Connected: call `get-plan-blocks` on the `plan` MCP connector (schema-only; no recap
+  content leaves the machine).
+- Offline / `local-files` fallback: run `plan blocks --out plan-blocks.md` and read it
+  first (calls the public no-auth `get-plan-blocks` route; sends no recap content).
+
+Author every block against the tags and schemas that call returns. The scratch
+`plan-blocks.md` is git-ignored — do not commit it.
+
+## Phase 3 — Map the diff to blocks
+
+Derive every structured block mechanically from the real diff (real paths, real fields,
+real method/path, real before/after text). The names below are CONCEPTUAL block types;
+resolve each to its exact tag + props via `get-plan-blocks`.
+
+- **Schema / migration change** → `data-model` for the resulting entities, fields, and
+  relations. Flag each field/entity with `change: "added" | "modified" | "removed" |
+"renamed"`; for a changed type set `was` to the prior value. The diff-aware
+  `data-model` is the headline; add a split `diff` of literal SQL only when the exact
+  statement still matters.
+- **API / action / route change** → `api-endpoint` with the post-change method, path,
+  params, request, and responses. Flag each changed param/response with `change` (and
+  `was` when a type/shape changed); set `change` on the endpoint root for a wholly added
+  or removed route; mark removed routes `deprecated: true`. Author each request/response
+  example as a single valid JSON value.
+- **Files added / removed / renamed** → `file-tree` with each entry's `change` flag
+  (`added`, `removed`, `modified`, `renamed`) and a short `note`.
+- **Any meaningful code hunk** → `diff` with **split view as the default** (`mode:
+"split"`), carrying the real `before`/`after` text plus `filename`/`language`. Give
+  every `diff` a one-line `summary`; attach a few high-signal `annotations` to the key
+  files. Reserve `mode: "unified"` for a genuinely narrow standalone hunk. Group the key
+  files under a `## Key changes` heading in a single horizontal `tabs` block (one file
+  per tab) so the selected split diff gets full document width.
+- **Brand-new file with no meaningful "before"** → `annotated-code` rather than a
+  one-sided split `diff`.
+- **Rendered UI / interaction change** → `wireframe` blocks (see below) showing the
+  visible delta before any code.
+- **Architecture or data-flow shift** → `diagram` (`data.html`/`data.css` two-panel
+  before/after, layered, or swimlane; or `mermaid` for a quick graph). Use `--wf-*`
+  theme tokens and `.diagram-*` primitives — never hex, rgb/hsl, or `font-family`. Do
+  not use `diagram` as a stand-in for rendered UI; UI changes need `wireframe`.
+- **Outcome-first narrative** → `rich-text` for the "what changed and why": the
+  objective, key decisions visible in the diff, and risks. This is the only place the
+  model writes freely.
+
+### Canonical shape
+
+A strong recap follows one skeleton, top to bottom:
+
+1. UI-impact headline — wireframes first, when the diff changed rendered UI.
+2. Short outcome narrative (`rich-text`): what changed and why, 1–3 paragraphs.
+3. `data-model` / `api-endpoint` blocks for schema and contract changes.
+4. `file-tree` of the changed files with `change` flags.
+5. `## Key changes` — one horizontal `tabs` block of `diff` / `annotated-code`
+   (3–8 focused tabs; prefer under ~150 lines per tab).
+
+Keep the body lean: no boilerplate intro/disclaimer/provenance prose. Add prose only
+when it tells the reviewer something the structured blocks do not.
+
+## UI impact requires wireframes (MANDATORY)
+
+When the diff changes rendered UI, layout, density, visual state, interaction
+affordances, navigation, controls, menus, dialogs, or design tokens, the recap **MUST**
+include one or more `wireframe` blocks. Prose and file diffs are not a substitute for
+showing what changed visually.
+
+Before authoring ANY wireframe, **read
+`~/.codex/plugins/ycc/skills/visual-recap/references/wireframe.md` in full** — it is the
+single source of truth for HTML wireframe quality (`.wf-*` classes, `[data-icon]` Tabler
+set, `surface` presets, `--wf-*` tokens, before/after comparability, skeleton states).
+Do not author wireframes from memory. Show the changed entry point, the main changed
+interaction surface, and the resulting/destination state; for UI-heavy changes a single
+before/after of the entry surface is not enough.
+
+## Phase 4 — Write and serve the local recap
+
+Write the recap as a local MDX folder inside the collected bundle directory:
+
+- `docs/prps/reviews/visual/<slug>/plan.mdx` (required), optional `canvas.mdx`, and
+  optional `.plan-state.json`. Set `kind: "recap"` and `localOnly: true` in the source
+  frontmatter/state.
+
+Validate, then serve via the localhost bridge:
+
+```bash
+plan local check --dir docs/prps/reviews/visual/<slug>
+plan local serve --dir docs/prps/reviews/visual/<slug> --kind recap --open
+```
+
+`serve` binds **127.0.0.1** on an ephemeral CLI-chosen port and opens the preview. It
+performs **no DB writes and sends nothing to any server** — it is a purely local render
+of the on-disk MDX. Report the local bridge URL from stdout (or `<slug>/.plan-url`, a
+local token file — do not commit it). The URL is not shareable across machines.
+
+Treat review feedback as file/chat feedback: edit the MDX directly, rerun
+`plan local serve`, and report the new local bridge URL. Hosted comments, sharing,
+screenshots, and PR sticky-comment publishing are intentionally unavailable.
+
+## Grounding & security
+
+- **Grounding rule.** `diff`, `data-model`, `api-endpoint`, and `file-tree` blocks must
+  be built mechanically from the real changed lines — never inferred, rounded, or
+  invented. Mark anything the model inferred (not extracted) as inferred in prose. When
+  the diff does not contain a fact, leave it out.
+- **Never transcribe secrets.** A diff can contain API keys, tokens, webhook URLs,
+  signing secrets, or `.env` values. Never copy these into any block, snippet, caption,
+  or note — redact them (`sk-•••`). This mirrors the repo's hardcoded-secret rule.
+- **No egress.** This skill performs no hosted upload. The shared
+  `~/.codex/plugins/ycc/shared/scripts/visual-egress-guard.sh` exists for the
+  consent-gated hosted path used by `visual-plan`; it is NOT invoked here because
+  this recap never leaves the machine.
+
+## Output
+
+- Local MDX recap under `docs/prps/reviews/visual/<slug>/` (`plan.mdx` + bundle).
+- A `127.0.0.1` localhost-bridge preview URL printed to stdout.
+- **No hosted link, no shareable URL, no PR comment, no GitHub/Forgejo Action.**
+
+## Related
+
+- `visual-plan` — forward planning; faithful hosted+local MDX workflow with
+  consent-gated egress. Shares the wireframe quality bar word-for-word.
+- `~/.codex/plugins/ycc/shared/references/agent-native-setup.md` — runtime
+  contract (install pin, connector, bridge, egress policy).

--- a/.codex-plugin/ycc/skills/visual-recap/references/wireframe.md
+++ b/.codex-plugin/ycc/skills/visual-recap/references/wireframe.md
@@ -1,0 +1,234 @@
+# HTML wireframe quality — single source of truth
+
+This file is the canonical quality bar for HTML wireframes / `WireframeBlock`
+content, shared word for word by `visual-plan` and `visual-recap`. Read it in
+full before authoring ANY wireframe; do not author wireframes from memory or paraphrase
+these rules per command.
+
+**A wireframe is an HTML mockup. The renderer owns the look; you write the content.**
+Set `data.html` to a self-contained, semantic HTML fragment of the screen and set
+`data.surface`. The renderer owns the surface footprint/aspect, the dark/light theme,
+the hand-drawn font, and the sketch overlay — you never write `<html>`/`<body>`/`<svg>`
+tags or any width/height/coordinates. You write real HTML layout and real product
+content; the renderer styles and roughens it.
+
+**A wireframe block's data is an HTML screen plus a surface:**
+
+```json
+{
+  "surface": "browser",
+  "html": "<div style=\"display:flex;flex-direction:column;gap:10px;padding:16px;height:100%\"><h1>Sign in</h1><p class=\"wf-muted\">Use your work email to continue.</p><div class=\"wf-card\" style=\"display:flex;flex-direction:column;gap:10px\"><label>Email<input value=\"jane@acme.co\" /></label><label>Password<input value=\"••••••••\" /></label><label style=\"display:flex;align-items:center;gap:8px\"><input type=\"checkbox\" checked /> Remember me</label><button class=\"primary\">Sign in</button></div><a href=\"#\">Forgot password?</a></div>"
+}
+```
+
+**Write PLAIN semantic HTML and let the renderer style it.** Bare elements
+(`h1`/`h2`/`h3`, `p`, `button`, `input`, `label`, `a`, `hr`) are auto-themed — no
+classes needed. Helper classes carry the rest:
+
+- `.wf-card` / `.wf-box` — a bordered, padded container (a panel, a list item).
+- `.wf-pill` / `.wf-chip` — a rounded tag or filter; add `.accent` for the
+  accent-filled variant.
+- `.wf-muted` — secondary/muted text.
+- `button.primary` or any element with `[data-primary]` — the accent-filled primary
+  button.
+
+**No decorative shadows around mockups.** Do not put `box-shadow`,
+`filter: drop-shadow(...)`, Tailwind `shadow-*` classes, or other fake depth effects on
+a wireframe frame, root container, `.wf-card` / `.wf-box`, or canvas artboard. Mockups
+should read as flat, bordered surfaces; use spacing, borders, labels, and annotations
+for separation. Only show a shadow when the real product UI already has that shadow and
+it is essential to the change being reviewed.
+
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading icons
+inside fields, chips, menu items, and toolbars, write an empty marker such as
+`<i data-icon="mail"></i>` or `<span data-icon="search"></span>`. The renderer replaces
+it with a Tabler-style SVG and the `.wf-icon` class sizes it to the surrounding text.
+Supported names and aliases: `mail`/`email`, `lock`/`password`, `search`, `plus`/`add`,
+`x`/`close`, `check`, `chevronDown`, `chevronUp`, `chevronLeft`, `chevronRight`,
+`dots`/`more`, `chevron`/`caret`/`dropdown` (down chevron), `user`, `settings`,
+`calendar`, `bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do not put visible
+words like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
+**Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips these on
+light/dark, so reading them is what keeps a mockup correct in both themes. For any
+inline border, background, or text color, reference a token:
+`style="border:1.4px solid var(--wf-line)"`. The tokens are `--wf-ink` (text),
+`--wf-muted` (secondary text), `--wf-line` (borders/dividers), `--wf-paper` (page
+background), `--wf-card` (container surface), `--wf-accent` / `--wf-accent-fg` /
+`--wf-accent-soft` (brand action), `--wf-warn`, `--wf-ok`, and `--wf-radius`. Never
+hard-code a hex color and never set `font-family` — the renderer owns the sketch/clean
+font.
+
+**Lay out with inline `style` flex/grid.** You write the real layout —
+`display:flex; flex-direction:column; gap:10px; padding:16px` and so on — and the
+renderer never repositions anything. Compose the actual product: reproduce the current
+screen, then show the modification. Real labels, real counts, real dates, real button
+text grounded in the screen you read; not lorem or gray bars.
+
+**Surface presets — match the real footprint, never default to desktop+mobile.** Pick
+the `surface` that matches what the user will actually see:
+
+- `browser`: a web page that needs a browser chrome frame around it.
+- `desktop`: a full desktop app page or app shell.
+- `mobile`: a phone screen, only when the work is genuinely mobile.
+- `popover`: a small floating menu, dropdown, or inline popover.
+- `panel`: a side panel, inspector, or sidebar widget.
+
+A sidebar popover renders as a small surface, not a desktop page and a phone frame. Do
+not emit `desktop` + `mobile` variants unless responsive behavior actually changes the
+layout. For a component or widget, show one broader app-context frame only when
+placement affects understanding, then the focused component states.
+
+**Model the actual component shell for small surfaces.** A rendered UI change belongs in
+a wireframe; reserve `diagram` for architecture, dependency, state, or data-flow
+relationships. Popovers, dropdown menus, command palettes, and context menus use
+`surface: "popover"` unless the surrounding page placement is the point of the change.
+Dialogs, sheets, inspectors, sidebars, and long property panels use the matching
+`panel` / `desktop` surface as appropriate. Show the real chrome: trigger or anchor when
+it matters, title/header row, top-right actions, separators, fields, options, selected
+states, body content, and footer actions that are visible in the workflow.
+
+**Modify, don't redesign.** When the task changes an existing screen, reproduce the
+current screen's real layout and footprint FIRST, then change only the delta and call it
+out with a single annotation. Do not restack the page into a new layout. For net-new
+surfaces, compose from the real app shell. Inspect the actual app components before
+drawing an existing product: sidebar density, toolbar actions, overflow menus, property
+panels, and framework chrome should match the product unless the plan intentionally
+changes them.
+
+**Keep product screens pure.** A product wireframe shows the app state a user would
+actually see. Do not embed file contracts, architecture arrows, repo pills, mode
+explanations, or implementation callouts inside the screen just to explain the plan. Put
+those in canvas annotations, a separate diagram, or the document body. Secondary UI such
+as properties, history, sync, export, or agent controls should appear where the real
+product would put them: an overflow popover, sheet, panel, or separate framework sidebar
+state, not a generic permanent right inspector unless that inspector is the actual
+design.
+
+**Classify mockup scope before implementation.** Before turning a plan mockup into
+source code, decide whether each artboard represents the whole page/app shell, a route
+body inside an existing shell, or a component/sub-surface. If an artboard includes
+navigation, sidebars, auth banners, or a signup/login form, map those pieces to the real
+shared shell/auth components instead of nesting the entire mockup inside the current
+page. When a mockup references the product's standard signup/login page, find and reuse
+that existing implementation; do not approximate it from the wireframe.
+
+**Zoom in on sub-surfaces, don't redraw the page.** For a small sub-surface (a popover,
+menu, dialog, toast), show the full screen once, then add a small separate artboard
+whose `html` contains ONLY that sub-surface — do not re-draw the whole page around it,
+and do not scale a duplicate up. Pick the matching `surface` (e.g. `popover`) so the
+footprint is right; never widen a popover to page width.
+
+**Loading / skeleton states.** Set `data.skeleton: true` on the wireframe and fill the
+`html` with neutral, textless placeholder geometry — boxes and bars built as `<div>`s
+with `background:var(--wf-line)` and explicit heights/widths, no labels or copy. The
+renderer drops borders, sketch, and color into the skeleton register automatically.
+Never escape to a `custom-html` document block to fake a loader.
+
+**Editing an existing mockup.** Because this skill is LOCAL-ONLY, edit the MDX source
+file directly (no hosted patch tool), then rerun `plan local serve` to re-render. Read
+the current `html` first so each replacement targets a unique snippet; the result is
+re-sanitized on reload.
+
+**Treat the wireframe border as part of the visible design.** Always wrap HTML wireframe
+content in a root container with real inner padding before drawing cards, fields, pills,
+labels, or controls. Use at least 14–16px of padding, `box-sizing: border-box`,
+`height: 100%`, and `gap` between child rows so the first row never sits flush against
+the screen border. Keep text away from borders: every container, field, button, menu
+item, and annotation needs enough padding and line-height to read cleanly in the
+rendered Plan view.
+
+**Lay out children safely so they never collide.** Use HTML flex/grid with `gap`,
+`min-width: 0`, and sensible overflow. Avoid negative margins, absolute positioning, or
+fixed child widths that can collide when the renderer switches between light/dark,
+sketch/clean, or different zoom levels.
+
+**Do not wrap intentionally single-line labels.** For toolbars, tab rails, breadcrumbs,
+chip/filter rows, branch and file names, file chips, and code filenames — any
+deliberately single-line row — do not let long text wrap. Put `white-space: nowrap` on
+the row (and `overflow: hidden; text-overflow: ellipsis` on the individual labels that
+can grow), so the wireframe demonstrates the actual layout behavior instead of producing
+ugly stacked or vertical text. Use horizontally scrollable or clipped rails for
+overflow.
+
+**Fill the frame; keep labels short.** Each artboard is a fixed-size surface — compose
+enough realistic HTML to fill it top to bottom with even vertical rhythm; never leave a
+large empty band. On desktop/app-shell sidebars, let the nav stack flex to fill
+(`flex:1`) and add any persistent bottom action/status after it so the rail reads
+complete in taller frames. On mobile especially, flow real rows down the whole screen
+(status bar, header, then list/detail content) rather than a header floating above a
+gap. Keep every label short enough to sit on one line within its column — shorten the
+copy rather than relying on the frame to absorb it.
+
+**Persistent chrome bars span the full frame width.** Top bars, app headers, toolbars,
+and bottom tab/nav bars are full-width chrome, not centered content. Lay each one out as
+a single flex row that fills the frame (`style="display:flex;align-items:center;width:100%"`)
+and push trailing actions to the right edge with a flex spacer
+(`<div style="flex:1"></div>`) between the leading group and the trailing group — never
+center a bar inside a narrow, centered block, and never let it collapse to the width of
+its contents. In a Before/After pair the bar stays full-width in BOTH states even when
+one state has fewer controls; the spacer absorbs the difference so the remaining controls
+hold their edge alignment.
+
+**Pin bottom bars to the bottom of the frame.** For mobile tab bars, footers, and any
+persistent bottom action row, make the frame itself a flex column at `height:100%`
+(`style="display:flex;flex-direction:column;height:100%"`), give the scrolling body
+`flex:1` so it absorbs the slack, and place the bar as the LAST child of the frame (or
+set `margin-top:auto` on it). The bar then sits flush at the bottom of the surface
+instead of floating directly under the content with an empty band beneath it.
+
+**Before / after must be comparable.** When showing a state change, preserve the
+unchanged controls in both states so the reviewer can see exactly what moved or
+appeared; do not show an added control as a generic box floating elsewhere in the
+surface. Place the new/changed affordance where the implementation puts it — for
+example, a new `Edit with AI` action in a popover header belongs in the top-right header
+slot, aligned with the title, not in the body or footer. Use the same frame size, scale,
+outer padding, border radius, and visual density on both sides unless the change itself
+alters those properties, and let the frame height fit the content rather than leaving a
+tall empty lower half.
+
+**Name the states with the column header, never inside the frame.** For document-body
+wireframes (recaps), put the two states in a `columns` block and set each column's
+`label` to `Before` and `After` — the renderer draws that label as an `h4` heading above
+each frame. Do NOT bake a `Before`/`After` pill, title, or heading into the wireframe
+`html`: a label placed inside reads as part of the product UI, lands in a random corner,
+and clutters the comparison. The column header is the one and only place the state name
+belongs.
+
+**Let the surface choose side-by-side vs. stacked.** For document-body wireframes
+(recaps), the `columns` renderer lays narrow surfaces (`mobile`, `popover`, `panel`) out
+side by side, and automatically stacks wide surfaces (`desktop`, `browser`) vertically
+at full document width so a large frame is never crushed into a half-width column and
+cropped. Author both wireframes with the real `surface` and the matching `Before`/`After`
+column labels; do not hand-stack the pair into separate top-level wireframes or duplicate
+the state name as body content.
+
+**Good example — a contacts list, surface `browser`.** A small, real screen composed
+from the helper classes and tokens, layout in inline flex, no fonts or hex colors:
+
+```html
+<div style="display:flex;flex-direction:column;gap:12px;padding:16px;height:100%">
+  <div style="display:flex;align-items:center;justify-content:space-between">
+    <h1>Contacts</h1>
+    <button class="primary">New contact</button>
+  </div>
+  <div style="display:flex;gap:6px">
+    <span class="wf-pill accent">All 128</span>
+    <span class="wf-pill">Favorites</span>
+    <span class="wf-pill">Archived</span>
+  </div>
+  <div class="wf-card" style="display:flex;flex-direction:column;gap:0;padding:0">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-bottom:1.4px solid var(--wf-line)">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Jane Cooper</strong><br /><small>jane@acme.co</small></div>
+      <span class="wf-pill">Lead</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Marcus Lee</strong><br /><small>marcus@globex.io</small></div>
+      <span class="wf-pill">Customer</span>
+    </div>
+  </div>
+</div>
+```

--- a/.cursor-plugin/skills/_shared/references/agent-native-setup.md
+++ b/.cursor-plugin/skills/_shared/references/agent-native-setup.md
@@ -1,0 +1,102 @@
+# Agent-Native Runtime — Shared Setup Contract
+
+Reference for ycc skills that drive the Agent-Native visual-planning runtime — currently
+`${CURSOR_PLUGIN_ROOT}/skills/visual-plan/SKILL.md` and
+`${CURSOR_PLUGIN_ROOT}/skills/visual-recap/SKILL.md`. Both skills cite this doc so the install
+pin, the auth/reconnect flow, the connector names, the localhost bridge, and the egress
+policy stay convergent. Fix them here, not per skill (DRY).
+
+The pinned version below was resolved with `npm view @agent-native/core version` at authoring
+time. Re-resolve and re-pin before a release if the runtime has advanced — never substitute a
+floating `latest` dist-tag into committed content.
+
+---
+
+## Install (pinned)
+
+Install a skill from the Agent-Native core CLI with an **explicit pinned version**:
+
+```
+npx -y @agent-native/core@0.59.1 skills add <skill>
+```
+
+- The pin (`0.59.1`) is the version resolved via `npm view @agent-native/core version`.
+- Never commit a floating `latest` dist-tag — the block vocabulary and CLI surface drift
+  between releases, so an unpinned install can silently change behavior. Pin, verify, then bump
+  deliberately.
+
+## Reconnect / auth (one-time per client)
+
+Authorize the runtime against the hosted Plans origin once per client. This is a one-time
+step per machine/client, not per skill run:
+
+```
+npx -y @agent-native/core@0.59.1 reconnect https://plan.agent-native.com --client [claude-code|codex|all]
+```
+
+- `--client all` reconnects every detected client at once.
+- Re-run only when credentials are revoked or the client is reinstalled.
+
+## MCP connector
+
+The runtime exposes an MCP connector named **`plan`**. The legacy alias **`agent-native-plans`**
+still resolves to the same connector — accept either name when detecting an existing
+connection, but prefer `plan` in new guidance.
+
+## Local-only operation
+
+For local-only operation (no hosted calls, no auth required), set:
+
+```
+AGENT_NATIVE_PLANS_MODE=local-files
+```
+
+In this mode the runtime reads and writes plans on the local filesystem only; it does not
+contact `plan.agent-native.com`.
+
+## Localhost bridge
+
+To preview a plan locally, use the `plan local` bridge commands against the plan directory:
+
+```
+plan local check --dir plans/<slug>
+plan local serve --dir plans/<slug> --open
+```
+
+- `check` validates the plan files under `plans/<slug>` without serving.
+- `serve` binds **127.0.0.1** on an **ephemeral, CLI-chosen port** and opens the preview with
+  `--open`.
+- The bridge performs **no DB writes** and sends **nothing to any server** — it is a purely
+  local render of the on-disk plan.
+
+## Block vocabulary (resolve at USE TIME)
+
+> GOTCHA: The MDX block vocabulary drifts upstream between releases. Do **not** trust any
+> hardcoded component/block list in skill bodies or in this doc.
+
+At the runtime-author step (use time, not authoring time), fetch the live block catalog:
+
+- Hosted/connected: call the **`get-plan-blocks`** MCP tool.
+- Offline / `local-files` fallback: run `plan blocks --out <path>` to dump the current catalog.
+
+Always render plan MDX against the freshly-fetched block list, never a list memorized in a
+skill.
+
+## Egress policy
+
+Hosted upload is **OFF by default** and **consent-gated**:
+
+- No plan content leaves the machine unless the operator passes an explicit `--share` flag
+  that names the destination host `plan.agent-native.com`.
+- All hosted egress MUST be routed through
+  `${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/visual-egress-guard.sh` so the consent check
+  and destination allowlist are enforced in one place.
+- Localhost bridge usage (above) is not egress: it stays on 127.0.0.1 and writes nothing
+  remote.
+
+## Hosted Plans app
+
+- Hosted origin: `https://plan.agent-native.com`.
+- Create tools return **absolute, shareable URLs** under that origin.
+- Plans backed by a **private repo are org-gated** — only members of the owning org can open
+  the shared URL.

--- a/.cursor-plugin/skills/_shared/references/visual-mode.md
+++ b/.cursor-plugin/skills/_shared/references/visual-mode.md
@@ -1,0 +1,152 @@
+# Visual Mode — Canonical Reference
+
+Used by `prp-plan`, `plan`, `parallel-plan`, and `plan-workflow`
+to expose a uniform `--visual` decorator. This file documents the **single
+`--visual` contract** shared by all four planning skills: when it runs, how it
+composes with other flags, how `--dry-run` short-circuits it, and the hand-off
+to `visual-plan`. Individual skills own their own flag plumbing and the path
+where they write a plan; the shared **invariant** lives here.
+
+`--visual` is a **terminal decorator step**, not a dispatch mode. It does not
+change how a plan is researched, dispatched, or written — it only runs once,
+**after** the plan exists and has been validated, to produce a visual rendering
+of that plan.
+
+See [worktree-strategy.md](./worktree-strategy.md) for where plan artifacts live
+and [agent-team-dispatch.md](./agent-team-dispatch.md) for the team lifecycle
+that `--team` layers on top of planning.
+
+---
+
+## 0. Default Behavior
+
+`--visual` is **off by default** on all four planning skills. When omitted, the
+skill behaves exactly as it does today and writes no visual output.
+
+| Skill               | Writes a plan artifact by default?   | `--visual` target                         |
+| ------------------- | ------------------------------------ | ----------------------------------------- |
+| `prp-plan`      | yes — `docs/prps/plans/*.plan.md`    | the written plan file                     |
+| `parallel-plan` | yes — feature-dir `parallel-plan.md` | the written plan file                     |
+| `plan-workflow` | yes — feature-dir `parallel-plan.md` | the written plan file                     |
+| `plan`          | **no** — plan kept in-chat           | a plan file `--visual` is forced to write |
+
+The plan path differs per skill (and `plan` writes none by default). The
+contract therefore never hardcodes `docs/prps/plans`; it passes whatever
+absolute plan path the skill produced to `visual-plan` and lets that skill
+derive its output directory. See §3 (hand-off) and §4 (`plan` special case).
+
+---
+
+## 1. Timing — runs AFTER write AND validation
+
+`--visual` is the **last** step of a planning run. The order is fixed:
+
+1. Research / dispatch / plan generation (unchanged by `--visual`).
+2. Write the plan artifact to its skill-specific path.
+3. **Validate** the plan per the skill's existing rules.
+4. **Only then** run the `--visual` decorator step.
+
+If steps 1–3 do not complete (research aborts, write fails, or validation
+fails), the `--visual` step does **not** run. There is nothing valid to
+visualize, so the skill reports the upstream failure and stops.
+
+`--visual` never re-orders, re-runs, or substitutes for any earlier phase.
+
+---
+
+## 2. Composition with other flags
+
+`--visual` is **orthogonal** to and **composes with** the dispatch/runtime
+flags. It is applied once, at the end, regardless of which of these are present:
+
+| Flag            | Interaction with `--visual`                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| `--parallel`    | Independent. Parallel dispatch finishes, plan is written + validated, then `--visual` runs once. |
+| `--team`        | Independent. Team lifecycle completes first; `--visual` decorates the final plan.                |
+| `--enhanced`    | Independent. Enhancement affects plan content; `--visual` renders the enhanced result.           |
+| `--no-worktree` | Independent. Worktree opt-out does not affect whether or how `--visual` runs.                    |
+| `--dry-run`     | **Short-circuits** `--visual` (see §2.1).                                                        |
+
+Because `--visual` is a terminal decorator, the combination
+`--parallel --team --visual` (etc.) means: do the parallel/team planning, write
+
+- validate the plan, then run the single `--visual` step on the result.
+
+### 2.1 `--dry-run` short-circuit
+
+When `--dry-run` is present, `--visual` is **short-circuited**: the skill prints
+
+```
+visual generation would run
+```
+
+and does **not** generate anything and does **not** invoke `visual-plan`.
+`--dry-run` always wins over `--visual`; no visual artifacts, directories, or
+links are produced in a dry run.
+
+---
+
+## 3. Hand-off to `visual-plan`
+
+When `--visual` runs for real (not `--dry-run`), the planning skill invokes:
+
+```
+visual-plan <absolute-plan-path>
+```
+
+passing the **absolute path** of the plan file it wrote and validated.
+
+Contract for `visual-plan`:
+
+- **Accept ANY plan path.** It must not assume `docs/prps/plans` or any other
+  fixed location. The plan path is supplied by the caller and may live anywhere
+  (e.g. `docs/prps/plans/<name>.plan.md`, a feature-dir `parallel-plan.md`, or a
+  forced-write file from `plan`).
+- **Derive `visual/` relative to the given plan path.** The output directory is
+  a `visual/` sibling of the plan file — i.e. `<dirname of plan>/visual/` —
+  computed from the path it was handed, never hardcoded.
+- **Print the resulting link to stdout.** Exactly one of:
+  - a hosted shareable URL, or
+  - a localhost preview `http://127.0.0.1:PORT/...`, or
+  - `local files only` when no server/host is available.
+- **NEVER re-run research or dispatch.** It only consumes an existing plan.
+- **NEVER edit the plan file.** It reads the plan and writes only into the
+  derived `visual/` directory; the plan artifact is left byte-for-byte intact.
+
+The planning skill surfaces whatever link `visual-plan` prints; it does not
+re-derive the path itself.
+
+---
+
+## 4. `/plan --visual` special case — force a write FIRST
+
+`plan` writes **no** artifact by default (the plan stays in-chat). There is
+therefore nothing on disk to visualize. When `--visual` is passed to
+`plan`:
+
+1. `plan` **MUST force a plan-file write first**, producing an absolute plan
+   path on disk (this write happens even though it would normally be skipped).
+2. That forced write is then validated like any other plan.
+3. Only after a valid file exists does `plan` hand the absolute path to
+   `visual-plan <absolute-plan-path>`.
+
+Without the forced write there is no input for `visual-plan`, so the
+force-write rule is mandatory — not optional — for `plan --visual`. Under
+`--dry-run` this is moot: the §2.1 short-circuit applies and `plan` prints
+`visual generation would run` without forcing any write.
+
+---
+
+## 5. NAMING_CONVENTION
+
+In-body references to skill assets use the plugin-root variable, e.g.:
+
+- `${CURSOR_PLUGIN_ROOT}/skills/visual-plan/SKILL.md`
+- `${CURSOR_PLUGIN_ROOT}/skills/plan/SKILL.md`
+- `${CURSOR_PLUGIN_ROOT}/skills/prp-plan/SKILL.md`
+- `${CURSOR_PLUGIN_ROOT}/skills/parallel-plan/SKILL.md`
+- `${CURSOR_PLUGIN_ROOT}/skills/plan-workflow/SKILL.md`
+
+The hand-off is always expressed as the skill invocation
+`visual-plan <absolute-plan-path>`, with `<absolute-plan-path>` resolved by
+the calling skill to a real, absolute path on disk.

--- a/.cursor-plugin/skills/_shared/scripts/visual-egress-guard.sh
+++ b/.cursor-plugin/skills/_shared/scripts/visual-egress-guard.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+#
+# visual-egress-guard.sh — pre-upload guard for hosted visual-plan egress.
+#
+# Runs BEFORE any MDX/diff payload leaves the machine for a hosted service
+# (e.g. plan.agent-native.com). It enforces three independent gates:
+#   1. Secret/denylist scan of the payload (mirrors clean/validate-safety.sh).
+#   2. Public-remote check — refuses when the repo's resolved remote is the
+#      private Forgejo origin or any non-public host (never hardcodes a host
+#      beyond the public allowlist; the remote URL comes from `git remote
+#      get-url`).
+#   3. Explicit consent — a consent token naming the destination host must be
+#      supplied before egress is permitted.
+#
+# Usage:
+#   visual-egress-guard.sh --payload <path> [--remote <name>] \
+#       [--destination <host>] [--consent <host>]
+#
+# Arguments:
+#   --payload <path>        File or directory to scan before upload (required).
+#   --remote <name>         Remote whose URL gates publicity (default: tracked
+#                           upstream's remote, else "origin").
+#   --destination <host>    Hosted egress destination (default: plan.agent-native.com).
+#   --consent <host>        Explicit consent token; MUST equal --destination.
+#
+# Exit codes:
+#   0 - All gates passed; hosted egress is permitted
+#   1 - Usage / missing required argument
+#   2 - Secret/denylist hit found in the payload (egress aborted)
+#   3 - Resolved remote is non-public (private Forgejo / non-allowlisted host)
+#   4 - Missing or mismatched consent token
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging helpers (stdout = results, stderr = diagnostics)
+# ---------------------------------------------------------------------------
+
+_error() {
+  echo "visual-egress-guard.sh: error: $*" >&2
+}
+
+_info() {
+  echo "visual-egress-guard.sh: $*" >&2
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  visual-egress-guard.sh --payload <path> [--remote <name>] \
+      [--destination <host>] [--consent <host>]
+
+Arguments:
+  --payload <path>      File or directory to scan before upload (required).
+  --remote <name>       Remote whose URL gates publicity (default: upstream's
+                        remote, else "origin").
+  --destination <host>  Hosted egress destination (default: plan.agent-native.com).
+  --consent <host>      Explicit consent token; MUST equal --destination.
+
+Exit codes: 0 ok | 1 usage | 2 secret hit | 3 non-public remote | 4 no consent
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Denylist — mirrors clean/validate-safety.sh PROTECTED/SECURITY patterns.
+# ---------------------------------------------------------------------------
+
+declare -a PROTECTED=(
+  ".env"
+  ".env.*"
+  "*.pem"
+  "*.key"
+  "*.p12"
+  "*.pfx"
+  "*.crt"
+  "id_rsa"
+  "id_ed25519"
+  "credentials.json"
+  "secrets.json"
+)
+
+# Non-public host detection. A host is treated as non-public (egress refused)
+# when it is the known-private Forgejo origin, sits on a private/tailnet TLD, is
+# a loopback/RFC1918 address, or is an unqualified single-label hostname. Any
+# other fully-qualified public host is allowed. This deliberately avoids
+# hardcoding a public vendor host: publicity is inferred, privacy is matched.
+#
+# The known-private host defaults to the Forgejo origin and may be overridden
+# via VISUAL_EGRESS_PRIVATE_HOST for other deployments.
+PRIVATE_HOST="${VISUAL_EGRESS_PRIVATE_HOST:-git.azules-celsius.ts.net}"
+
+declare -a PRIVATE_SUFFIXES=(
+  ".ts.net"
+  ".local"
+  ".internal"
+  ".lan"
+  ".home.arpa"
+  ".localdomain"
+)
+
+DEFAULT_DESTINATION="plan.agent-native.com"
+
+# ---------------------------------------------------------------------------
+# Argument parsing (strict case-based flag handling)
+# ---------------------------------------------------------------------------
+
+PAYLOAD=""
+REMOTE_NAME=""
+DESTINATION="$DEFAULT_DESTINATION"
+CONSENT=""
+
+require_value() {
+  if [[ $# -lt 2 || -z "$2" ]]; then
+    _error "flag $1 requires a value"
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --payload)
+      require_value "$@"
+      PAYLOAD="$2"
+      shift 2
+      ;;
+    --remote)
+      require_value "$@"
+      REMOTE_NAME="$2"
+      shift 2
+      ;;
+    --destination)
+      require_value "$@"
+      DESTINATION="$2"
+      shift 2
+      ;;
+    --consent)
+      require_value "$@"
+      CONSENT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      _error "unexpected positional argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$PAYLOAD" ]]; then
+  _error "--payload is required"
+  usage
+  exit 1
+fi
+
+if [[ ! -e "$PAYLOAD" ]]; then
+  _error "payload not found: $PAYLOAD"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Gate 1: secret / denylist scan (exit 2 on hit)
+# ---------------------------------------------------------------------------
+
+# Convert a denylist glob into a path-anchored extended regex.
+glob_to_regex() {
+  local g="$1"
+  g="${g//./\\.}"        # escape literal dots
+  g="${g//\*/[^/ ]*}"    # '*' matches a run of non-slash, non-space chars
+  printf '(^|[ /])%s($|[ /])' "$g"
+}
+
+SECRET_HITS=0
+for pattern in "${PROTECTED[@]}"; do
+  regex="$(glob_to_regex "$pattern")"
+
+  # (a) Protected path referenced in payload content (e.g. diff headers).
+  if grep -rInE -- "$regex" "$PAYLOAD" >/dev/null 2>&1; then
+    _error "denylist hit (content): pattern '$pattern' present in payload"
+    SECRET_HITS=$((SECRET_HITS + 1))
+  fi
+
+  # (b) An actual protected file inside the payload tree.
+  if [[ -d "$PAYLOAD" ]]; then
+    if find "$PAYLOAD" -type f -name "$pattern" -print -quit 2>/dev/null | grep -q .; then
+      _error "denylist hit (file): '$pattern' file exists under payload"
+      SECRET_HITS=$((SECRET_HITS + 1))
+    fi
+  else
+    # shellcheck disable=SC2053
+    if [[ "$(basename "$PAYLOAD")" == $pattern ]]; then
+      _error "denylist hit (file): payload basename matches '$pattern'"
+      SECRET_HITS=$((SECRET_HITS + 1))
+    fi
+  fi
+done
+
+if [[ "$SECRET_HITS" -gt 0 ]]; then
+  _error "aborting: ${SECRET_HITS} secret/denylist hit(s) — payload is unsafe to upload"
+  exit 2
+fi
+_info "secret scan clean"
+
+# ---------------------------------------------------------------------------
+# Gate 2: public-remote check (exit 3 when non-public)
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository; cannot verify remote publicity"
+  exit 3
+fi
+
+# Default the remote name to the tracked upstream's remote, else "origin".
+if [[ -z "$REMOTE_NAME" ]]; then
+  UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+  if [[ -n "$UPSTREAM" && "$UPSTREAM" == */* ]]; then
+    REMOTE_NAME="${UPSTREAM%%/*}"
+  else
+    REMOTE_NAME="origin"
+  fi
+fi
+
+REMOTE_URL="$(git remote get-url "$REMOTE_NAME" 2>/dev/null || true)"
+if [[ -z "$REMOTE_URL" ]]; then
+  _error "could not resolve URL for remote '$REMOTE_NAME'"
+  exit 3
+fi
+
+# Extract the host from any common git URL form without hardcoding a host.
+remote_host() {
+  local url="$1"
+  url="${url#*://}"   # drop scheme:// if present
+  url="${url#*@}"     # drop user@ if present
+  url="${url%%[:/]*}" # host is up to the first ':' or '/'
+  printf '%s' "$url"
+}
+
+HOST="$(remote_host "$REMOTE_URL")"
+HOST="$(printf '%s' "$HOST" | tr '[:upper:]' '[:lower:]')"
+
+# Decide whether a host is public. Privacy is matched explicitly; anything not
+# matched as private but shaped like a public FQDN is treated as public.
+is_public_host() {
+  local host="$1"
+
+  # Known-private origin.
+  [[ "$host" == "$PRIVATE_HOST" ]] && return 1
+
+  # Loopback / RFC1918 literals.
+  case "$host" in
+    localhost|127.*|10.*|192.168.*) return 1 ;;
+    172.1[6-9].*|172.2[0-9].*|172.3[01].*) return 1 ;;
+  esac
+
+  # Private / internal / tailnet suffixes.
+  local suffix
+  for suffix in "${PRIVATE_SUFFIXES[@]}"; do
+    [[ "$host" == *"$suffix" ]] && return 1
+  done
+
+  # Unqualified single-label hostnames are not public.
+  [[ "$host" != *.* ]] && return 1
+
+  return 0
+}
+
+if ! is_public_host "$HOST"; then
+  _error "refusing hosted egress: remote '$REMOTE_NAME' host '$HOST' is not public"
+  _error "private/internal remotes (e.g. the Forgejo origin) must not upload to ${DESTINATION}"
+  exit 3
+fi
+_info "remote '$REMOTE_NAME' host '$HOST' is public"
+
+# ---------------------------------------------------------------------------
+# Gate 3: explicit consent (exit 4 when missing/mismatched)
+# ---------------------------------------------------------------------------
+
+if [[ -z "$CONSENT" ]]; then
+  _error "missing consent: pass --consent ${DESTINATION} to authorize hosted egress"
+  exit 4
+fi
+
+if [[ "$CONSENT" != "$DESTINATION" ]]; then
+  _error "consent mismatch: --consent '$CONSENT' does not name destination '${DESTINATION}'"
+  exit 4
+fi
+_info "consent confirmed for destination '${DESTINATION}'"
+
+# ---------------------------------------------------------------------------
+# All gates passed -> result on stdout
+# ---------------------------------------------------------------------------
+
+echo "egress-permitted destination=${DESTINATION} remote=${REMOTE_NAME} host=${HOST}"
+exit 0

--- a/.cursor-plugin/skills/_shared/scripts/visual-recap-collect.sh
+++ b/.cursor-plugin/skills/_shared/scripts/visual-recap-collect.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# visual-recap-collect.sh — remote-agnostic local diff collector for visual recap.
+#
+# Collects a diff bundle using ONLY local git refs so it behaves identically on
+# any remote (public GitHub or the private Forgejo). It NEVER calls a vendor PR
+# API and NEVER hardcodes a remote host or branch name.
+#
+# Usage:
+#   visual-recap-collect.sh [<base>..<head> | <branch>]
+#
+# Arguments:
+#   (none)            Collect the working-tree diff (git diff HEAD).
+#   <base>..<head>    Collect git diff <base>...<head> (explicit two endpoints).
+#   <branch>          Treat <branch> as head; compute base via `git merge-base`
+#                     against the tracked upstream (resolved from @{upstream}).
+#
+# Base resolution NEVER hardcodes a trunk branch: the upstream is resolved with
+#   git rev-parse --abbrev-ref --symbolic-full-name @{upstream}
+# and falls back gracefully to merge-base against HEAD when no upstream is set.
+#
+# Output:
+#   - Diff bundle written under docs/prps/reviews/visual/<slug>/
+#       diff.patch     full unified diff (local refs only)
+#       files.txt      changed-file name list
+#       metadata.txt   range/base/head/remote provenance
+#   - Results (bundle path + summary) on stdout.
+#   - All errors and progress notes on stderr.
+#
+# Exit codes:
+#   0 - Bundle collected successfully
+#   1 - Usage / git / I/O failure
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging helpers (stdout = results, stderr = diagnostics)
+# ---------------------------------------------------------------------------
+
+_error() {
+  echo "visual-recap-collect.sh: error: $*" >&2
+}
+
+_info() {
+  echo "visual-recap-collect.sh: $*" >&2
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  visual-recap-collect.sh [<base>..<head> | <branch>]
+
+Arguments:
+  (none)            Collect the working-tree diff (git diff HEAD).
+  <base>..<head>    Collect git diff <base>...<head>.
+  <branch>          Use <branch> as head; base = merge-base(@{upstream}, <branch>).
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing (strict case-based flag handling)
+# ---------------------------------------------------------------------------
+
+RANGE_ARG=""
+
+set_range_arg() {
+  if [[ -z "$RANGE_ARG" ]]; then
+    RANGE_ARG="$1"
+  else
+    _error "unexpected positional argument: $1"
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        set_range_arg "$1"
+        shift
+      done
+      break
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      set_range_arg "$1"
+      shift
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Git context
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository"
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+CURRENT_BRANCH="$(git branch --show-current || true)"
+
+# Resolve the tracked upstream without ever hardcoding a trunk branch name.
+resolve_upstream() {
+  git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true
+}
+
+# Resolve the remote URL for the given remote name (never hardcode a host).
+remote_url_for() {
+  local name="$1"
+  git remote get-url "$name" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Range / mode resolution
+# ---------------------------------------------------------------------------
+
+MODE=""
+BASE_REF=""
+HEAD_REF=""
+RANGE_LABEL=""
+
+if [[ -z "$RANGE_ARG" ]]; then
+  # Default: working-tree diff against HEAD.
+  MODE="worktree"
+  HEAD_REF="HEAD"
+  RANGE_LABEL="working-tree"
+elif [[ "$RANGE_ARG" == *".."* ]]; then
+  MODE="range"
+  BASE_REF="${RANGE_ARG%%..*}"
+  HEAD_REF="${RANGE_ARG##*..}"
+  if [[ -z "$BASE_REF" || -z "$HEAD_REF" ]]; then
+    _error "malformed range '$RANGE_ARG'; expected <base>..<head>"
+    exit 1
+  fi
+  RANGE_LABEL="${BASE_REF}...${HEAD_REF}"
+else
+  MODE="branch"
+  HEAD_REF="$RANGE_ARG"
+  if ! git rev-parse --verify --quiet "${HEAD_REF}^{commit}" >/dev/null; then
+    _error "not a valid ref: $HEAD_REF"
+    exit 1
+  fi
+  UPSTREAM="$(resolve_upstream)"
+  if [[ -n "$UPSTREAM" ]]; then
+    _info "tracked upstream: $UPSTREAM"
+    BASE_REF="$(git merge-base "$UPSTREAM" "$HEAD_REF" 2>/dev/null || true)"
+  fi
+  if [[ -z "$BASE_REF" ]]; then
+    _info "no upstream merge-base; falling back to merge-base against HEAD"
+    BASE_REF="$(git merge-base HEAD "$HEAD_REF" 2>/dev/null || true)"
+  fi
+  if [[ -z "$BASE_REF" ]]; then
+    _error "could not compute a merge-base for '$HEAD_REF'"
+    exit 1
+  fi
+  RANGE_LABEL="${BASE_REF}...${HEAD_REF}"
+fi
+
+# ---------------------------------------------------------------------------
+# Slug derivation (filesystem-safe; lowercase alnum + dashes)
+# ---------------------------------------------------------------------------
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -e 's#[^a-z0-9]\+#-#g' -e 's#^-\+##' -e 's#-\+$##'
+}
+
+case "$MODE" in
+  worktree)
+    SLUG_SOURCE="${CURRENT_BRANCH:-detached-head}"
+    ;;
+  range)
+    SLUG_SOURCE="${BASE_REF}-to-${HEAD_REF}"
+    ;;
+  branch)
+    SLUG_SOURCE="$HEAD_REF"
+    ;;
+esac
+
+SLUG="$(slugify "$SLUG_SOURCE")"
+if [[ -z "$SLUG" ]]; then
+  SLUG="recap"
+fi
+
+# ---------------------------------------------------------------------------
+# Collect the diff (LOCAL refs only — identical on GitHub and Forgejo)
+# ---------------------------------------------------------------------------
+
+OUT_DIR="docs/prps/reviews/visual/${SLUG}"
+mkdir -p "$OUT_DIR"
+
+DIFF_FILE="${OUT_DIR}/diff.patch"
+FILES_FILE="${OUT_DIR}/files.txt"
+META_FILE="${OUT_DIR}/metadata.txt"
+
+if [[ "$MODE" == "worktree" ]]; then
+  git diff HEAD >"$DIFF_FILE" || { _error "git diff failed"; exit 1; }
+  git diff --name-only HEAD >"$FILES_FILE" || { _error "git diff --name-only failed"; exit 1; }
+else
+  # Three-dot diff against the merge-base of base and head.
+  git diff "${BASE_REF}...${HEAD_REF}" >"$DIFF_FILE" || { _error "git diff failed"; exit 1; }
+  git diff --name-only "${BASE_REF}...${HEAD_REF}" >"$FILES_FILE" || { _error "git diff --name-only failed"; exit 1; }
+fi
+
+# Remote provenance: record every remote URL via `git remote get-url` so the
+# bundle is auditable without hardcoding any host.
+{
+  echo "generated-by: visual-recap-collect.sh"
+  echo "mode: ${MODE}"
+  echo "range: ${RANGE_LABEL}"
+  echo "base: ${BASE_REF:-<working-tree>}"
+  echo "head: ${HEAD_REF}"
+  echo "current-branch: ${CURRENT_BRANCH:-<detached>}"
+  echo "slug: ${SLUG}"
+  echo "remotes:"
+  while IFS= read -r _rname; do
+    [[ -z "$_rname" ]] && continue
+    echo "  - ${_rname}: $(remote_url_for "$_rname")"
+  done < <(git remote)
+} >"$META_FILE"
+
+CHANGED_COUNT="$(grep -c . "$FILES_FILE" 2>/dev/null)" || CHANGED_COUNT=0
+
+# ---------------------------------------------------------------------------
+# Results -> stdout
+# ---------------------------------------------------------------------------
+
+echo "$OUT_DIR"
+_info "collected ${CHANGED_COUNT} changed file(s) for range '${RANGE_LABEL}'"
+_info "bundle: ${OUT_DIR}/{diff.patch,files.txt,metadata.txt}"
+
+exit 0

--- a/.cursor-plugin/skills/parallel-plan/SKILL.md
+++ b/.cursor-plugin/skills/parallel-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: parallel-plan
 description: Create detailed parallel implementation plans by running analysis and validation stages, then synthesizing dependency-aware tasks into parallel-plan.md. Use after shared-context to prepare implementation-ready planning artifacts. Defaults to standalone parallel sub-agents via Cursor; pass `--team` (Claude Code only) to orchestrate the analysis and validation stages as teammates under a shared TeamCreate/TaskList with coordinated shutdown.
-argument-hint: '[--team] [--no-worktree] [feature-name] [--dry-run]'
+argument-hint: '[--team] [--no-worktree] [--visual] [feature-name] [--dry-run]'
 allowed-tools:
   - Read
   - Grep
@@ -69,13 +69,14 @@ Parse arguments (flags first, then the feature name):
 - **--team**: Optional. (Claude Code only) Deploy the analysis and validation stages as teammates under a shared `TeamCreate`/`TaskList` with coordinated shutdown. Default is standalone parallel sub-agents via the `Task` tool. Cursor and Codex bundles lack team tools — do not pass `--team` there.
 - **--worktree**: Optional. (legacy — now default; safe to omit) Worktree annotations are emitted by default. Accepted as a silent no-op so existing pipelines continue to work.
 - **--no-worktree**: Optional. Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.
+- **--visual**: Optional. Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`.
 - **--dry-run**: Show what would be created without making changes. With `--team`, also prints the team name and teammate roster.
 - **feature-name**: Required. Matches directory name in `${PLANS_DIR}`.
 
 If no feature name provided, abort with usage instructions:
 
 ```
-Usage: /parallel-plan [--team] [--no-worktree] [feature-name] [--dry-run]
+Usage: /parallel-plan [--team] [--no-worktree] [--visual] [feature-name] [--dry-run]
 
 Examples:
   /parallel-plan user-authentication
@@ -84,7 +85,18 @@ Examples:
   /parallel-plan --team --dry-run user-authentication
   /parallel-plan user-authentication                     # worktree annotations included by default
   /parallel-plan --no-worktree user-authentication       # skip worktree annotations
+  /parallel-plan --visual user-authentication            # also render the plan as a visual artifact
 ```
+
+---
+
+## Visual mode
+
+`--visual` follows the canonical contract at `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md`. It is a **terminal decorator**, not a dispatch mode: it does not change how the plan is researched, dispatched, or written, and composes orthogonally with `--team` and `--no-worktree`.
+
+When `VISUAL_MODE` is set and not `--dry-run`, after the final phase (plan written in Phase 4, validated in Phase 6 Step 21) the skill invokes `visual-plan <absolute-plan-path>` on the **actual written plan path** — the absolute path of `${feature_dir}/parallel-plan.md`. The bootstrap invocation lives in Step 21.5.
+
+When `--dry-run` is also present, `--visual` is short-circuited (see Step 4): the skill prints `visual generation would run` and generates no artifact, directory, or link.
 
 ---
 
@@ -106,7 +118,8 @@ Extract from `$ARGUMENTS`:
 1. **--team**: Boolean flag. Set `AGENT_TEAM_MODE=true` if present, else `false`.
 2. **--dry-run**: Boolean flag. Set `DRY_RUN=true` if present, else `false`.
 3. **--no-worktree / --worktree**: Default `WORKTREE_MODE=true`. Set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default).
-4. **feature-name**: First non-flag argument (required).
+4. **--visual**: Boolean flag. Set `VISUAL_MODE=true` if present, else `false`.
+5. **feature-name**: First non-flag argument (required).
 
 ```bash
 # Default ON; pass --no-worktree to opt out. --worktree accepted as legacy no-op.
@@ -116,7 +129,15 @@ case " $ARGUMENTS " in
 esac
 ARGUMENTS="${ARGUMENTS//--no-worktree/}"
 ARGUMENTS="${ARGUMENTS//--worktree/}"  # legacy no-op
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
+
+`--visual` is orthogonal — it composes with `--team`/`--no-worktree` and runs after the plan is written and validated. `--dry-run` short-circuits it (prints intent only); see Step 4 and the `## Visual mode` section.
 
 **Compatibility note**: When this skill is invoked from a Cursor or Codex bundle, `--team` must not be used (those bundles ship without team tools).
 
@@ -202,6 +223,14 @@ Teammates:      6 across 2 batches
 ```
 
 Do **not** call `TeamCreate`, `TaskCreate`, `Agent`, `Task`, `SendMessage`, or `TeamDelete` in dry-run mode.
+
+If `VISUAL_MODE=true`, the `--visual` step is **short-circuited** by `--dry-run`: print intent ONLY and generate no visual artifact (`--dry-run` always wins over `--visual`):
+
+```
+visual generation would run
+```
+
+Do **not** invoke `visual-plan` or create any `visual/` directory or link in dry-run mode.
 
 **STOP HERE** - do not write files or deploy agents.
 
@@ -538,6 +567,21 @@ ${CURSOR_PLUGIN_ROOT}/skills/parallel-plan/scripts/validate-parallel-plan.sh "${
 ```
 
 Report any structural issues found.
+
+### Step 21.5: Visual Artifact (if `--visual`)
+
+If `VISUAL_MODE=false`, skip this step entirely.
+
+This step runs **only after** the plan has been written (Step 14) and validated (Step 21). Follow the canonical contract at `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md`. `--visual` is a terminal decorator: it never re-runs research, dispatch, or plan generation.
+
+- If `DRY_RUN=true`, this step was already short-circuited in Step 4 (printed `visual generation would run`); do **not** generate anything here.
+- Otherwise, when `VISUAL_MODE=true` and not `--dry-run`, invoke `visual-plan` on the **actual written plan path** (the absolute path of `${feature_dir}/parallel-plan.md`):
+
+```
+visual-plan <absolute-path-to-${feature_dir}/parallel-plan.md>
+```
+
+Surface whatever link `visual-plan` prints (hosted shareable URL with `--share`, localhost preview, or `local files only`). Do not re-derive the output path — `visual-plan` derives `visual/` relative to the plan path and leaves the plan file byte-for-byte intact.
 
 ### Step 22: Clean Up Team (if `--team`)
 

--- a/.cursor-plugin/skills/plan-workflow/SKILL.md
+++ b/.cursor-plugin/skills/plan-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-workflow
 description: Unified planning workflow - research, analyze, and generate parallel implementation plans in one command. Combines shared-context and parallel-plan with checkpoint support. Default is standalone parallel sub-agents via Cursor. Pass `--team` (Claude Code only) to orchestrate research, analysis, and validation stages as teammates under a shared TeamCreate/TaskList with coordinated shutdown.
-argument-hint: '[--team] [--research-only] [--plan-only] [--no-checkpoint] [--optimized] [--dry-run] [--no-worktree] [feature-name]'
+argument-hint: '[--team] [--research-only] [--plan-only] [--no-checkpoint] [--optimized] [--dry-run] [--no-worktree] [--visual] [feature-name]'
 allowed-tools:
   - Read
   - Grep
@@ -61,12 +61,13 @@ Parse arguments (flags first, then the feature name):
 - **--dry-run**: Show execution plan without running. With `--team`, also prints the team name and teammate roster.
 - **--worktree**: Optional. (legacy — now default; safe to omit) Worktree annotations are emitted in the generated `parallel-plan.md` by default. Accepted as a silent no-op so existing pipelines continue to work.
 - **--no-worktree**: Optional. Opt out of worktree annotations in the generated `parallel-plan.md`. No effect when `--research-only` is passed (no plan file is generated). Honored with `--plan-only`.
+- **--visual**: Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`.
 - **feature-name**: Required. Directory name in `${PLANS_DIR}/`
 
 If no feature name provided, abort with usage instructions:
 
 ```
-Usage: /plan-workflow [--team] [options] [feature-name]
+Usage: /plan-workflow [--team] [options] [--visual] [feature-name]
 
 Options:
   --team            (Claude Code only) Dispatch stages as agent team (default: standalone sub-agents)
@@ -77,6 +78,7 @@ Options:
   --dry-run         Show execution plan without running
   --worktree        (legacy — now default; safe to omit) Worktree annotations emitted by default
   --no-worktree     Opt out of worktree annotations in the generated parallel-plan.md
+  --visual          Render the finished plan as a visual artifact via visual-plan (local-files by default; hosted link requires --share)
 
 Examples:
   /plan-workflow user-authentication
@@ -87,7 +89,26 @@ Examples:
   /plan-workflow --team --dry-run new-feature
   /plan-workflow add-billing-dashboard                 # worktree annotations included by default
   /plan-workflow --no-worktree add-billing-dashboard   # skip worktree annotations
+  /plan-workflow --visual add-billing-dashboard        # render the finished plan as a visual artifact
 ```
+
+---
+
+## Visual mode
+
+See `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md` for the canonical `--visual` contract shared by all planning skills.
+
+`--visual` is a **terminal decorator step**, not a dispatch mode. It is orthogonal to and composes with `--team`, `--optimized`, and `--no-worktree`, and runs once at the very end.
+
+When `VISUAL_MODE=true` and `--dry-run` is **not** set, after the final phase (the plan has been written and validated) the workflow invokes:
+
+```
+visual-plan <absolute-plan-path>
+```
+
+where `<absolute-plan-path>` is the **actual written plan path** — the feature-dir plan at `${feature_dir}/parallel-plan.md` resolved in Phase 0 — **not** a hardcoded `docs/prps/plans` path. `visual-plan` derives its `visual/` output directory relative to that plan path.
+
+When `--dry-run` is set, `--visual` is **short-circuited**: print `visual generation would run` and do not invoke `visual-plan`. `--research-only` produces no plan file, so `--visual` has nothing to render and does not run.
 
 ---
 
@@ -109,9 +130,16 @@ case " $ARGUMENTS " in
 esac
 ARGUMENTS="${ARGUMENTS//--no-worktree/}"
 ARGUMENTS="${ARGUMENTS//--worktree/}"  # legacy no-op
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
-4. **feature-name**: First non-flag argument (required).
+4. **--visual**: Boolean flag. Set `VISUAL_MODE=true` if present, else `false`. Terminal decorator — see [## Visual mode](#visual-mode).
+5. **feature-name**: First non-flag argument (required).
 
 Validate the feature name:
 
@@ -625,6 +653,26 @@ After validators complete:
 If `AGENT_TEAM_MODE=false`, skip this step — standalone sub-agents return on their own.
 
 Otherwise, send shutdown requests to all validation teammates.
+
+---
+
+## Phase 9.5: Visual Mode (if --visual)
+
+If `VISUAL_MODE=false`, skip this phase entirely.
+
+This step runs only after the plan has been written (Phase 8) and validated (Phases 8–9). It never re-orders, re-runs, or substitutes for any earlier phase. See `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md`.
+
+### Step 32.5: Render Visual Artifact
+
+- If `--dry-run` is set, print `visual generation would run` and **STOP** this phase (the §2.1 short-circuit — no visual artifacts are produced).
+- If `--research-only` was used, no plan file was generated; skip this phase.
+- Otherwise, invoke `visual-plan` on the **actual written plan path** (the feature-dir plan resolved in Phase 0, not a hardcoded `docs/prps/plans` path):
+
+```
+visual-plan "${feature_dir}/parallel-plan.md"
+```
+
+`visual-plan` derives its `visual/` output directory relative to the supplied plan path and prints the resulting link (hosted URL, localhost preview, or `local files only`). Surface that link in the Phase 10 summary; do not re-derive the path yourself, and do not edit the plan file.
 
 ---
 

--- a/.cursor-plugin/skills/plan/SKILL.md
+++ b/.cursor-plugin/skills/plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan
 description: Lightweight conversational planner — dispatches planner (or a multi-perspective fan-out) to produce a phased plan with file paths, dependencies, risks, and tests, then WAITS for confirmation. Lighter than plan-workflow or PRD-driven prp-plan. Use when the user asks to "plan this", "outline an approach", "break this down before I code", "parallel plan", "multi-perspective plan", "enhanced plan", or says "/plan".
-argument-hint: '[--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree] <what you want to plan>'
+argument-hint: '[--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree] [--visual] <what you want to plan>'
 allowed-tools:
   - Read
   - Grep
@@ -48,6 +48,7 @@ Create a comprehensive implementation plan before writing any code. This is the 
 | `--dry-run`     | Valid with `--team` (prints team-coordinated roster) or `--enhanced` (prints standalone or team roster depending on whether `--team` is also present). Prints the roster, then exits without spawning any agents.                                                                                                                                                                                                                                                                                                                                                                                  |
 | `--worktree`    | (legacy — now default; safe to omit) Previously required to emit worktree annotations; the annotations are now emitted by default. Accepted as a silent no-op so existing pipelines continue to work.                                                                                                                                                                                                                                                                                                                                                                                              |
 | `--no-worktree` | Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `--visual`      | Force-write the plan to a file, then render it as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`.                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 **Flag interaction**:
 
@@ -76,7 +77,7 @@ Use this skill when:
 
 ### Step 1 — Parse flags and the user's request
 
-**Flag parsing**: Extract `--parallel`, `--team`, `--enhanced`, `--dry-run`, `--no-worktree`, and `--worktree` from `$ARGUMENTS` before processing. Strip them out. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `ENHANCED_MODE=true|false`, `DRY_RUN=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). The remaining text is the user's request.
+**Flag parsing**: Extract `--parallel`, `--team`, `--enhanced`, `--dry-run`, `--no-worktree`, `--worktree`, and `--visual` from `$ARGUMENTS` before processing. Strip them out. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `ENHANCED_MODE=true|false`, `DRY_RUN=true|false`, `VISUAL_MODE=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). The remaining text is the user's request.
 
 ```bash
 # Default ON; pass --no-worktree to opt out. --worktree accepted as legacy no-op.
@@ -92,6 +93,12 @@ case " $ARGUMENTS " in
   *" --enhanced "*) ENHANCED_MODE=true ;;
 esac
 ARGUMENTS="${ARGUMENTS//--enhanced/}"
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
 **Validation**:
@@ -100,6 +107,7 @@ ARGUMENTS="${ARGUMENTS//--enhanced/}"
 - If `DRY_RUN=true` and both `AGENT_TEAM_MODE=false` and `ENHANCED_MODE=false` → abort with: `--dry-run requires --team or --enhanced (no-op for the single-agent path).`
 - If `--team` is invoked from a Cursor or Codex bundle, abort with the existing compatibility message: `--team requires team tools, which Cursor/Codex bundles do not ship. Use --parallel instead.`
 - `--enhanced` alone is supported in every bundle: Path C uses parallel `Agent` calls without team tools. Only the `--enhanced --team` combination requires Claude Code; in Cursor or Codex, abort with: `--enhanced --team requires team tools, which Cursor/Codex bundles do not ship. Drop --team to use the standalone 5-persona path.`
+- `--visual` is orthogonal and runs after the plan is produced. Because `/plan` writes no file by default, `--visual` forces a plan-file write first. `--dry-run` short-circuits it (prints intent only).
 
 Read the stripped `$ARGUMENTS`. If it references a file path, read that file for context. If the request is ambiguous, ask a single focused clarifying question **before** dispatching.
 
@@ -533,6 +541,50 @@ Valid user responses:
 **Team-mode re-dispatch note**: Path B's team is `TeamDelete`d in Step B.8 _before_ the user sees the plan. Any re-dispatch from this step creates a **new** team (same name is fine — the old one no longer exists) with a fresh set of teammates. Do not attempt to send messages to teammates from the prior team.
 
 **Path C re-dispatch note**: Path C never created a team, so there is no teardown to worry about. Any re-dispatch from this step simply fires a fresh batch of 5 parallel `Agent` calls (no `team_name=`).
+
+---
+
+### Step 5 — Visual rendering (if `VISUAL_MODE=true`)
+
+This step runs **only after** the user confirms the plan in Step 4 (it is the terminal decorator step). It never re-orders or substitutes for any earlier phase.
+
+- **If `DRY_RUN=true`**: print `visual generation would run` and skip — do not force any write and do not invoke `visual-plan`. (`--dry-run` already exits earlier at the dispatch gate; this is the no-op contract for the combination.)
+- **Otherwise**:
+  1. **Force-write the plan to a file.** `/plan` keeps the plan in-chat and writes no artifact by default, so there is nothing on disk to visualize. Write the confirmed plan verbatim to a concrete path. Default location: `docs/prps/plans/<slug>.plan.md`, where `<slug>` is the user's request sanitized to kebab-case (same scheme as Path B §B.1: lowercase, non-`[a-z0-9-]` → `-`, collapse runs, trim, truncate to 20 chars, fallback `untitled`). Create the directory first (`mkdir -p docs/prps/plans`). Resolve the path to an **absolute** path.
+  2. **Invoke** `visual-plan <absolute-plan-path>` with the absolute path written in the previous step.
+  3. **Surface the link** that `visual-plan` prints (hosted URL, localhost preview, or `local files only`). Do not re-derive the output directory yourself.
+
+See the canonical contract for the full force-write-first rule and `--dry-run` short-circuit:
+
+```
+${CURSOR_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md
+```
+
+---
+
+## Visual mode
+
+`--visual` is the single, shared visual decorator described in
+`${CURSOR_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md`. It is a
+**terminal decorator step** — it does not change how the plan is researched,
+dispatched, or relayed. It runs once, last, on the confirmed plan.
+
+**FORCE-WRITE-FIRST (mandatory for `/plan`)**: unlike the other planning
+skills, `/plan` writes **no** plan artifact by default — the plan stays
+in-chat. There is therefore nothing on disk to visualize. When `VISUAL_MODE` is
+set (and **not** `--dry-run`), the skill MUST:
+
+1. **Write the otherwise-inline plan to a concrete file path first.** Default:
+   `docs/prps/plans/<slug>.plan.md` (absolute path; directory created if
+   missing). This forced write happens even though it would normally be skipped.
+2. **Then invoke** `visual-plan <absolute-plan-path>` with that absolute
+   path.
+
+Without the forced write there is no input for `visual-plan`, so the
+force-write is required, not optional. Under `--dry-run` this is moot: the
+skill prints `visual generation would run` and forces no write (see §2.1 and §4
+of the canonical reference). `visual-plan` derives its `visual/` output
+directory relative to the plan path it is handed and never edits the plan file.
 
 ---
 

--- a/.cursor-plugin/skills/prp-plan/SKILL.md
+++ b/.cursor-plugin/skills/prp-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prp-plan
 description: Create a self-contained feature implementation plan with codebase pattern extraction and optional external research. Detects PRD vs free-form input, runs codebase discovery via prp-researcher, and writes docs/prps/plans/{name}.plan.md ready for /prp-implement. Use when the user asks for a "PRP plan", "implementation plan from PRD", "feature plan with patterns to mirror", "parallel PRP plan", "team PRP plan", or says "/prp-plan".
-argument-hint: '[--parallel | --team] [--enhanced] [--no-worktree] [--dry-run] <feature description | path/to/prd.md>'
+argument-hint: '[--parallel | --team] [--enhanced] [--no-worktree] [--visual] [--dry-run] <feature description | path/to/prd.md>'
 allowed-tools:
   - Read
   - Grep
@@ -55,6 +55,7 @@ Extract flags from `$ARGUMENTS`:
 | `--no-worktree` | Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.                                                                                                                                                                                            |
 | `--dry-run`     | Only valid with `--team`. Prints the team name and teammate roster, then exits without spawning any teammates.                                                                                                                                                                                                               |
 | `--enhanced`    | Enhanced research mode: grow the research fan-out from 3 to 7 specialized researchers (api/business/tech/ux/security/practices/recommendations — same coverage as feature-research). Output is still a single PRP-compliant plan file. Composes with --parallel (default), --team (Claude Code only), and --no-worktree. |
+| `--visual`      | Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted shareable link requires `--share`.                                                                                                                                                                   |
 
 Strip the flags. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `DRY_RUN=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). Remaining text is the feature description or PRD path.
 
@@ -72,6 +73,12 @@ case " $ARGUMENTS " in
   *" --enhanced "*) ENHANCED_MODE=true ;;
 esac
 ARGUMENTS="${ARGUMENTS//--enhanced/}"
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
 **Validation**:
@@ -80,6 +87,7 @@ ARGUMENTS="${ARGUMENTS//--enhanced/}"
 - `--dry-run` requires `--team`. If `DRY_RUN=true` and `AGENT_TEAM_MODE=false` → abort with: `--dry-run requires --team.`
 - `--no-worktree` is **orthogonal** to `--parallel` and `--team` — it may be combined freely with either flag or used alone to suppress annotations.
 - If `--enhanced` is passed without `--parallel` or `--team`, default to standalone sub-agent dispatch (Path B equivalent at width 7). If `--enhanced --team` is invoked from a Cursor or Codex bundle, abort with the same compatibility message used today for plain `--team`. If `--dry-run` is passed, it requires `--team` (same constraint as today); `--enhanced --dry-run` alone is invalid.
+- `--visual` is orthogonal — it composes with `--parallel`/`--team`/`--enhanced`/`--no-worktree` and runs after the plan is written and validated. `--dry-run` short-circuits it (prints intent only).
 
 **Compatibility note**: When this skill is invoked from a Cursor or Codex bundle, `--team` must not be used (those bundles ship without team tools). Use `--parallel` instead.
 
@@ -406,6 +414,23 @@ Include a brief note in the report: "Plan validated with N warning(s) — see va
 
 ---
 
+## Phase 7 — VISUALIZE (optional)
+
+This step runs after the plan is written (Phase 6) and validated (Phase 6.5), regardless of the dispatch path taken (`--parallel`, `--team`, or sequential):
+
+- If `VISUAL_MODE=true` and `--dry-run` is NOT set, invoke `visual-plan <plan-path>` — passing the absolute path of the just-written `docs/prps/plans/{name}.plan.md` — and capture its printed link.
+- If `--dry-run` is set, print `visual generation would run` and skip the invocation.
+
+---
+
+## Visual mode
+
+This skill exposes the shared `--visual` decorator. The canonical contract lives at `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md` — follow it for composition, timing, and hand-off rules.
+
+When `VISUAL_MODE` is set and `--dry-run` is NOT, the skill invokes `visual-plan <absolute-plan-path>` AFTER Phase 6, passing the just-written `.plan.md` path (the file written in Phase 6 and validated in Phase 6.5). `visual-plan` derives its own `visual/` output directory from that path and prints the resulting link; the skill surfaces that link in the Report block. When `--dry-run` is set, print `visual generation would run` and skip — no visual artifacts, directories, or links are produced.
+
+---
+
 ## Output
 
 ### Update PRD (if input was a PRD)
@@ -429,6 +454,8 @@ Update the phase status from `pending` to `in-progress` and add the plan file pa
 - **Research Dispatch**: [Sequential | Parallel sub-agents | Agent team | Enhanced (7 researchers)]
 - **Execution Mode**: [Sequential | Parallel (N batches, max width X)]
 - **Worktree Mode**: [Enabled (default) — plan includes ## Worktree Setup (single feature worktree — **Parent**: line only) | Disabled via --no-worktree]
+- **Visual Artifact**: [Generated via visual-plan | n/a (--visual not set)]
+- **Visual Link**: [hosted URL | http://127.0.0.1:PORT/... | local files only | n/a (--visual not set)]
 
 > Next step: Run `/prp-implement docs/prps/plans/{name}.plan.md` to execute this plan.
 ```

--- a/.cursor-plugin/skills/visual-plan/SKILL.md
+++ b/.cursor-plugin/skills/visual-plan/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: visual-plan
+description: Turn an existing text plan into a rich, interactive visual plan — diagrams, file maps, annotated code, open questions, and an optional UI/prototype review surface. Read-only with respect to the plan file. Use when the user asks to "make this plan visual", "render a visual plan", "create a wireframe/canvas for this plan", "visualize the implementation plan", says "/visual-plan", or when a planning skill hands off via the shared `--visual` decorator.
+argument-hint: '[--share] <path/to/plan.md>'
+allowed-tools:
+  - Read
+  - Write
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - Bash(test:*)
+  - Bash(mkdir:*)
+  - Bash(dirname:*)
+  - Bash(npx:*)
+  - Bash(plan:*)
+  - 'Bash(${CURSOR_PLUGIN_ROOT}/skills/visual-plan/scripts/*.sh:*)'
+  - 'Bash(${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/*.sh:*)'
+---
+
+# Visual Plan (Agent-Native Plans)
+
+Turn an ordinary text plan into a structured, reviewable visual plan. Build the
+plan a reader would normally skim in Markdown, but as a scannable document with
+editable blocks mixed in: inline diagrams, annotated code, open questions, and
+an optional top visual review surface (wireframe canvas, live prototype, or both
+in tabs). Architecture and backend plans stay document-only; UI and product
+plans start with the top canvas/prototype.
+
+`visual-plan` is the packaged entry point (slash command `/visual-plan`). It
+**consumes an existing plan** handed to it — it does not research, dispatch, or
+re-plan. The runtime is the Agent-Native Plans CLI/MCP connector; its install
+pin, auth/reconnect flow, connector names, localhost bridge, block-catalog
+lookup, and egress policy are defined ONCE in
+`${CURSOR_PLUGIN_ROOT}/skills/_shared/references/agent-native-setup.md`. Read
+that file for any setup/auth/serve/egress detail rather than memorizing it here.
+
+## Contract (read first)
+
+This skill is the hand-off target of the shared `--visual` decorator. The full
+contract lives in `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md`.
+The non-negotiable invariants:
+
+- **Accept ANY plan path.** Never assume `docs/prps/plans` or any fixed
+  location. The plan path is supplied by the caller and may live anywhere.
+- **Derive `visual/` relative to the given plan path.** Output goes into a
+  `visual/` sibling of the plan file — `<dirname of plan>/visual/` — computed
+  from the path handed in, never hardcoded.
+- **NEVER edit the plan file.** Read it; write only into the derived `visual/`
+  directory. The plan artifact stays byte-for-byte intact.
+- **NEVER re-run research or dispatch.** Only consume the existing plan.
+- **Print exactly one resulting link to stdout** — a hosted shareable URL, a
+  localhost preview `http://127.0.0.1:PORT/...`, or `local files only`.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- **`<path/to/plan.md>`** (required positional) — absolute or repo-relative path
+  to the source plan. Read it; derive `visual/` from its directory.
+- **`--share`** (optional, **consent flag**) — the explicit, named opt-in to
+  hosted egress (destination `plan.agent-native.com`). Without it, the skill
+  runs in **local-files** mode and nothing leaves the machine. See **Egress &
+  consent** below.
+
+## Mode selection (auto)
+
+Choose the review surface from the source plan's content — do not add visual
+chrome by default:
+
+- **UI-first** — work is primarily product UI; review should start with screens.
+  Top canvas is the primary surface (`create-ui-plan`).
+- **prototype-first** — review should start with a functional live prototype;
+  interaction is the main question (`create-prototype-plan`).
+- **design-first** — review needs full-fidelity branded screens
+  (`create-plan-design`).
+- **visual-intake** — only when the user explicitly asks for a questionnaire
+  before planning (`create-visual-questions`). Never run it as `/visual-plan`
+  preflight.
+- **document-only** — architecture, backend, data, refactor, or API plans get NO
+  top canvas; inline `diagram` blocks sit next to the relevant prose
+  (`create-visual-plan`).
+
+When the source plan is already a Codex / Claude Code / Markdown / pasted plan,
+use it as `planText` and build the review surface from it instead of starting
+over. Preserve its useful intent and codebase facts; publish a clean standalone
+proposal (no "this revision changes…" framing).
+
+## Block vocabulary — resolve at USE TIME
+
+> The MDX block vocabulary drifts upstream between releases. Do NOT author from a
+> memorized tag list — not from this skill, not from the references.
+
+At author time (use time), fetch the live block catalog FIRST:
+
+- Hosted / connected: call the **`get-plan-blocks`** MCP tool.
+- Offline / `local-files`: run `plan blocks --out <path>` (per
+  `agent-native-setup.md`) and read that file.
+
+Render plan MDX against the freshly-fetched list. The references in this skill
+describe block _families_ and quality bars; the catalog is the authority on
+exact tag names, required fields, and prop shapes.
+
+## Core workflow
+
+1. **Read the source plan.** Read the file at the given path (read-only). Derive
+   the output dir with the thin helper (it computes the `visual/` sibling per the
+   contract and never hardcodes a location):
+
+   ```
+   OUT="$(${CURSOR_PLUGIN_ROOT}/skills/visual-plan/scripts/derive-visual-dir.sh <plan> --mkdir)"
+   ```
+
+   Gather the plan's exact text — do not invent source content.
+
+2. **Resolve blocks.** Call `get-plan-blocks` (or the offline `plan blocks`
+   fallback) for the authoritative catalog before authoring any MDX.
+3. **Create the plan** with the mode-matched create tool (see Mode selection),
+   passing the source as `planText`. For UI/product plans, compose the top canvas
+   first with the primary wireframes and annotated states, then write the
+   document body with native blocks. For non-visual plans, skip the top surface
+   and place `diagram` / `code` / `annotated-code` / `table` blocks next to the
+   relevant prose.
+4. **Emit files** into the derived `visual/` dir: `plan.mdx` plus, when a canvas
+   is used, `canvas.mdx` (and `prototype.mdx` for prototype plans). These are the
+   portable source artifacts (per `visual-mode.md`).
+5. **Surface the link.** Print exactly one link to stdout (see Contract). In
+   local-files mode this is the localhost bridge URL from `plan local serve`
+   (127.0.0.1, ephemeral port) or `local files only` if no server is available.
+   With `--share`, it is the hosted shareable URL returned by the create tool.
+6. **Read feedback** with `get-plan-feedback` before editing, after review, and
+   before the final response. Treat anchor details and resolver intent as the
+   source of truth for what each comment points at.
+7. **Apply changes** with `update-visual-plan`, preferring targeted
+   `contentPatches`: `patch-wireframe-html`, `patch-diagram-html`, `update-block`,
+   `replace-blocks`, `update-rich-text`, plus `read-visual-plan-source` /
+   `patch-visual-plan-source` for source-control-friendly MDX edits. Treat the
+   top-level `content` payload as a full replacement, never a partial merge — if a
+   full replacement is unavoidable, read the complete source first and carry
+   forward every existing block and surface.
+
+## Quality references — read before authoring
+
+These are provider-neutral quality bars. Read the relevant one IN FULL before
+authoring; do not paraphrase from memory:
+
+- `${CURSOR_PLUGIN_ROOT}/skills/visual-plan/references/document-quality.md` — the
+  plan-document quality bar and block families.
+- `${CURSOR_PLUGIN_ROOT}/skills/visual-plan/references/canvas.md` — canvas /
+  artboard / annotation mechanics and patch ops.
+- `${CURSOR_PLUGIN_ROOT}/skills/visual-plan/references/wireframe.md` — the HTML
+  wireframe quality bar (`.wf-*` tokens, surfaces, icons, skeletons).
+- `${CURSOR_PLUGIN_ROOT}/skills/visual-plan/references/exemplar.md` — a worked
+  example plus the anti-patterns to avoid.
+
+## Planning is read-only
+
+Make NO source edits while building or reviewing the visual plan, and never edit
+the input plan file. Begin editing code only after the user approves the
+direction. The plan is the approval gate: surface it, name which files/areas the
+work touches, and request sign-off.
+
+## Egress & consent (default OFF)
+
+Hosted upload is **OFF by default** and **consent-gated**. The full policy lives
+in `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/agent-native-setup.md`;
+the operational rules for this skill:
+
+- **Default = `local-files`.** Set `AGENT_NATIVE_PLANS_MODE=local-files`. In this
+  mode the runtime reads/writes plan files locally and never contacts
+  `plan.agent-native.com`. Preview via the localhost bridge
+  (`plan local serve --dir <OUT> --open`), which binds 127.0.0.1 on an ephemeral
+  port, performs no DB writes, and sends nothing remote — this is **not** egress.
+- **`--share` is the only opt-in.** It names the destination host
+  `plan.agent-native.com`. Only when the operator passes `--share` may any plan
+  content leave the machine.
+- **Route all hosted egress through the guard.** Before any MDX/diff payload is
+  uploaded, run:
+
+  ```
+  ${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/visual-egress-guard.sh \
+    --payload <OUT> --destination plan.agent-native.com \
+    --consent plan.agent-native.com
+  ```
+
+  The guard scans the payload for secrets, refuses non-public/private remotes,
+  and requires a consent token matching the destination. If it exits non-zero,
+  STOP — do not upload; report the gate that failed.
+
+## Setup, auth, and the localhost bridge
+
+Do not duplicate install/reconnect/serve commands here. For the pinned install
+version, the one-time per-client reconnect, the `plan` MCP connector (legacy
+alias `agent-native-plans`), local-files mode, and the localhost bridge
+(`plan local check` / `plan local serve`), read
+`${CURSOR_PLUGIN_ROOT}/skills/_shared/references/agent-native-setup.md`. If a
+Plans tool returns `needs auth` / `Unauthorized` / `Session terminated`, stop and
+give the user the reconnect step from that reference — never reinstall from
+scratch to fix auth, and never fall back to inline chat-only plan output.
+
+## Output
+
+Exactly one of the following is printed to stdout, per the `visual-mode.md`
+contract:
+
+- a hosted shareable URL under `https://plan.agent-native.com` (only with
+  `--share`, after the egress guard passes), or
+- a localhost preview `http://127.0.0.1:PORT/...` (default local-files mode), or
+- `local files only` when no server/host is available.
+
+The calling planning skill surfaces whatever link this skill prints.

--- a/.cursor-plugin/skills/visual-plan/references/canvas.md
+++ b/.cursor-plugin/skills/visual-plan/references/canvas.md
@@ -1,0 +1,121 @@
+# Canvas & artboard placement — single source of truth
+
+The canonical guide for how the visual-plan canvas works: artboard placement,
+lane layout, annotations, patching, and emitted files. Read it in full before
+authoring or editing any canvas/artboard content; do not author canvas layouts
+from memory. Resolve exact block/component tag names against the live catalog
+(`get-plan-blocks` or the offline `plan blocks` dump).
+
+---
+
+## Canvas block families
+
+A plan canvas is composed from these block families (resolve exact tag names and
+props via the catalog):
+
+- **`<DesignBoard>`** — the canvas root that holds the artboards and annotations.
+- **`<Section>`** — groups related artboards into a labeled region/lane.
+- **`<Artboard>`** — a single fixed-footprint frame; its size/aspect is locked by
+  `surface` (see `wireframe.md`). Carries an `html` wireframe or references a
+  wireframe block via `blockId`.
+- **`<Screen>`** — a product screen surface inside the board (a UI state under
+  review).
+- **`<Annotation>`** — a plain-text designer note anchored to a frame by
+  `targetId` + `placement`.
+- **`<Connector>`** — an arrow between neighboring steps of a real sequence.
+
+## Emitted files
+
+- `plan.mdx` — frontmatter plus markdown/document blocks (the plan body).
+- `canvas.mdx` — the `<DesignBoard>` / `<Section>` / `<Artboard>` / `<Screen>` /
+  `<Annotation>` / `<Connector>` tree.
+- `prototype.mdx` — present only for prototype plans (the functional flow).
+
+JSON is the canonical runtime shape; MDX is the repo-friendly authoring/export
+surface. Both live under the derived `visual/` directory.
+
+## The coordinate rule
+
+The `surface` locks each artboard's footprint and aspect — **never** set artboard
+width/height and **never** use coordinates inside the wireframe HTML. Board-level
+artboard `x`/`y` IS allowed when it creates clear lanes. Let canvas
+auto-placement handle simple one-row boards. Sizing is always via `surface`, not
+explicit pixels.
+
+## Lay out mixed canvases in lanes
+
+When a canvas contains broad `browser` / `desktop` frames plus compact `mobile`,
+`popover`, or `panel` surfaces, do not put everything in one horizontal strip.
+Use board-level artboard `x`/`y` to reserve lanes with generous empty space: main
+flow on one row, compact surfaces in their own column or row, loading/error
+states in a lower row. Keep at least **96px** between rendered artboard rectangles
+plus room for annotation gutters. Connect only neighboring steps; never draw a
+long connector that skips across unrelated frames. Before handoff, inspect the
+top canvas at default zoom and move any frame whose label, connector, or
+annotation crosses another frame.
+
+## Annotations are designer notes on the artboard
+
+When a top canvas is present, sprinkle Figma-style notes near the frames they
+explain: a short heading, supporting text, and bullets — plain text layers, never
+bordered or shadowed cards, and never a box around a frame. The renderer spaces
+notes away from frames, so place each note by the frame it describes. Use an
+arrow (`<Connector>`) only to point at one specific control or transition; for a
+broad frame-level note, write text beside the frame with no connector.
+
+**Do not create overlapping annotations.** Anchor each ordinary note to the frame
+it explains with `targetId` + `placement` (top/right/bottom/left), and omit
+`type` or use `type: "note"`. The renderer parks notes in a gutter beside the
+frame and lays them out automatically. Do not use `type: "callout"`,
+`type: "text"`, `type: "arrow"`, x/y, or points for ordinary notes; those are
+freeform review-markup layers reserved for intentional markup in open canvas
+space. Connectors are for real sequences only — never fake "Step 1 → Step 2"
+lines between independent states.
+
+## Patching
+
+Edit one wireframe, canvas annotation, diagram, or block with targeted
+`contentPatches` rather than regenerating the whole plan:
+
+- `patch-wireframe-html` — edit the HTML of one artboard's wireframe.
+- `patch-diagram-html` — edit the HTML/SVG of one diagram.
+- `update-block` / `replace-blocks` — replace a block by stable id.
+- `update-canvas-annotation` — edit one annotation.
+- `read-visual-plan-source` / `patch-visual-plan-source` — granular MDX AST
+  patches by stable block, artboard, annotation, component, or wireframe-node id
+  when working from exported source files.
+- `update-rich-text` — prose edits (agents use this or source patches; humans
+  edit prose inline in the browser).
+
+`contentPatches` are part of the public MCP action schema, so every host can make
+surgical edits. **Never** send a partial top-level `content` object as a shortcut
+to add a canvas, frame, or block: `content` is a full structured replacement, so
+omitted blocks or surfaces disappear. If a full replacement is truly unavoidable,
+read the complete source/JSON first, include every existing block and surface in
+the new payload, and verify the source/export immediately after the update.
+
+## Never emit a titled artboard with no interior wireframe content
+
+Every artboard must carry an `html` wireframe or reference a wireframe block via
+`blockId`; when using `blockId`, the referenced wireframe block must remain in the
+plan. If you remove a duplicate wireframe from the document body, first move its
+`data` inline onto the corresponding canvas frame. A label-only frame or a frame
+pointing at a deleted block renders empty and is rejected at parse time. If you
+only have a title, write it as a section header or annotation, not an empty
+artboard.
+
+## UI mockups belong in the top visual review area
+
+Static UI/product visuals live on the canvas; multi-step UI flows get both canvas
+wireframes and a `prototype`. When the user asks for a mockup, UI state, loading
+state, layout, screen, or visual comparison, make the canvas the primary home for
+that static visual. Architecture/code diagrams stay inline in the document
+(`document-quality.md` owns that rule) unless the user explicitly asks for a
+spatial board. A skeleton/loading mockup also lives in a canvas artboard — never
+move a mockup out of the canvas into a `custom-html` document block.
+
+For abstract product concepts, use the canvas to create the first "I get it"
+moment: one real app state near the top showing how the concept appears to a
+user, followed by separate annotations or diagrams for mechanics. Do not make the
+first artboard a hybrid of app UI and architecture notes; the app screen should be
+inspectable as product UI on its own.

--- a/.cursor-plugin/skills/visual-plan/references/document-quality.md
+++ b/.cursor-plugin/skills/visual-plan/references/document-quality.md
@@ -1,0 +1,169 @@
+# Plan document quality — single source of truth
+
+The canonical quality bar for the plan document below the canvas: how it reads,
+which block families to use, how open questions are surfaced, and the pre-handoff
+check. Read it in full before authoring the plan document. Resolve exact tag
+names and field shapes against the live catalog (`get-plan-blocks`, or the
+offline `plan blocks` dump) — the families below are the bar, the catalog is the
+authority.
+
+---
+
+**The document is a serious technical plan, not marketing.** Write it the way a
+strong implementation plan reads: outcome-first, prose-first, self-contained, and
+specific. State the objective and what "done" means, the scope and non-goals, the
+proposed approach with key decisions and their rationale, ordered steps that name
+real files / symbols / actions / data shapes, the risks, and a closing
+verification step (tests, build, or a checkable behavior). Replace vague prose
+with specifics; never ship a step like "make it work." No hero art, gradients,
+logos, nav bars, slogans, value props, giant landing-page headings, or marketing
+cards unless the user explicitly asks.
+
+**Every published plan must stand alone.** Even when revising an existing plan,
+the output is a plan to do the work, not a changelog of the conversation. Do not
+write phrases like "preserve the previous plan", "do not drop the old idea", "as
+discussed above", "this revision", "unlike the prior version", or "correction
+from the earlier plan". Fold the right decisions into the plan as normal
+objective, architecture, scope, and roadmap prose. A reviewer who opens the plan
+from a link with no chat history should understand it. Avoid negative framing
+that only makes sense against absent context ("not the old mode", "not just X")
+unless the contrast is defined in the plan and genuinely helps; state the
+positive model directly.
+
+**Make abstract plans instantly legible.** If the idea is broad, strategic, or
+intended for a third-party reviewer, put one concrete product snapshot near the
+top before dense architecture, mode tables, manifests, or roadmaps. For
+UI-capable concepts, that snapshot is usually a top-canvas app state plus a short
+paragraph that says what the user sees and what changes under the hood. Then put
+mechanics, data flow, sync boundaries, and implementation detail in separate
+diagrams or document sections.
+
+**Preserve the user's level of abstraction.** A motivating use case is not
+automatically the architecture. When the prompt describes a broader framework,
+product mode, or reusable primitive, separate the reusable core from specific
+apps, providers, customers, scripts, or launch examples. Use the concrete example
+to make the plan understandable, then make clear which parts are core, which are
+app-specific adapters, and which are future examples.
+
+**When top visuals exist, they and the document never duplicate each other.** For
+UI work, the UI story lives in the top visual surface: canvas artboards for static
+inspection, plus prototype tabs when the flow should be functional. The document
+carries the technical depth the visuals cannot show — concrete file/symbol maps,
+API and data contracts, code snippets, migration or implementation phases, risks,
+and validation. For architecture/code reviews, invert that: the document is the
+visual surface, and each recommendation carries its own nearby inline `diagram`
+block plus file evidence. Repeat a wireframe in the document only for a genuinely
+new detail view or comparison. Skip the visual surface entirely for non-visual
+work and write a clean rich document.
+
+## Block families (resolve exact tags via `get-plan-blocks`)
+
+Use the right block, and make it carry substance:
+
+- **`rich-text`** — plan prose with real bold/italic/code/links and nested lists.
+- **`annotated-code`** — the file map: for a load-bearing file, prefer the
+  annotated walkthrough over a bare `code` block. Carry the real,
+  syntax-highlighted code AND anchor short margin notes to the lines that
+  actually change (the new action, the changed schema, the wiring point). Each
+  annotation is `{ lines: "12" | "12-18"; label?; note }`; keep a few high-signal
+  notes per file, not one per line. Highlight only files worth reading.
+- **`code`** — a throwaway snippet with nothing to call out. When more than one
+  file matters, group blocks in a vertical `tabs` block rather than a bespoke
+  container.
+- **`tabs`** — multiple states, directions, or comparisons. A tab that reveals
+  only prose usually means the plan is under-specified — include a relevant visual
+  unless the tab is intentionally document-only.
+- **`columns`** — side-by-side before/after or current/target comparisons where
+  each side needs real nested blocks; label the columns clearly.
+- **`diagram`** — two-dimensional architecture, dependency, data-flow, or state
+  relationships, only when it clarifies something real. See **Diagram primitives**
+  below.
+- **`table`** — scannable structured data.
+- **`checklist`** — copy the catalog example verbatim: items need `id` and
+  `label`.
+- **`callout`** — for a decision you have committed to, use `tone="decision"`
+  (optionally with a `columns` block weighing the options). Use other tones for
+  concise assumptions or risks in the relevant section.
+- **`question-form`** — the bottom-only Open Questions block (see below).
+- **`custom-html`** — a bounded escape hatch only (see below).
+
+## Decisions
+
+- If the reviewer must still pick between a genuinely-open either/or, put it in
+  the bottom Open Questions `question-form` as a `single` question — one option
+  per real alternative, each with a short detail and `recommended: true` on the
+  one you would choose. Do not also restate the same choice elsewhere.
+- If you have already committed to an approach, state it as settled prose or a
+  `callout` with `tone="decision"` — never as a confusing mid-document form for a
+  question you have already answered.
+
+## Diagram primitives
+
+For architecture/code diagrams, prefer `data.html` / `data.css` with semantic
+HTML and inline SVG so the diagram can use panels, layers, matrices, arrows,
+annotations, and responsive layout directly. Author with renderer-owned
+primitives: `.diagram-panel`, `.diagram-card`, `.diagram-node`, `.diagram-box`,
+`.diagram-pill`, `.diagram-muted`, and `[data-rough]` for sketchy mode. They map
+to the theme variables `--wf-ink`, `--wf-muted`, `--wf-line`, `--wf-paper`,
+`--wf-card`, `--wf-accent`, `--wf-accent-soft`, `--wf-warn`, and `--wf-ok`, and
+switch to the sketch font plus rough.js outlines in sketchy mode.
+
+- Do NOT set `font-family` and do NOT hard-code hex, rgb, or hsl colors in
+  diagram HTML or CSS.
+- Prefer standard two-dimensional layouts — paired before/after panels, layered
+  diagrams, swimlanes, dependency maps, matrices, or grouped regions; do not
+  default to left-to-right chains, and use a line only when the relationship is
+  truly a sequence.
+- Leave room for the sketch font: keep labels short, give nodes generous width,
+  and place boundary/annotation labels in unused space — labels must not overlap
+  nodes, connectors, or each other.
+- For small text/SVG changes to an existing HTML diagram, use **`patch-diagram-html`**
+  with a unique `find`/`replace` snippet instead of resending the whole
+  `data.html` string. Use legacy `nodes` / `edges` only for small previews or
+  truly sequential flows.
+
+## Open questions live at the bottom as a form
+
+Surface answerable unresolved decisions in a final `question-form` block titled
+"Open Questions" so the renderer presents it as a distinct section. That bottom
+form is the ONLY place that enumerates the open questions: never add a second
+"Open Questions" heading, list, or recap of the same questions earlier in the
+document. A one-line pointer in the overview prose ("a few decisions are still
+open — see Open Questions below") is fine.
+
+- Use `single` or `multi` for clear choices, `freeform` for constraints,
+  `recommended: true` for the default you would pick. `single`/`multi` questions
+  always render a write-in field, so never add an explicit "Other" option
+  yourself; set `allowOther: false` only when a free-text answer makes no sense.
+- Copy the catalog example verbatim for required fields: each question needs
+  `id`, `title`, and `mode`; each option needs `id` and `label`.
+- Keep non-answerable assumptions or risks as concise `callout` blocks in the
+  relevant section. Never bury a questions/decisions wall inside the plan
+  narrative, and never ask the same question twice.
+
+For complex plans, do not end without an open-question audit. If architecture,
+scope, UX, data shape, rollout, provider mapping, or ownership still depends on a
+choice, either commit to a recommendation with rationale or add it to the bottom
+form with a recommended default.
+
+## `custom-html` is a bounded escape hatch only
+
+A single complete fragment inside a block, never `html`/`head`/`body`/`script`
+tags, never a generic placeholder, density demo, or proof that custom HTML works.
+Prefer native blocks for normal plans. For architecture/code reviews, use
+`diagram` `data.html` / `data.css` for rich local HTML/SVG diagrams instead of
+`custom-html`. For UI/product work, `custom-html` is never the primary home for a
+requested mockup, UI state, or visual comparison.
+
+## Verification must exercise the real workflow
+
+The final verification section should go beyond typecheck/unit tests when the
+plan changes UI, local files, sync, providers, browser behavior, or multi-app
+flows. Include at least one end-to-end smoke that matches the user journey — a
+fresh repo/folder, real manifest or data fixture, browser interaction, save/sync
+action, and an on-disk or database assertion. Name the command or manual browser
+path when it is known.
+
+**Before handoff, open the plan and check it.** Fix overlap, excessive
+whitespace, clipped fragments, misleading inactive controls, poor contrast, and
+unreadable diagrams before asking for approval.

--- a/.cursor-plugin/skills/visual-plan/references/exemplar.md
+++ b/.cursor-plugin/skills/visual-plan/references/exemplar.md
@@ -1,0 +1,113 @@
+# Good vs. bad exemplar — single source of truth
+
+The canonical worked example of a great plan (and the anti-patterns to avoid).
+Read it alongside `document-quality.md` and `canvas.md` before authoring a plan;
+it is the bar these plans must clear. Resolve exact block tags against the live
+catalog (`get-plan-blocks` / offline `plan blocks` dump) before emitting MDX.
+
+---
+
+## A worked example — UI-first plan MDX
+
+The following sketch shows the _shape_ of a strong UI-first plan: a top canvas
+with one real `desktop` artboard, plain-text designer notes off the frame, then a
+serious document below it. Treat the tags as families — confirm exact names/props
+against the catalog.
+
+```mdx
+---
+title: Inbox triage redesign
+mode: ui-first
+---
+
+{/* canvas.mdx — the top review surface */}
+
+<DesignBoard>
+  <Section label="Triage view">
+    <Artboard id="inbox-default" surface="desktop" label="Inbox — default">
+      {/* data.html is a real flex layout: a sidebar of links
+          (Inbox 12, Today 4, Done), a main column headed "Today",
+          accent .wf-pill filters, a muted "OVERDUE" section label,
+          and .wf-card task rows with real titles, due dates, and a
+          button.primary — styled only via bare elements, helper
+          classes, and --wf-* tokens. */}
+    </Artboard>
+    <Annotation targetId="inbox-default" placement="right">
+      Overdue items float to the top; the primary action stays in the header so triage never scrolls.
+    </Annotation>
+  </Section>
+</DesignBoard>
+
+{/* plan.mdx — the document body */}
+<rich-text>
+
+## Objective
+
+Cut inbox triage from many clicks to one. "Done" means an overdue item
+can be deferred or completed from the row without opening it.
+</rich-text>
+
+<tabs>
+  {/* one `code` / `annotated-code` block per load-bearing file:
+      the new defer action, the changed query, the row component */}
+</tabs>
+
+<callout tone="decision">
+  Defer writes a `snoozedUntil` timestamp rather than moving the row to a separate table — see the columns block for the
+  two options weighed.
+</callout>
+
+<question-form title="Open Questions">
+  {/* single/multi questions for genuinely-open decisions, each option
+      with id + label, recommended: true on the default */}
+</question-form>
+```
+
+If the task also changes a multi-step completion flow, the same top area gains a
+Prototype tab whose screens reuse the canvas labels and states.
+
+## GOOD — the bar
+
+- **UI-first todo/inbox plan.** A canvas `desktop` artboard whose `data.html` is a
+  real flex layout (sidebar links, a "Today" heading, accent `.wf-pill` filters, a
+  muted `OVERDUE` label, `.wf-card` task rows with real titles/dates and a
+  `button.primary`), styled only through bare elements, helper classes, and
+  `--wf-*` tokens. Plain-text designer notes sit spaced off the frame, pointing
+  only at controls that need explanation. Below it, a strong document: objective
+  and done-criteria, a few `code` blocks (grouped in a vertical `tabs` block when
+  more than one) showing the real shape of load-bearing files, a `callout` with
+  `tone="decision"` stating the chosen approach with a `columns` block weighing the
+  two real options, and a validation step — none of it repeating the canvas.
+- **Broad product-architecture plan.** Opens with a plain recommendation and one
+  concrete app state before the abstraction. The first canvas artboard is pure
+  product UI that matches the current app shell; nearby notes explain the
+  user-visible delta. A separate `diagram` below shows the mechanics. The document
+  separates the reusable core from app/provider adapters and examples, covers
+  contracts and schema shape, roadmap, non-goals, a bottom Open Questions form, and
+  a verification section with at least one realistic end-to-end smoke.
+- **Backend architecture review.** No top canvas. The document opens with context
+  and a legend, then repeats recommendation cards: title, confidence/category
+  badges, a monospace grid of real file paths, one inline two-dimensional
+  before/after or layered architecture `diagram` (using space to show boundaries
+  and ownership, not a default left-to-right chain), and terse
+  Problem/Solution/Why bullets in the codebase's vocabulary. Ends with a top
+  recommendation and a bottom `question-form` only if the next direction is
+  genuinely open.
+
+## BAD — never produce this
+
+- A `data.html` with hard-coded hex colors, a `font-family`, or fixed pixel
+  width/height.
+- Gray placeholder bars "insinuating" text on a non-skeleton frame.
+- A forced `desktop` + `mobile` pair for a popover.
+- Floating bordered annotation cards hugging the frames.
+- A multi-step UI flow with only static frames and no prototype tab.
+- A mockup escaped into a document `custom-html` block.
+- A marketing-style document with a hero heading and value props that just
+  restates what the canvas already shows.
+- An architecture-only plan forced into a top canvas of labeled boxes with
+  overlapping text, where the real code evidence lives elsewhere.
+- A product wireframe that mixes a real screen with repo names, file-contract
+  arrows, architecture explanations, or a made-up permanent inspector.
+- A plan that describes itself as a revision of a prior conversation instead of a
+  standalone proposal.

--- a/.cursor-plugin/skills/visual-plan/references/wireframe.md
+++ b/.cursor-plugin/skills/visual-plan/references/wireframe.md
@@ -1,0 +1,210 @@
+# HTML wireframe quality — single source of truth
+
+The canonical quality bar for HTML wireframe content. Read it in full before
+authoring ANY wireframe; do not author wireframes from memory or paraphrase these
+rules per mode.
+
+---
+
+**A wireframe is an HTML mockup. The renderer owns the look; you write the
+content.** Set `data.html` to a self-contained, semantic HTML fragment of the
+screen and set `data.surface`. The renderer owns the surface footprint/aspect, the
+dark/light theme, the hand-drawn font, and the sketch overlay — you never write
+`<style>` / `<link>` / `<font>` tags or any width/height/coordinates. You write
+real HTML layout and real product content; the renderer styles and roughens it.
+
+**A wireframe block's data is an HTML screen plus a surface:**
+
+```json
+{
+  "surface": "browser",
+  "html": "<div style=\"display:flex;flex-direction:column;gap:10px;padding:16px;height:100%\"><h1>Sign in</h1><p class=\"wf-muted\">Use your work email to continue.</p><div class=\"wf-card\" style=\"display:flex;flex-direction:column;gap:10px\"><label>Email<input value=\"jane@acme.co\" /></label><label>Password<input value=\"********\" /></label><label style=\"display:flex;align-items:center;gap:8px\"><input type=\"checkbox\" checked /> Remember me</label><button class=\"primary\">Sign in</button></div><a href=\"#\">Forgot password?</a></div>"
+}
+```
+
+**Write PLAIN semantic HTML and let the renderer style it.** Bare elements
+(`h1`/`h2`/`h3`, `p`, `button`, `input`, `label`, `a`, `hr`) are auto-themed — no
+classes needed. Helper classes carry the rest:
+
+- `.wf-card` / `.wf-box` — a bordered, padded container (a panel, a list item).
+- `.wf-pill` / `.wf-chip` — a rounded tag or filter; add `.accent` for the
+  accent-filled variant.
+- `.wf-muted` — secondary/muted text.
+- `button.primary` or any element with `[data-primary]` — the accent-filled
+  primary button.
+
+**No decorative shadows around mockups.** Do not put `box-shadow`,
+`filter: drop-shadow(...)`, Tailwind `shadow-*` classes, or other fake depth on a
+wireframe frame, root container, `.wf-card` / `.wf-box`, or canvas artboard.
+Mockups should read as flat, bordered surfaces; use spacing, borders, labels, and
+annotations for separation. Only show a shadow when the real product UI already
+has it and it is essential to the change being reviewed.
+
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker with
+`[data-icon]` (e.g. `<span data-icon="search"></span>`). The renderer replaces it
+with a Tabler-style SVG and the `.wf-icon` class sizes it to the surrounding text.
+Supported names and aliases include: `mail`/`email`, `lock`/`password`, `search`,
+`plus`/`add`, `x`/`close`, `check`, `chevronDown`, `chevronUp`, `chevronLeft`,
+`chevronRight`, `dots`/`more`, `chevron`/`caret`/`dropdown` (down chevron), `user`,
+`settings`, `calendar`, `bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do
+not put visible words like "email", "lock", "search", "chevron", or "more" where
+the product UI would show an icon; use text only when it is a real label a user
+would read.
+
+**Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips
+these on light/dark, so referencing tokens is what keeps a mockup correct in both
+themes. For any inline border, background, or text color, reference a token:
+`style="border:1.4px solid var(--wf-line)"`. The tokens are `--wf-ink` (text),
+`--wf-muted` (secondary text), `--wf-line` (borders/dividers), `--wf-paper` (page
+background), `--wf-card` (container surface), `--wf-accent` / `--wf-accent-fg` /
+`--wf-accent-soft` (brand action), `--wf-warn`, `--wf-ok`, and `--wf-radius`.
+**Never hard-code a hex (or rgb/hsl) color and never set `font-family`** — the
+renderer owns the sketch/clean font.
+
+**Lay out with inline `style` flex/grid.** You write the real layout —
+`display:flex; flex-direction:column; gap:10px; padding:16px` — and the renderer
+never repositions anything. Compose the actual product: reproduce the current
+screen, then show the modification. Real labels, real counts, real dates, real
+button text grounded in the screen you read; not lorem or gray bars.
+
+**Surface presets — match the real footprint, never default to desktop+mobile.**
+Pick the `surface` that matches what the user will actually see:
+
+- `browser`: a web page that needs a browser chrome frame around it.
+- `desktop`: a full desktop app page or app shell.
+- `mobile`: a phone screen, only when the work is genuinely mobile.
+- `popover`: a small floating menu, dropdown, or inline popover.
+- `panel`: a side panel, inspector, or sidebar widget.
+
+A sidebar popover renders as a small surface, not a desktop page and a phone
+frame. Do not emit `desktop` + `mobile` variants unless responsive behavior
+actually changes the layout.
+
+**Model the actual component shell for small surfaces.** A rendered UI change
+belongs in a wireframe; reserve `diagram` for architecture, dependency, state, or
+data-flow relationships. Popovers, dropdown menus, command palettes, and context
+menus use `surface: "popover"` unless the surrounding page placement is the point
+of the change. Dialogs, sheets, inspectors, sidebars, and long property panels use
+the matching `panel` / `desktop` surface. Show the real chrome: trigger/anchor
+when it matters, title/header row, top-right actions, separators, fields, options,
+selected states, body content, and visible footer actions.
+
+**Modify, don't redesign.** When the task changes an existing screen, reproduce
+the current screen's real layout and footprint FIRST, then change only the delta
+and call it out with a single annotation. Do not restack the page into a new
+layout. For net-new surfaces, compose from the real app shell.
+
+**Keep product screens pure.** A product wireframe shows the app state a user
+would actually see. Do not embed file contracts, architecture arrows, repo pills,
+mode explanations, or implementation callouts inside the screen just to explain
+the plan. Put those in canvas annotations, a separate diagram, or the document
+body.
+
+**Zoom in on sub-surfaces, don't redraw the page.** For a small sub-surface (a
+popover, menu, dialog, toast), show the full screen once, then add a small
+separate artboard whose `html` contains ONLY that sub-surface — do not re-draw the
+whole page around it, and do not scale a duplicate up. Pick the matching `surface`
+(e.g. `popover`) so the footprint is right; never widen a popover to page width.
+
+**Loading / skeleton states.** Set `data.skeleton: true` on the wireframe and fill
+the `html` with neutral, textless placeholder geometry — boxes and bars built as
+`<div>`s with `background:var(--wf-line)` and explicit heights/widths, no labels
+or copy. The renderer drops borders, sketch, and color into the skeleton register
+automatically. Never escape to a `custom-html` document block to fake a loader.
+
+**Editing an existing mockup.** To change one element, text, or color, call
+`update-visual-plan` with
+`contentPatches: [{ op: "patch-wireframe-html", blockId, edits: [{ find, replace }] }]`.
+Each `find` is a unique snippet of the current html (read it first); set
+`all: true` on an edit to replace every occurrence. The result is re-sanitized.
+
+**Treat the wireframe border as part of the visible design.** Always wrap HTML
+wireframe content in a root container with real inner padding before drawing
+cards, fields, pills, labels, or controls. Use at least 14-16px of padding,
+`box-sizing: border-box`, `height: 100%`, and `gap` between child rows so the
+first row never sits flush against the screen border.
+
+**Lay out children safely so they never collide.** Use HTML flex/grid with `gap`,
+`min-width: 0`, and sensible overflow. Avoid negative margins, absolute
+positioning, or fixed child widths that can collide across light/dark, sketch/clean,
+or zoom levels.
+
+**Do not wrap intentionally single-line labels.** For toolbars, tab rails,
+breadcrumbs, chip/filter rows, branch and file names, and code filenames — any
+deliberately single-line row — put `white-space: nowrap` on the row (and
+`overflow: hidden; text-overflow: ellipsis` on labels that can grow). Use
+horizontally scrollable or clipped rails for overflow.
+
+**Fill the frame; keep labels short.** Each artboard is a fixed-size surface —
+compose enough realistic HTML to fill it top to bottom with even vertical rhythm;
+never leave a large empty band. On desktop/app-shell sidebars, let the nav stack
+flex to fill (`flex:1`) and add any persistent bottom action/status after it. On
+mobile, flow real rows down the whole screen rather than a header floating above a
+gap. Keep every label short enough to sit on one line within its column.
+
+**Persistent chrome bars span the full frame width.** Top bars, app headers,
+toolbars, and bottom tab/nav bars are full-width chrome, not centered content. Lay
+each one out as a single flex row that fills the frame
+(`style="display:flex;align-items:center;width:100%"`) and push trailing actions to
+the right edge with a flex spacer (`<div style="flex:1"></div>`) between the
+leading and trailing groups — never center a bar inside a narrow block, and never
+let it collapse to the width of its contents.
+
+**Pin bottom bars to the bottom of the frame.** For mobile tab bars, footers, and
+any persistent bottom action row, make the frame itself a flex column at
+`height:100%` (`style="display:flex;flex-direction:column;height:100%"`), give the
+scrolling body `flex:1`, and place the bar as the LAST child (or set
+`margin-top:auto`). The bar then sits flush at the bottom instead of floating with
+an empty band beneath it.
+
+**Before / after must be comparable.** When showing a state change, preserve the
+unchanged controls in both states so the reviewer can see exactly what moved or
+appeared; do not show an added control as a generic box floating elsewhere. Place
+the new/changed affordance where the implementation puts it. Use the same frame
+size, scale, outer padding, border radius, and visual density on both sides unless
+the change itself alters those properties.
+
+**Name the states with the column header, never inside the frame.** For
+document-body wireframes, put the two states in a `columns` block and set each
+column's `label` to `Before` and `After` — the renderer draws that label as a
+heading above each frame. Do NOT bake a `Before`/`After` pill, title, or heading
+into the wireframe `html`. On a canvas, place the two state artboards as neighbors
+with frame labels — never encode Before/After inside the html.
+
+**Let the surface choose side-by-side vs. stacked.** For document-body wireframes,
+the `columns` renderer lays narrow surfaces (`mobile`, `popover`, `panel`) out
+side by side, and automatically stacks wide surfaces (`desktop`, `browser`)
+vertically at full document width so a large frame is never crushed into a
+half-width column. Author both wireframes with the real `surface` and matching
+`Before`/`After` column labels.
+
+**Good example — a contacts list, surface `browser`.** A small, real screen
+composed from the helper classes and tokens, layout in inline flex, no fonts or
+hex colors:
+
+```html
+<div style="display:flex;flex-direction:column;gap:12px;padding:16px;height:100%">
+  <div style="display:flex;align-items:center;justify-content:space-between">
+    <h1>Contacts</h1>
+    <button class="primary">New contact</button>
+  </div>
+  <div style="display:flex;gap:6px">
+    <span class="wf-pill accent">All 128</span>
+    <span class="wf-pill">Favorites</span>
+    <span class="wf-pill">Archived</span>
+  </div>
+  <div class="wf-card" style="display:flex;flex-direction:column;gap:0;padding:0">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-bottom:1.4px solid var(--wf-line)">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Jane Cooper</strong><br /><small>jane@acme.co</small></div>
+      <span class="wf-pill">Lead</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Marcus Lee</strong><br /><small>marcus@globex.io</small></div>
+      <span class="wf-pill">Customer</span>
+    </div>
+  </div>
+</div>
+```

--- a/.cursor-plugin/skills/visual-plan/scripts/derive-visual-dir.sh
+++ b/.cursor-plugin/skills/visual-plan/scripts/derive-visual-dir.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# derive-visual-dir.sh — compute the visual/ output directory for a plan path.
+#
+# The visual-plan contract (skills/_shared/references/visual-mode.md) requires
+# the output to live in a `visual/` sibling of the input plan file, derived from
+# the path handed in — never hardcoded. This thin wrapper performs that single
+# derivation so the skill never improvises the path.
+#
+# Usage:
+#   derive-visual-dir.sh <path/to/plan.md> [--mkdir]
+#
+# Arguments:
+#   <path/to/plan.md>   Source plan path (absolute or relative). Must exist.
+#   --mkdir             Create the derived directory if it does not exist.
+#
+# Output:
+#   The derived visual/ directory path on stdout.
+#
+# Exit codes:
+#   0 - Derived (and created, if --mkdir) successfully
+#   1 - Usage error or plan path missing
+#
+set -euo pipefail
+
+_error() {
+  echo "derive-visual-dir.sh: error: $*" >&2
+}
+
+PLAN_PATH=""
+DO_MKDIR=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mkdir)
+      DO_MKDIR=1
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: derive-visual-dir.sh <path/to/plan.md> [--mkdir]" >&2
+      exit 0
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      exit 1
+      ;;
+    *)
+      if [[ -n "$PLAN_PATH" ]]; then
+        _error "unexpected extra argument: $1"
+        exit 1
+      fi
+      PLAN_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$PLAN_PATH" ]]; then
+  _error "a plan path is required"
+  echo "Usage: derive-visual-dir.sh <path/to/plan.md> [--mkdir]" >&2
+  exit 1
+fi
+
+if [[ ! -f "$PLAN_PATH" ]]; then
+  _error "plan file not found: $PLAN_PATH"
+  exit 1
+fi
+
+PLAN_DIR="$(cd "$(dirname "$PLAN_PATH")" && pwd)"
+OUT_DIR="${PLAN_DIR}/visual"
+
+if [[ "$DO_MKDIR" -eq 1 ]]; then
+  mkdir -p "$OUT_DIR"
+fi
+
+echo "$OUT_DIR"
+exit 0

--- a/.cursor-plugin/skills/visual-recap/SKILL.md
+++ b/.cursor-plugin/skills/visual-recap/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: visual-recap
+description: Turn a finished change — a git range, branch, or working-tree diff — into a LOCAL-ONLY interactive visual recap (annotated diffs, file map, schema/API deltas, diagrams, wireframes) under docs/prps/reviews/visual/, previewed in the browser via the localhost bridge. Use when the user asks to "recap this branch", "show what changed visually", "visual recap", "review the diff visually", or says "/visual-recap". Never uploads code to a hosted service; remote-agnostic (identical on the public GitHub remote and the private Forgejo origin).
+argument-hint: '[base..head | branch]'
+allowed-tools:
+  - Read
+  - Write
+  - Bash(npx:*)
+  - Bash(plan:*)
+  - 'Bash(${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/visual-recap-collect.sh:*)'
+  - 'Bash(${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/visual-egress-guard.sh:*)'
+---
+
+# Visual Recap (LOCAL-ONLY)
+
+`/visual-recap` builds a visual plan **from** a diff, not toward one. It is the
+reverse of forward planning: instead of describing the change you are about to
+make, you describe the change that was just made, at a higher altitude than
+line-by-line review. Schema, API, file, and architecture changes become the same
+`data-model`, `api-endpoint`, `file-tree`, and `diagram` blocks a forward plan
+would use, only now they summarize work that exists. A reviewer scans the shape
+of the change before spending attention on the literal lines.
+
+## LOCAL-ONLY mandate — read this first
+
+> This ycc port **inverts** the upstream BuilderIO `visual-recap` skill. Upstream
+> ALWAYS publishes the recap to the hosted Agent-Native Plan database and FORBIDS
+> inline output ("a recap's entire value is the hosted plan"). **This skill does the
+> opposite.** It is permanently pinned to local-files mode and MUST NOT regress to
+> any hosted Plan create tool.
+
+Hard rules for this skill:
+
+- **`AGENT_NATIVE_PLANS_MODE=local-files` is always set.** Export it before running
+  any runtime command. The recap never writes to the hosted Plan database.
+- **NEVER call a hosted Plan create/publish tool.** The hosted recap-create tool,
+  `create-visual-plan`, `import-visual-plan-source`, `update-visual-plan`,
+  `patch-visual-plan-source`, `get-plan-feedback`, `export-visual-plan`, and
+  `set-resource-visibility` are all **disabled** in this skill. They are listed only
+  to be explicitly excluded — do not invoke them.
+- **The ONLY permitted network call is `get-plan-blocks`** (schema-only block catalog;
+  offline fallback `plan blocks --out`). It carries no recap content. Everything else
+  stays on this machine.
+- **The deliverable is local MDX** under `docs/prps/reviews/visual/<slug>/`, served via
+  the localhost bridge (`plan local serve --open`, 127.0.0.1, ephemeral port). There is
+  no hosted link and no shareable URL.
+- **Diffs are sourced through the shared collector**
+  `${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/visual-recap-collect.sh`, which uses
+  local git refs only — so it behaves identically against the public `github` remote and
+  the private Forgejo `origin` (no vendor PR API, no hardcoded host or trunk branch).
+
+For the pinned `@agent-native/*` install, the `plan` MCP connector (legacy alias
+`agent-native-plans`), the localhost-bridge command surface, and the hosted-egress
+policy, read — do not duplicate —
+`${CURSOR_PLUGIN_ROOT}/skills/_shared/references/agent-native-setup.md`.
+
+## When to use
+
+Build a recap when a change is large, multi-file, or touches schema, API contracts,
+or architecture, and a reviewer would benefit from seeing the change mapped to
+structured blocks before reading the raw diff. Skip it for small, single-file, or
+obvious diffs — a recap is review overhead, and a tiny change reviews faster as plain
+diff.
+
+## Phase 0 — Collect the diff (remote-agnostic, local refs only)
+
+Set local-files mode, then drive the shared collector with `$ARGUMENTS`:
+
+```bash
+export AGENT_NATIVE_PLANS_MODE=local-files
+
+# (none)         → working-tree diff vs HEAD
+# <base>..<head> → explicit range
+# <branch>       → branch as head; base = merge-base against tracked upstream
+BUNDLE_DIR="$(${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/visual-recap-collect.sh $ARGUMENTS)"
+```
+
+The collector writes a bundle under `docs/prps/reviews/visual/<slug>/`:
+
+- `diff.patch` — full unified diff (local refs only)
+- `files.txt` — changed-file name list
+- `metadata.txt` — range / base / head / remote provenance (every remote URL via
+  `git remote get-url`, never a hardcoded host)
+
+`$BUNDLE_DIR` (printed on stdout) is the slug directory the recap MDX is written into.
+Read `diff.patch` and `files.txt` to ground every block. **Print the resolved
+range and remote provenance from `metadata.txt` before authoring** so it is obvious
+which refs the recap covers.
+
+## Phase 1 — Scope the work unit
+
+Default scope is the whole change in the collected range, not only the most recent
+edit. Separate the changes that belong to this work unit from unrelated pre-existing
+dirty work. If the scope is genuinely ambiguous, state the assumption or ask a concise
+question before authoring.
+
+Make a short surface/state inventory from the diff before writing any block: changed
+routes, components, popovers/dialogs, role/access states, empty/error/loading states,
+and shared abstractions. The final recap must either represent each meaningful item
+with a block or intentionally omit it as tiny/redundant/not-user-visible.
+
+## Phase 2 — Fetch the block catalog (the one permitted network call)
+
+> GOTCHA: The MDX block vocabulary drifts upstream between releases. Do NOT author
+> from memorized JSX tags — they silently produce wrong tags that error on import.
+
+Before writing any structured MDX, fetch the live block catalog:
+
+- Connected: call `get-plan-blocks` on the `plan` MCP connector (schema-only; no recap
+  content leaves the machine).
+- Offline / `local-files` fallback: run `plan blocks --out plan-blocks.md` and read it
+  first (calls the public no-auth `get-plan-blocks` route; sends no recap content).
+
+Author every block against the tags and schemas that call returns. The scratch
+`plan-blocks.md` is git-ignored — do not commit it.
+
+## Phase 3 — Map the diff to blocks
+
+Derive every structured block mechanically from the real diff (real paths, real fields,
+real method/path, real before/after text). The names below are CONCEPTUAL block types;
+resolve each to its exact tag + props via `get-plan-blocks`.
+
+- **Schema / migration change** → `data-model` for the resulting entities, fields, and
+  relations. Flag each field/entity with `change: "added" | "modified" | "removed" |
+"renamed"`; for a changed type set `was` to the prior value. The diff-aware
+  `data-model` is the headline; add a split `diff` of literal SQL only when the exact
+  statement still matters.
+- **API / action / route change** → `api-endpoint` with the post-change method, path,
+  params, request, and responses. Flag each changed param/response with `change` (and
+  `was` when a type/shape changed); set `change` on the endpoint root for a wholly added
+  or removed route; mark removed routes `deprecated: true`. Author each request/response
+  example as a single valid JSON value.
+- **Files added / removed / renamed** → `file-tree` with each entry's `change` flag
+  (`added`, `removed`, `modified`, `renamed`) and a short `note`.
+- **Any meaningful code hunk** → `diff` with **split view as the default** (`mode:
+"split"`), carrying the real `before`/`after` text plus `filename`/`language`. Give
+  every `diff` a one-line `summary`; attach a few high-signal `annotations` to the key
+  files. Reserve `mode: "unified"` for a genuinely narrow standalone hunk. Group the key
+  files under a `## Key changes` heading in a single horizontal `tabs` block (one file
+  per tab) so the selected split diff gets full document width.
+- **Brand-new file with no meaningful "before"** → `annotated-code` rather than a
+  one-sided split `diff`.
+- **Rendered UI / interaction change** → `wireframe` blocks (see below) showing the
+  visible delta before any code.
+- **Architecture or data-flow shift** → `diagram` (`data.html`/`data.css` two-panel
+  before/after, layered, or swimlane; or `mermaid` for a quick graph). Use `--wf-*`
+  theme tokens and `.diagram-*` primitives — never hex, rgb/hsl, or `font-family`. Do
+  not use `diagram` as a stand-in for rendered UI; UI changes need `wireframe`.
+- **Outcome-first narrative** → `rich-text` for the "what changed and why": the
+  objective, key decisions visible in the diff, and risks. This is the only place the
+  model writes freely.
+
+### Canonical shape
+
+A strong recap follows one skeleton, top to bottom:
+
+1. UI-impact headline — wireframes first, when the diff changed rendered UI.
+2. Short outcome narrative (`rich-text`): what changed and why, 1–3 paragraphs.
+3. `data-model` / `api-endpoint` blocks for schema and contract changes.
+4. `file-tree` of the changed files with `change` flags.
+5. `## Key changes` — one horizontal `tabs` block of `diff` / `annotated-code`
+   (3–8 focused tabs; prefer under ~150 lines per tab).
+
+Keep the body lean: no boilerplate intro/disclaimer/provenance prose. Add prose only
+when it tells the reviewer something the structured blocks do not.
+
+## UI impact requires wireframes (MANDATORY)
+
+When the diff changes rendered UI, layout, density, visual state, interaction
+affordances, navigation, controls, menus, dialogs, or design tokens, the recap **MUST**
+include one or more `wireframe` blocks. Prose and file diffs are not a substitute for
+showing what changed visually.
+
+Before authoring ANY wireframe, **read
+`${CURSOR_PLUGIN_ROOT}/skills/visual-recap/references/wireframe.md` in full** — it is the
+single source of truth for HTML wireframe quality (`.wf-*` classes, `[data-icon]` Tabler
+set, `surface` presets, `--wf-*` tokens, before/after comparability, skeleton states).
+Do not author wireframes from memory. Show the changed entry point, the main changed
+interaction surface, and the resulting/destination state; for UI-heavy changes a single
+before/after of the entry surface is not enough.
+
+## Phase 4 — Write and serve the local recap
+
+Write the recap as a local MDX folder inside the collected bundle directory:
+
+- `docs/prps/reviews/visual/<slug>/plan.mdx` (required), optional `canvas.mdx`, and
+  optional `.plan-state.json`. Set `kind: "recap"` and `localOnly: true` in the source
+  frontmatter/state.
+
+Validate, then serve via the localhost bridge:
+
+```bash
+plan local check --dir docs/prps/reviews/visual/<slug>
+plan local serve --dir docs/prps/reviews/visual/<slug> --kind recap --open
+```
+
+`serve` binds **127.0.0.1** on an ephemeral CLI-chosen port and opens the preview. It
+performs **no DB writes and sends nothing to any server** — it is a purely local render
+of the on-disk MDX. Report the local bridge URL from stdout (or `<slug>/.plan-url`, a
+local token file — do not commit it). The URL is not shareable across machines.
+
+Treat review feedback as file/chat feedback: edit the MDX directly, rerun
+`plan local serve`, and report the new local bridge URL. Hosted comments, sharing,
+screenshots, and PR sticky-comment publishing are intentionally unavailable.
+
+## Grounding & security
+
+- **Grounding rule.** `diff`, `data-model`, `api-endpoint`, and `file-tree` blocks must
+  be built mechanically from the real changed lines — never inferred, rounded, or
+  invented. Mark anything the model inferred (not extracted) as inferred in prose. When
+  the diff does not contain a fact, leave it out.
+- **Never transcribe secrets.** A diff can contain API keys, tokens, webhook URLs,
+  signing secrets, or `.env` values. Never copy these into any block, snippet, caption,
+  or note — redact them (`sk-•••`). This mirrors the repo's hardcoded-secret rule.
+- **No egress.** This skill performs no hosted upload. The shared
+  `${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/visual-egress-guard.sh` exists for the
+  consent-gated hosted path used by `visual-plan`; it is NOT invoked here because
+  this recap never leaves the machine.
+
+## Output
+
+- Local MDX recap under `docs/prps/reviews/visual/<slug>/` (`plan.mdx` + bundle).
+- A `127.0.0.1` localhost-bridge preview URL printed to stdout.
+- **No hosted link, no shareable URL, no PR comment, no GitHub/Forgejo Action.**
+
+## Related
+
+- `visual-plan` — forward planning; faithful hosted+local MDX workflow with
+  consent-gated egress. Shares the wireframe quality bar word-for-word.
+- `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/agent-native-setup.md` — runtime
+  contract (install pin, connector, bridge, egress policy).

--- a/.cursor-plugin/skills/visual-recap/references/wireframe.md
+++ b/.cursor-plugin/skills/visual-recap/references/wireframe.md
@@ -1,0 +1,234 @@
+# HTML wireframe quality — single source of truth
+
+This file is the canonical quality bar for HTML wireframes / `WireframeBlock`
+content, shared word for word by `visual-plan` and `visual-recap`. Read it in
+full before authoring ANY wireframe; do not author wireframes from memory or paraphrase
+these rules per command.
+
+**A wireframe is an HTML mockup. The renderer owns the look; you write the content.**
+Set `data.html` to a self-contained, semantic HTML fragment of the screen and set
+`data.surface`. The renderer owns the surface footprint/aspect, the dark/light theme,
+the hand-drawn font, and the sketch overlay — you never write `<html>`/`<body>`/`<svg>`
+tags or any width/height/coordinates. You write real HTML layout and real product
+content; the renderer styles and roughens it.
+
+**A wireframe block's data is an HTML screen plus a surface:**
+
+```json
+{
+  "surface": "browser",
+  "html": "<div style=\"display:flex;flex-direction:column;gap:10px;padding:16px;height:100%\"><h1>Sign in</h1><p class=\"wf-muted\">Use your work email to continue.</p><div class=\"wf-card\" style=\"display:flex;flex-direction:column;gap:10px\"><label>Email<input value=\"jane@acme.co\" /></label><label>Password<input value=\"••••••••\" /></label><label style=\"display:flex;align-items:center;gap:8px\"><input type=\"checkbox\" checked /> Remember me</label><button class=\"primary\">Sign in</button></div><a href=\"#\">Forgot password?</a></div>"
+}
+```
+
+**Write PLAIN semantic HTML and let the renderer style it.** Bare elements
+(`h1`/`h2`/`h3`, `p`, `button`, `input`, `label`, `a`, `hr`) are auto-themed — no
+classes needed. Helper classes carry the rest:
+
+- `.wf-card` / `.wf-box` — a bordered, padded container (a panel, a list item).
+- `.wf-pill` / `.wf-chip` — a rounded tag or filter; add `.accent` for the
+  accent-filled variant.
+- `.wf-muted` — secondary/muted text.
+- `button.primary` or any element with `[data-primary]` — the accent-filled primary
+  button.
+
+**No decorative shadows around mockups.** Do not put `box-shadow`,
+`filter: drop-shadow(...)`, Tailwind `shadow-*` classes, or other fake depth effects on
+a wireframe frame, root container, `.wf-card` / `.wf-box`, or canvas artboard. Mockups
+should read as flat, bordered surfaces; use spacing, borders, labels, and annotations
+for separation. Only show a shadow when the real product UI already has that shadow and
+it is essential to the change being reviewed.
+
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading icons
+inside fields, chips, menu items, and toolbars, write an empty marker such as
+`<i data-icon="mail"></i>` or `<span data-icon="search"></span>`. The renderer replaces
+it with a Tabler-style SVG and the `.wf-icon` class sizes it to the surrounding text.
+Supported names and aliases: `mail`/`email`, `lock`/`password`, `search`, `plus`/`add`,
+`x`/`close`, `check`, `chevronDown`, `chevronUp`, `chevronLeft`, `chevronRight`,
+`dots`/`more`, `chevron`/`caret`/`dropdown` (down chevron), `user`, `settings`,
+`calendar`, `bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do not put visible
+words like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
+**Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips these on
+light/dark, so reading them is what keeps a mockup correct in both themes. For any
+inline border, background, or text color, reference a token:
+`style="border:1.4px solid var(--wf-line)"`. The tokens are `--wf-ink` (text),
+`--wf-muted` (secondary text), `--wf-line` (borders/dividers), `--wf-paper` (page
+background), `--wf-card` (container surface), `--wf-accent` / `--wf-accent-fg` /
+`--wf-accent-soft` (brand action), `--wf-warn`, `--wf-ok`, and `--wf-radius`. Never
+hard-code a hex color and never set `font-family` — the renderer owns the sketch/clean
+font.
+
+**Lay out with inline `style` flex/grid.** You write the real layout —
+`display:flex; flex-direction:column; gap:10px; padding:16px` and so on — and the
+renderer never repositions anything. Compose the actual product: reproduce the current
+screen, then show the modification. Real labels, real counts, real dates, real button
+text grounded in the screen you read; not lorem or gray bars.
+
+**Surface presets — match the real footprint, never default to desktop+mobile.** Pick
+the `surface` that matches what the user will actually see:
+
+- `browser`: a web page that needs a browser chrome frame around it.
+- `desktop`: a full desktop app page or app shell.
+- `mobile`: a phone screen, only when the work is genuinely mobile.
+- `popover`: a small floating menu, dropdown, or inline popover.
+- `panel`: a side panel, inspector, or sidebar widget.
+
+A sidebar popover renders as a small surface, not a desktop page and a phone frame. Do
+not emit `desktop` + `mobile` variants unless responsive behavior actually changes the
+layout. For a component or widget, show one broader app-context frame only when
+placement affects understanding, then the focused component states.
+
+**Model the actual component shell for small surfaces.** A rendered UI change belongs in
+a wireframe; reserve `diagram` for architecture, dependency, state, or data-flow
+relationships. Popovers, dropdown menus, command palettes, and context menus use
+`surface: "popover"` unless the surrounding page placement is the point of the change.
+Dialogs, sheets, inspectors, sidebars, and long property panels use the matching
+`panel` / `desktop` surface as appropriate. Show the real chrome: trigger or anchor when
+it matters, title/header row, top-right actions, separators, fields, options, selected
+states, body content, and footer actions that are visible in the workflow.
+
+**Modify, don't redesign.** When the task changes an existing screen, reproduce the
+current screen's real layout and footprint FIRST, then change only the delta and call it
+out with a single annotation. Do not restack the page into a new layout. For net-new
+surfaces, compose from the real app shell. Inspect the actual app components before
+drawing an existing product: sidebar density, toolbar actions, overflow menus, property
+panels, and framework chrome should match the product unless the plan intentionally
+changes them.
+
+**Keep product screens pure.** A product wireframe shows the app state a user would
+actually see. Do not embed file contracts, architecture arrows, repo pills, mode
+explanations, or implementation callouts inside the screen just to explain the plan. Put
+those in canvas annotations, a separate diagram, or the document body. Secondary UI such
+as properties, history, sync, export, or agent controls should appear where the real
+product would put them: an overflow popover, sheet, panel, or separate framework sidebar
+state, not a generic permanent right inspector unless that inspector is the actual
+design.
+
+**Classify mockup scope before implementation.** Before turning a plan mockup into
+source code, decide whether each artboard represents the whole page/app shell, a route
+body inside an existing shell, or a component/sub-surface. If an artboard includes
+navigation, sidebars, auth banners, or a signup/login form, map those pieces to the real
+shared shell/auth components instead of nesting the entire mockup inside the current
+page. When a mockup references the product's standard signup/login page, find and reuse
+that existing implementation; do not approximate it from the wireframe.
+
+**Zoom in on sub-surfaces, don't redraw the page.** For a small sub-surface (a popover,
+menu, dialog, toast), show the full screen once, then add a small separate artboard
+whose `html` contains ONLY that sub-surface — do not re-draw the whole page around it,
+and do not scale a duplicate up. Pick the matching `surface` (e.g. `popover`) so the
+footprint is right; never widen a popover to page width.
+
+**Loading / skeleton states.** Set `data.skeleton: true` on the wireframe and fill the
+`html` with neutral, textless placeholder geometry — boxes and bars built as `<div>`s
+with `background:var(--wf-line)` and explicit heights/widths, no labels or copy. The
+renderer drops borders, sketch, and color into the skeleton register automatically.
+Never escape to a `custom-html` document block to fake a loader.
+
+**Editing an existing mockup.** Because this skill is LOCAL-ONLY, edit the MDX source
+file directly (no hosted patch tool), then rerun `plan local serve` to re-render. Read
+the current `html` first so each replacement targets a unique snippet; the result is
+re-sanitized on reload.
+
+**Treat the wireframe border as part of the visible design.** Always wrap HTML wireframe
+content in a root container with real inner padding before drawing cards, fields, pills,
+labels, or controls. Use at least 14–16px of padding, `box-sizing: border-box`,
+`height: 100%`, and `gap` between child rows so the first row never sits flush against
+the screen border. Keep text away from borders: every container, field, button, menu
+item, and annotation needs enough padding and line-height to read cleanly in the
+rendered Plan view.
+
+**Lay out children safely so they never collide.** Use HTML flex/grid with `gap`,
+`min-width: 0`, and sensible overflow. Avoid negative margins, absolute positioning, or
+fixed child widths that can collide when the renderer switches between light/dark,
+sketch/clean, or different zoom levels.
+
+**Do not wrap intentionally single-line labels.** For toolbars, tab rails, breadcrumbs,
+chip/filter rows, branch and file names, file chips, and code filenames — any
+deliberately single-line row — do not let long text wrap. Put `white-space: nowrap` on
+the row (and `overflow: hidden; text-overflow: ellipsis` on the individual labels that
+can grow), so the wireframe demonstrates the actual layout behavior instead of producing
+ugly stacked or vertical text. Use horizontally scrollable or clipped rails for
+overflow.
+
+**Fill the frame; keep labels short.** Each artboard is a fixed-size surface — compose
+enough realistic HTML to fill it top to bottom with even vertical rhythm; never leave a
+large empty band. On desktop/app-shell sidebars, let the nav stack flex to fill
+(`flex:1`) and add any persistent bottom action/status after it so the rail reads
+complete in taller frames. On mobile especially, flow real rows down the whole screen
+(status bar, header, then list/detail content) rather than a header floating above a
+gap. Keep every label short enough to sit on one line within its column — shorten the
+copy rather than relying on the frame to absorb it.
+
+**Persistent chrome bars span the full frame width.** Top bars, app headers, toolbars,
+and bottom tab/nav bars are full-width chrome, not centered content. Lay each one out as
+a single flex row that fills the frame (`style="display:flex;align-items:center;width:100%"`)
+and push trailing actions to the right edge with a flex spacer
+(`<div style="flex:1"></div>`) between the leading group and the trailing group — never
+center a bar inside a narrow, centered block, and never let it collapse to the width of
+its contents. In a Before/After pair the bar stays full-width in BOTH states even when
+one state has fewer controls; the spacer absorbs the difference so the remaining controls
+hold their edge alignment.
+
+**Pin bottom bars to the bottom of the frame.** For mobile tab bars, footers, and any
+persistent bottom action row, make the frame itself a flex column at `height:100%`
+(`style="display:flex;flex-direction:column;height:100%"`), give the scrolling body
+`flex:1` so it absorbs the slack, and place the bar as the LAST child of the frame (or
+set `margin-top:auto` on it). The bar then sits flush at the bottom of the surface
+instead of floating directly under the content with an empty band beneath it.
+
+**Before / after must be comparable.** When showing a state change, preserve the
+unchanged controls in both states so the reviewer can see exactly what moved or
+appeared; do not show an added control as a generic box floating elsewhere in the
+surface. Place the new/changed affordance where the implementation puts it — for
+example, a new `Edit with AI` action in a popover header belongs in the top-right header
+slot, aligned with the title, not in the body or footer. Use the same frame size, scale,
+outer padding, border radius, and visual density on both sides unless the change itself
+alters those properties, and let the frame height fit the content rather than leaving a
+tall empty lower half.
+
+**Name the states with the column header, never inside the frame.** For document-body
+wireframes (recaps), put the two states in a `columns` block and set each column's
+`label` to `Before` and `After` — the renderer draws that label as an `h4` heading above
+each frame. Do NOT bake a `Before`/`After` pill, title, or heading into the wireframe
+`html`: a label placed inside reads as part of the product UI, lands in a random corner,
+and clutters the comparison. The column header is the one and only place the state name
+belongs.
+
+**Let the surface choose side-by-side vs. stacked.** For document-body wireframes
+(recaps), the `columns` renderer lays narrow surfaces (`mobile`, `popover`, `panel`) out
+side by side, and automatically stacks wide surfaces (`desktop`, `browser`) vertically
+at full document width so a large frame is never crushed into a half-width column and
+cropped. Author both wireframes with the real `surface` and the matching `Before`/`After`
+column labels; do not hand-stack the pair into separate top-level wireframes or duplicate
+the state name as body content.
+
+**Good example — a contacts list, surface `browser`.** A small, real screen composed
+from the helper classes and tokens, layout in inline flex, no fonts or hex colors:
+
+```html
+<div style="display:flex;flex-direction:column;gap:12px;padding:16px;height:100%">
+  <div style="display:flex;align-items:center;justify-content:space-between">
+    <h1>Contacts</h1>
+    <button class="primary">New contact</button>
+  </div>
+  <div style="display:flex;gap:6px">
+    <span class="wf-pill accent">All 128</span>
+    <span class="wf-pill">Favorites</span>
+    <span class="wf-pill">Archived</span>
+  </div>
+  <div class="wf-card" style="display:flex;flex-direction:column;gap:0;padding:0">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-bottom:1.4px solid var(--wf-line)">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Jane Cooper</strong><br /><small>jane@acme.co</small></div>
+      <span class="wf-pill">Lead</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Marcus Lee</strong><br /><small>marcus@globex.io</small></div>
+      <span class="wf-pill">Customer</span>
+    </div>
+  </div>
+</div>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ __pycache__/
 
 # opencode model-alias overrides (per-user, optional)
 scripts/opencode_model_aliases.local.json
+
+# Agent-Native visual-plan/visual-recap local scratch
+plan-blocks.md
+**/plans/*/.plan-serve/
+**/.agent-native/

--- a/.opencode-plugin/commands/parallel-plan.md
+++ b/.opencode-plugin/commands/parallel-plan.md
@@ -5,7 +5,7 @@ description: 'Generate a detailed parallel implementation plan with task depende
   parallel sub-agents via the opencode `task` tool; pass --team (Claude Code only)
   to orchestrate the analysis and validation stages as teammates under a shared spawn
   coordinated subagents/the todo tracker with coordinated shutdown. Usage: [--team]
-  [--no-worktree] [feature-name] [--dry-run]'
+  [--no-worktree] [--visual] [feature-name] [--dry-run]'
 ---
 
 # Parallel Plan Command
@@ -21,6 +21,7 @@ The skill analyzes the shared context, designs independent task batches with exp
 - `--team` — (Claude Code only) Dispatch the 3 analysis agents and 3 validation agents as teammates under a shared `spawn coordinated subagents`/`the todo tracker` with coordinated shutdown and inter-teammate `send follow-up instructions` coordination. Default is standalone parallel sub-agents via the `Task` tool. Cursor and Codex bundles lack team tools — do not pass `--team` there.
 - `--worktree` — (legacy — now default; pass `--no-worktree` to opt out) Worktree annotations are emitted by default. This flag is accepted as a silent no-op so existing pipelines continue to work.
 - `--no-worktree` — Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.
+- `--visual` — Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`. Runs only after the plan is written and validated; `--dry-run` short-circuits it (prints intent only).
 - `--dry-run` — Preview the execution plan without deploying agents. With `--team`, also prints the team name and teammate roster.
 
 **Examples**:
@@ -31,5 +32,6 @@ The skill analyzes the shared context, designs independent task batches with exp
 /parallel-plan add a billing dashboard                    # worktree annotations included by default
 /parallel-plan --no-worktree add a billing dashboard      # skip worktree annotations
 /parallel-plan --team user-authentication                 # team mode with worktree annotations (default)
+/parallel-plan --visual user-authentication               # also render the plan as a visual artifact
 /parallel-plan payment-integration --dry-run
 ```

--- a/.opencode-plugin/commands/plan-workflow.md
+++ b/.opencode-plugin/commands/plan-workflow.md
@@ -5,7 +5,7 @@ description: 'Unified planning workflow — research, analyze, and generate para
   `task` tool; pass --team (Claude Code only) to orchestrate research, analysis, and
   validation stages as teammates under a shared spawn coordinated subagents/the todo
   tracker with coordinated shutdown. Usage: [--team] [--research-only] [--plan-only]
-  [--no-checkpoint] [--optimized] [--dry-run] [--no-worktree] [feature-name]'
+  [--no-checkpoint] [--optimized] [--dry-run] [--no-worktree] [--visual] [feature-name]'
 ---
 
 # Plan Workflow Command
@@ -26,6 +26,7 @@ The skill orchestrates research → shared-context → parallel-plan in a single
 - `--dry-run` — Preview the execution plan without deploying agents. With `--team`, also prints the team name and teammate roster.
 - `--worktree` — (legacy — now default; pass `--no-worktree` to opt out) Worktree annotations are emitted by default. This flag is accepted as a silent no-op so existing pipelines continue to work.
 - `--no-worktree` — Opt out of worktree annotations in the generated `parallel-plan.md`. No effect with `--research-only`. Honored with `--plan-only`. See `.opencode-plugin/skills/_shared/references/worktree-strategy.md`.
+- `--visual` — Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`. Terminal decorator — runs after the plan is written and validated; `--dry-run` short-circuits it. See `.opencode-plugin/skills/_shared/references/visual-mode.md`.
 
 **Examples**:
 
@@ -34,4 +35,5 @@ The skill orchestrates research → shared-context → parallel-plan in a single
 /plan-workflow --no-worktree add a billing dashboard         # skip worktree annotations
 /plan-workflow --team user-authentication                    # team mode with worktree annotations (default)
 /plan-workflow --team --no-worktree user-authentication      # team mode, no worktree annotations
+/plan-workflow --visual add a billing dashboard              # render the finished plan as a visual artifact
 ```

--- a/.opencode-plugin/commands/plan.md
+++ b/.opencode-plugin/commands/plan.md
@@ -3,7 +3,7 @@ description: 'Lightweight conversational planner. Restates requirements, identif
   risks, outlines phases, then WAITS for explicit confirmation before any code is
   written. Lighter than /plan-workflow (parallel research) and /prp-plan (PRD-driven,
   artifact-producing). Usage: [--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree]
-  <what you want to plan>'
+  [--visual] <what you want to plan>'
 ---
 
 # Plan Command
@@ -22,11 +22,12 @@ This is the lightweight planner. For an artifact-producing plan with codebase pa
 - `--dry-run` — Only valid with `--team` or `--enhanced`. Prints the roster (3 baseline or 5 enhanced) and dispatch mode (standalone sub-agents or team), then exits without spawning any agents.
 - `--worktree` — (legacy — now default; pass `--no-worktree` to opt out) Worktree annotations are emitted by default. This flag is accepted as a silent no-op so existing pipelines continue to work.
 - `--no-worktree` — Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.
+- `--visual` — Force-write the plan to a file, then render it as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`. Because `/plan` writes no file by default, `--visual` forces a plan-file write first. Orthogonal to the dispatch flags; `--dry-run` short-circuits it (prints intent only).
 
 `--parallel`, `--team`, and `--enhanced` are **independent and combinable**. `--parallel` shapes the plan's output format; `--team` switches the dispatch mechanism to a coordinated team; `--enhanced` widens the persona roster (3 → 5). With `--enhanced` alone (no `--team`), the 5 personas run as standalone parallel sub-agents. Pass any combination for a richer or more parallel-ready plan.
 
 ```
-Usage: /plan [--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree] <what you want to plan>
+Usage: /plan [--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree] [--visual] <what you want to plan>
 
 Examples:
   /plan add real-time notifications when a market resolves
@@ -41,6 +42,7 @@ Examples:
   /plan --enhanced --parallel add a public webhook endpoint         # 5 standalone subs + parallel-shaped plan
   /plan --parallel add a billing dashboard                          # worktree annotations included by default
   /plan --no-worktree --parallel add a billing dashboard            # skip worktree annotations
+  /plan --visual add a billing dashboard                            # force-write plan, then render visual artifact
 
 The skill will:
   1. Parse flags and restate requirements in clear terms

--- a/.opencode-plugin/commands/prp-plan.md
+++ b/.opencode-plugin/commands/prp-plan.md
@@ -3,8 +3,8 @@ description: 'Create a single-pass implementation plan from a feature descriptio
   or PRD. Runs codebase pattern extraction and optional external research, then writes
   docs/prps/plans/{name}.plan.md. Use --enhanced to grow research from 3 to 7 specialized
   researchers (same dimensions as feature-research) while keeping a single PRP-compliant
-  plan file. Usage: [--parallel | --team] [--enhanced] [--no-worktree] [--dry-run]
-  <feature description | path/to/prd.md>'
+  plan file. Usage: [--parallel | --team] [--enhanced] [--no-worktree] [--visual]
+  [--dry-run] <feature description | path/to/prd.md>'
 ---
 
 # PRP Plan Command
@@ -22,12 +22,13 @@ The skill detects whether the argument is a PRD file (selects the next pending p
 - `--worktree` — (legacy — now default; pass `--no-worktree` to opt out) Worktree annotations are emitted by default. This flag is accepted as a silent no-op so existing pipelines continue to work.
 - `--no-worktree` — Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.
 - `--enhanced` — Enhanced research mode. Grows the research fan-out from 3 to 7 specialized researchers (api / business / tech / ux / security / practices / recommendations — same coverage as `feature-research`). Output remains a single PRP-compliant plan file at `docs/prps/plans/{name}.plan.md`. Composes orthogonally with `--parallel`, `--team`, and `--no-worktree`. When passed alone, defaults to standalone sub-agent dispatch (Path B at width 7); combine with `--team` (Claude Code only) for team-coordinated dispatch.
+- `--visual` — Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted shareable link requires `--share`.
 - `--dry-run` — Only valid with `--team`. Prints the team name and teammate roster, then exits without spawning any teammates.
 
 `--parallel` and `--team` are **mutually exclusive** — pick one. `--no-worktree` is orthogonal and may be combined with either.
 
 ```
-Usage: /prp-plan [--parallel | --team] [--no-worktree] [--dry-run] <feature | path/to/prd.md>
+Usage: /prp-plan [--parallel | --team] [--enhanced] [--no-worktree] [--visual] [--dry-run] <feature | path/to/prd.md>
 
 Examples:
   /prp-plan add rate limiting to the API gateway
@@ -41,6 +42,7 @@ Examples:
   /prp-plan --enhanced "add JWT refresh flow"
   /prp-plan --enhanced --team docs/prps/prds/notifications.prd.md
   /prp-plan --enhanced --no-worktree "add rate limiting"
+  /prp-plan --visual "add JWT refresh flow"                                # render the finished plan as a visual artifact
 
 Next step after plan is written:
   /prp-implement docs/prps/plans/{name}.plan.md              # sequential execution

--- a/.opencode-plugin/commands/visual-plan.md
+++ b/.opencode-plugin/commands/visual-plan.md
@@ -1,0 +1,47 @@
+---
+description: 'Turn an existing text plan into a rich, interactive visual plan — diagrams,
+  file maps, annotated code, open questions, and an optional UI/prototype review surface.
+  Reads the plan (never edits it) and writes plan.mdx + canvas.mdx into a sibling
+  visual/ directory. Hosted sharing is consent-gated behind --share; default is a
+  local-files localhost preview. Usage: [--share] <path/to/plan.md>'
+---
+
+# Visual Plan Command
+
+Render an existing plan as a structured, reviewable visual plan.
+
+**Load and follow the `visual-plan` skill, passing through `$ARGUMENTS`.**
+
+The skill reads the plan at the given path (read-only), auto-selects a review
+mode from its content (UI-first / prototype-first / design-first / visual-intake,
+or document-only), resolves the live block catalog at use time, and emits
+`plan.mdx` (plus `canvas.mdx` when a canvas is used) into a `visual/` sibling of
+the input plan. It prints exactly one link: a localhost preview by default, or a
+hosted shareable URL when `--share` is passed.
+
+**Flags**:
+
+- `--share` — Opt in to hosted egress (destination `plan.agent-native.com`).
+  Hosted upload is OFF by default and consent-gated: without `--share` the skill
+  runs in local-files mode and nothing leaves the machine. Egress is routed
+  through the shared `visual-egress-guard.sh`, which scans for secrets, refuses
+  non-public remotes, and requires a consent token naming the destination.
+
+```
+Usage: /visual-plan [--share] <path/to/plan.md>
+
+Examples:
+  /visual-plan docs/prps/plans/notifications.plan.md          # local-files preview (default)
+  /visual-plan --share docs/prps/plans/notifications.plan.md  # hosted shareable URL (consent-gated)
+  /visual-plan .work/feature-x/parallel-plan.md               # any plan path; visual/ derived from it
+
+Output (exactly one of):
+  https://plan.agent-native.com/...   # hosted shareable URL (only with --share)
+  http://127.0.0.1:PORT/...           # localhost preview (default)
+  local files only                    # when no server/host is available
+```
+
+Invoked automatically as the hand-off target of the shared `--visual` decorator
+on `/prp-plan`, `/plan`, `/parallel-plan`, and `/plan-workflow`.
+The decorator runs only after a plan is written and validated, then calls
+`visual-plan <absolute-plan-path>`.

--- a/.opencode-plugin/commands/visual-recap.md
+++ b/.opencode-plugin/commands/visual-recap.md
@@ -1,0 +1,52 @@
+---
+description: 'Turn a finished change (git range, branch, or working-tree diff) into
+  a LOCAL-ONLY interactive visual recap — annotated split diffs, file map, schema/API
+  deltas, diagrams, and wireframes — written under docs/prps/reviews/visual/ and previewed
+  in the browser via the 127.0.0.1 localhost bridge. Never uploads code; remote-agnostic
+  across the public GitHub remote and the private Forgejo origin. Usage: [base..head
+  | branch]'
+---
+
+# Visual Recap Command
+
+Generate a LOCAL-ONLY visual recap of what a change touched.
+
+**Load and follow the `visual-recap` skill, passing through `$ARGUMENTS`.**
+
+The skill sources the diff through the remote-agnostic collector (local git refs only —
+identical on the public `github` remote and the private Forgejo `origin`), fetches the
+live block catalog, and authors MDX (`data-model`, `api-endpoint`, `file-tree`, split
+`diff`, `diagram`, and mandatory `wireframe` blocks when UI changed) under
+`docs/prps/reviews/visual/<slug>/`. The recap is previewed via the localhost bridge.
+
+**LOCAL-ONLY — what this command will NOT do:**
+
+- No hosted publish, no shareable hosted link, no Plan database write.
+- No hosted recap-create / publish tool — `AGENT_NATIVE_PLANS_MODE=local-files` is always set.
+- No PR comment and no GitHub/Forgejo Action.
+- The only permitted network call is the schema-only `get-plan-blocks` catalog lookup
+  (offline fallback `plan blocks --out`).
+
+**Arguments**:
+
+- _(none)_ — Recap the working-tree diff against `HEAD`.
+- `<base>..<head>` — Recap an explicit two-endpoint range.
+- `<branch>` — Treat `<branch>` as head; the base is computed via `git merge-base`
+  against the tracked upstream (never a hardcoded trunk).
+
+```
+Usage: /visual-recap [base..head | branch]
+
+Examples:
+  /visual-recap                       # working-tree diff vs HEAD
+  /visual-recap feat/rate-limiting    # branch vs merge-base(upstream)
+  /visual-recap main..HEAD            # explicit range
+  /visual-recap v1.2.0..v1.3.0        # release-to-release recap
+
+Output:
+  docs/prps/reviews/visual/<slug>/        # local MDX recap + diff bundle
+  http://127.0.0.1:<port>/...             # localhost-bridge preview (not shareable)
+```
+
+**Related**: `/visual-plan` renders a forward plan (hosted egress is consent-gated
+there); `/visual-recap` is strictly local and emits no remote link.

--- a/.opencode-plugin/opencode.json
+++ b/.opencode-plugin/opencode.json
@@ -22,6 +22,18 @@
         "-y",
         "@modelcontextprotocol/server-github"
       ]
+    },
+    "plan": {
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "@agent-native/core@0.59.1",
+        "mcp"
+      ],
+      "environment": {
+        "AGENT_NATIVE_PLANS_MODE": "local-files"
+      }
     }
   }
 }

--- a/.opencode-plugin/shared/references/agent-native-setup.md
+++ b/.opencode-plugin/shared/references/agent-native-setup.md
@@ -1,0 +1,102 @@
+# Agent-Native Runtime — Shared Setup Contract
+
+Reference for ycc skills that drive the Agent-Native visual-planning runtime — currently
+`~/.config/opencode/skills/visual-plan/SKILL.md` and
+`~/.config/opencode/skills/visual-recap/SKILL.md`. Both skills cite this doc so the install
+pin, the auth/reconnect flow, the connector names, the localhost bridge, and the egress
+policy stay convergent. Fix them here, not per skill (DRY).
+
+The pinned version below was resolved with `npm view @agent-native/core version` at authoring
+time. Re-resolve and re-pin before a release if the runtime has advanced — never substitute a
+floating `latest` dist-tag into committed content.
+
+---
+
+## Install (pinned)
+
+Install a skill from the Agent-Native core CLI with an **explicit pinned version**:
+
+```
+npx -y @agent-native/core@0.59.1 skills add <skill>
+```
+
+- The pin (`0.59.1`) is the version resolved via `npm view @agent-native/core version`.
+- Never commit a floating `latest` dist-tag — the block vocabulary and CLI surface drift
+  between releases, so an unpinned install can silently change behavior. Pin, verify, then bump
+  deliberately.
+
+## Reconnect / auth (one-time per client)
+
+Authorize the runtime against the hosted Plans origin once per client. This is a one-time
+step per machine/client, not per skill run:
+
+```
+npx -y @agent-native/core@0.59.1 reconnect https://plan.agent-native.com --client [claude-code|codex|all]
+```
+
+- `--client all` reconnects every detected client at once.
+- Re-run only when credentials are revoked or the client is reinstalled.
+
+## MCP connector
+
+The runtime exposes an MCP connector named **`plan`**. The legacy alias **`agent-native-plans`**
+still resolves to the same connector — accept either name when detecting an existing
+connection, but prefer `plan` in new guidance.
+
+## Local-only operation
+
+For local-only operation (no hosted calls, no auth required), set:
+
+```
+AGENT_NATIVE_PLANS_MODE=local-files
+```
+
+In this mode the runtime reads and writes plans on the local filesystem only; it does not
+contact `plan.agent-native.com`.
+
+## Localhost bridge
+
+To preview a plan locally, use the `plan local` bridge commands against the plan directory:
+
+```
+plan local check --dir plans/<slug>
+plan local serve --dir plans/<slug> --open
+```
+
+- `check` validates the plan files under `plans/<slug>` without serving.
+- `serve` binds **127.0.0.1** on an **ephemeral, CLI-chosen port** and opens the preview with
+  `--open`.
+- The bridge performs **no DB writes** and sends **nothing to any server** — it is a purely
+  local render of the on-disk plan.
+
+## Block vocabulary (resolve at USE TIME)
+
+> GOTCHA: The MDX block vocabulary drifts upstream between releases. Do **not** trust any
+> hardcoded component/block list in skill bodies or in this doc.
+
+At the runtime-author step (use time, not authoring time), fetch the live block catalog:
+
+- Hosted/connected: call the **`get-plan-blocks`** MCP tool.
+- Offline / `local-files` fallback: run `plan blocks --out <path>` to dump the current catalog.
+
+Always render plan MDX against the freshly-fetched block list, never a list memorized in a
+skill.
+
+## Egress policy
+
+Hosted upload is **OFF by default** and **consent-gated**:
+
+- No plan content leaves the machine unless the operator passes an explicit `--share` flag
+  that names the destination host `plan.agent-native.com`.
+- All hosted egress MUST be routed through
+  `~/.config/opencode/shared/scripts/visual-egress-guard.sh` so the consent check
+  and destination allowlist are enforced in one place.
+- Localhost bridge usage (above) is not egress: it stays on 127.0.0.1 and writes nothing
+  remote.
+
+## Hosted Plans app
+
+- Hosted origin: `https://plan.agent-native.com`.
+- Create tools return **absolute, shareable URLs** under that origin.
+- Plans backed by a **private repo are org-gated** — only members of the owning org can open
+  the shared URL.

--- a/.opencode-plugin/shared/references/visual-mode.md
+++ b/.opencode-plugin/shared/references/visual-mode.md
@@ -1,0 +1,152 @@
+# Visual Mode — Canonical Reference
+
+Used by `prp-plan`, `plan`, `parallel-plan`, and `plan-workflow`
+to expose a uniform `--visual` decorator. This file documents the **single
+`--visual` contract** shared by all four planning skills: when it runs, how it
+composes with other flags, how `--dry-run` short-circuits it, and the hand-off
+to `visual-plan`. Individual skills own their own flag plumbing and the path
+where they write a plan; the shared **invariant** lives here.
+
+`--visual` is a **terminal decorator step**, not a dispatch mode. It does not
+change how a plan is researched, dispatched, or written — it only runs once,
+**after** the plan exists and has been validated, to produce a visual rendering
+of that plan.
+
+See [worktree-strategy.md](./worktree-strategy.md) for where plan artifacts live
+and [agent-team-dispatch.md](./agent-team-dispatch.md) for the team lifecycle
+that `--team` layers on top of planning.
+
+---
+
+## 0. Default Behavior
+
+`--visual` is **off by default** on all four planning skills. When omitted, the
+skill behaves exactly as it does today and writes no visual output.
+
+| Skill               | Writes a plan artifact by default?   | `--visual` target                         |
+| ------------------- | ------------------------------------ | ----------------------------------------- |
+| `prp-plan`      | yes — `docs/prps/plans/*.plan.md`    | the written plan file                     |
+| `parallel-plan` | yes — feature-dir `parallel-plan.md` | the written plan file                     |
+| `plan-workflow` | yes — feature-dir `parallel-plan.md` | the written plan file                     |
+| `plan`          | **no** — plan kept in-chat           | a plan file `--visual` is forced to write |
+
+The plan path differs per skill (and `plan` writes none by default). The
+contract therefore never hardcodes `docs/prps/plans`; it passes whatever
+absolute plan path the skill produced to `visual-plan` and lets that skill
+derive its output directory. See §3 (hand-off) and §4 (`plan` special case).
+
+---
+
+## 1. Timing — runs AFTER write AND validation
+
+`--visual` is the **last** step of a planning run. The order is fixed:
+
+1. Research / dispatch / plan generation (unchanged by `--visual`).
+2. Write the plan artifact to its skill-specific path.
+3. **Validate** the plan per the skill's existing rules.
+4. **Only then** run the `--visual` decorator step.
+
+If steps 1–3 do not complete (research aborts, write fails, or validation
+fails), the `--visual` step does **not** run. There is nothing valid to
+visualize, so the skill reports the upstream failure and stops.
+
+`--visual` never re-orders, re-runs, or substitutes for any earlier phase.
+
+---
+
+## 2. Composition with other flags
+
+`--visual` is **orthogonal** to and **composes with** the dispatch/runtime
+flags. It is applied once, at the end, regardless of which of these are present:
+
+| Flag            | Interaction with `--visual`                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| `--parallel`    | Independent. Parallel dispatch finishes, plan is written + validated, then `--visual` runs once. |
+| `--team`        | Independent. Team lifecycle completes first; `--visual` decorates the final plan.                |
+| `--enhanced`    | Independent. Enhancement affects plan content; `--visual` renders the enhanced result.           |
+| `--no-worktree` | Independent. Worktree opt-out does not affect whether or how `--visual` runs.                    |
+| `--dry-run`     | **Short-circuits** `--visual` (see §2.1).                                                        |
+
+Because `--visual` is a terminal decorator, the combination
+`--parallel --team --visual` (etc.) means: do the parallel/team planning, write
+
+- validate the plan, then run the single `--visual` step on the result.
+
+### 2.1 `--dry-run` short-circuit
+
+When `--dry-run` is present, `--visual` is **short-circuited**: the skill prints
+
+```
+visual generation would run
+```
+
+and does **not** generate anything and does **not** invoke `visual-plan`.
+`--dry-run` always wins over `--visual`; no visual artifacts, directories, or
+links are produced in a dry run.
+
+---
+
+## 3. Hand-off to `visual-plan`
+
+When `--visual` runs for real (not `--dry-run`), the planning skill invokes:
+
+```
+visual-plan <absolute-plan-path>
+```
+
+passing the **absolute path** of the plan file it wrote and validated.
+
+Contract for `visual-plan`:
+
+- **Accept ANY plan path.** It must not assume `docs/prps/plans` or any other
+  fixed location. The plan path is supplied by the caller and may live anywhere
+  (e.g. `docs/prps/plans/<name>.plan.md`, a feature-dir `parallel-plan.md`, or a
+  forced-write file from `plan`).
+- **Derive `visual/` relative to the given plan path.** The output directory is
+  a `visual/` sibling of the plan file — i.e. `<dirname of plan>/visual/` —
+  computed from the path it was handed, never hardcoded.
+- **Print the resulting link to stdout.** Exactly one of:
+  - a hosted shareable URL, or
+  - a localhost preview `http://127.0.0.1:PORT/...`, or
+  - `local files only` when no server/host is available.
+- **NEVER re-run research or dispatch.** It only consumes an existing plan.
+- **NEVER edit the plan file.** It reads the plan and writes only into the
+  derived `visual/` directory; the plan artifact is left byte-for-byte intact.
+
+The planning skill surfaces whatever link `visual-plan` prints; it does not
+re-derive the path itself.
+
+---
+
+## 4. `/plan --visual` special case — force a write FIRST
+
+`plan` writes **no** artifact by default (the plan stays in-chat). There is
+therefore nothing on disk to visualize. When `--visual` is passed to
+`plan`:
+
+1. `plan` **MUST force a plan-file write first**, producing an absolute plan
+   path on disk (this write happens even though it would normally be skipped).
+2. That forced write is then validated like any other plan.
+3. Only after a valid file exists does `plan` hand the absolute path to
+   `visual-plan <absolute-plan-path>`.
+
+Without the forced write there is no input for `visual-plan`, so the
+force-write rule is mandatory — not optional — for `plan --visual`. Under
+`--dry-run` this is moot: the §2.1 short-circuit applies and `plan` prints
+`visual generation would run` without forcing any write.
+
+---
+
+## 5. NAMING_CONVENTION
+
+In-body references to skill assets use the plugin-root variable, e.g.:
+
+- `~/.config/opencode/skills/visual-plan/SKILL.md`
+- `~/.config/opencode/skills/plan/SKILL.md`
+- `~/.config/opencode/skills/prp-plan/SKILL.md`
+- `~/.config/opencode/skills/parallel-plan/SKILL.md`
+- `~/.config/opencode/skills/plan-workflow/SKILL.md`
+
+The hand-off is always expressed as the skill invocation
+`visual-plan <absolute-plan-path>`, with `<absolute-plan-path>` resolved by
+the calling skill to a real, absolute path on disk.

--- a/.opencode-plugin/shared/scripts/visual-egress-guard.sh
+++ b/.opencode-plugin/shared/scripts/visual-egress-guard.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+#
+# visual-egress-guard.sh — pre-upload guard for hosted visual-plan egress.
+#
+# Runs BEFORE any MDX/diff payload leaves the machine for a hosted service
+# (e.g. plan.agent-native.com). It enforces three independent gates:
+#   1. Secret/denylist scan of the payload (mirrors clean/validate-safety.sh).
+#   2. Public-remote check — refuses when the repo's resolved remote is the
+#      private Forgejo origin or any non-public host (never hardcodes a host
+#      beyond the public allowlist; the remote URL comes from `git remote
+#      get-url`).
+#   3. Explicit consent — a consent token naming the destination host must be
+#      supplied before egress is permitted.
+#
+# Usage:
+#   visual-egress-guard.sh --payload <path> [--remote <name>] \
+#       [--destination <host>] [--consent <host>]
+#
+# Arguments:
+#   --payload <path>        File or directory to scan before upload (required).
+#   --remote <name>         Remote whose URL gates publicity (default: tracked
+#                           upstream's remote, else "origin").
+#   --destination <host>    Hosted egress destination (default: plan.agent-native.com).
+#   --consent <host>        Explicit consent token; MUST equal --destination.
+#
+# Exit codes:
+#   0 - All gates passed; hosted egress is permitted
+#   1 - Usage / missing required argument
+#   2 - Secret/denylist hit found in the payload (egress aborted)
+#   3 - Resolved remote is non-public (private Forgejo / non-allowlisted host)
+#   4 - Missing or mismatched consent token
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging helpers (stdout = results, stderr = diagnostics)
+# ---------------------------------------------------------------------------
+
+_error() {
+  echo "visual-egress-guard.sh: error: $*" >&2
+}
+
+_info() {
+  echo "visual-egress-guard.sh: $*" >&2
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  visual-egress-guard.sh --payload <path> [--remote <name>] \
+      [--destination <host>] [--consent <host>]
+
+Arguments:
+  --payload <path>      File or directory to scan before upload (required).
+  --remote <name>       Remote whose URL gates publicity (default: upstream's
+                        remote, else "origin").
+  --destination <host>  Hosted egress destination (default: plan.agent-native.com).
+  --consent <host>      Explicit consent token; MUST equal --destination.
+
+Exit codes: 0 ok | 1 usage | 2 secret hit | 3 non-public remote | 4 no consent
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Denylist — mirrors clean/validate-safety.sh PROTECTED/SECURITY patterns.
+# ---------------------------------------------------------------------------
+
+declare -a PROTECTED=(
+  ".env"
+  ".env.*"
+  "*.pem"
+  "*.key"
+  "*.p12"
+  "*.pfx"
+  "*.crt"
+  "id_rsa"
+  "id_ed25519"
+  "credentials.json"
+  "secrets.json"
+)
+
+# Non-public host detection. A host is treated as non-public (egress refused)
+# when it is the known-private Forgejo origin, sits on a private/tailnet TLD, is
+# a loopback/RFC1918 address, or is an unqualified single-label hostname. Any
+# other fully-qualified public host is allowed. This deliberately avoids
+# hardcoding a public vendor host: publicity is inferred, privacy is matched.
+#
+# The known-private host defaults to the Forgejo origin and may be overridden
+# via VISUAL_EGRESS_PRIVATE_HOST for other deployments.
+PRIVATE_HOST="${VISUAL_EGRESS_PRIVATE_HOST:-git.azules-celsius.ts.net}"
+
+declare -a PRIVATE_SUFFIXES=(
+  ".ts.net"
+  ".local"
+  ".internal"
+  ".lan"
+  ".home.arpa"
+  ".localdomain"
+)
+
+DEFAULT_DESTINATION="plan.agent-native.com"
+
+# ---------------------------------------------------------------------------
+# Argument parsing (strict case-based flag handling)
+# ---------------------------------------------------------------------------
+
+PAYLOAD=""
+REMOTE_NAME=""
+DESTINATION="$DEFAULT_DESTINATION"
+CONSENT=""
+
+require_value() {
+  if [[ $# -lt 2 || -z "$2" ]]; then
+    _error "flag $1 requires a value"
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --payload)
+      require_value "$@"
+      PAYLOAD="$2"
+      shift 2
+      ;;
+    --remote)
+      require_value "$@"
+      REMOTE_NAME="$2"
+      shift 2
+      ;;
+    --destination)
+      require_value "$@"
+      DESTINATION="$2"
+      shift 2
+      ;;
+    --consent)
+      require_value "$@"
+      CONSENT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      _error "unexpected positional argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$PAYLOAD" ]]; then
+  _error "--payload is required"
+  usage
+  exit 1
+fi
+
+if [[ ! -e "$PAYLOAD" ]]; then
+  _error "payload not found: $PAYLOAD"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Gate 1: secret / denylist scan (exit 2 on hit)
+# ---------------------------------------------------------------------------
+
+# Convert a denylist glob into a path-anchored extended regex.
+glob_to_regex() {
+  local g="$1"
+  g="${g//./\\.}"        # escape literal dots
+  g="${g//\*/[^/ ]*}"    # '*' matches a run of non-slash, non-space chars
+  printf '(^|[ /])%s($|[ /])' "$g"
+}
+
+SECRET_HITS=0
+for pattern in "${PROTECTED[@]}"; do
+  regex="$(glob_to_regex "$pattern")"
+
+  # (a) Protected path referenced in payload content (e.g. diff headers).
+  if grep -rInE -- "$regex" "$PAYLOAD" >/dev/null 2>&1; then
+    _error "denylist hit (content): pattern '$pattern' present in payload"
+    SECRET_HITS=$((SECRET_HITS + 1))
+  fi
+
+  # (b) An actual protected file inside the payload tree.
+  if [[ -d "$PAYLOAD" ]]; then
+    if find "$PAYLOAD" -type f -name "$pattern" -print -quit 2>/dev/null | grep -q .; then
+      _error "denylist hit (file): '$pattern' file exists under payload"
+      SECRET_HITS=$((SECRET_HITS + 1))
+    fi
+  else
+    # shellcheck disable=SC2053
+    if [[ "$(basename "$PAYLOAD")" == $pattern ]]; then
+      _error "denylist hit (file): payload basename matches '$pattern'"
+      SECRET_HITS=$((SECRET_HITS + 1))
+    fi
+  fi
+done
+
+if [[ "$SECRET_HITS" -gt 0 ]]; then
+  _error "aborting: ${SECRET_HITS} secret/denylist hit(s) — payload is unsafe to upload"
+  exit 2
+fi
+_info "secret scan clean"
+
+# ---------------------------------------------------------------------------
+# Gate 2: public-remote check (exit 3 when non-public)
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository; cannot verify remote publicity"
+  exit 3
+fi
+
+# Default the remote name to the tracked upstream's remote, else "origin".
+if [[ -z "$REMOTE_NAME" ]]; then
+  UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+  if [[ -n "$UPSTREAM" && "$UPSTREAM" == */* ]]; then
+    REMOTE_NAME="${UPSTREAM%%/*}"
+  else
+    REMOTE_NAME="origin"
+  fi
+fi
+
+REMOTE_URL="$(git remote get-url "$REMOTE_NAME" 2>/dev/null || true)"
+if [[ -z "$REMOTE_URL" ]]; then
+  _error "could not resolve URL for remote '$REMOTE_NAME'"
+  exit 3
+fi
+
+# Extract the host from any common git URL form without hardcoding a host.
+remote_host() {
+  local url="$1"
+  url="${url#*://}"   # drop scheme:// if present
+  url="${url#*@}"     # drop user@ if present
+  url="${url%%[:/]*}" # host is up to the first ':' or '/'
+  printf '%s' "$url"
+}
+
+HOST="$(remote_host "$REMOTE_URL")"
+HOST="$(printf '%s' "$HOST" | tr '[:upper:]' '[:lower:]')"
+
+# Decide whether a host is public. Privacy is matched explicitly; anything not
+# matched as private but shaped like a public FQDN is treated as public.
+is_public_host() {
+  local host="$1"
+
+  # Known-private origin.
+  [[ "$host" == "$PRIVATE_HOST" ]] && return 1
+
+  # Loopback / RFC1918 literals.
+  case "$host" in
+    localhost|127.*|10.*|192.168.*) return 1 ;;
+    172.1[6-9].*|172.2[0-9].*|172.3[01].*) return 1 ;;
+  esac
+
+  # Private / internal / tailnet suffixes.
+  local suffix
+  for suffix in "${PRIVATE_SUFFIXES[@]}"; do
+    [[ "$host" == *"$suffix" ]] && return 1
+  done
+
+  # Unqualified single-label hostnames are not public.
+  [[ "$host" != *.* ]] && return 1
+
+  return 0
+}
+
+if ! is_public_host "$HOST"; then
+  _error "refusing hosted egress: remote '$REMOTE_NAME' host '$HOST' is not public"
+  _error "private/internal remotes (e.g. the Forgejo origin) must not upload to ${DESTINATION}"
+  exit 3
+fi
+_info "remote '$REMOTE_NAME' host '$HOST' is public"
+
+# ---------------------------------------------------------------------------
+# Gate 3: explicit consent (exit 4 when missing/mismatched)
+# ---------------------------------------------------------------------------
+
+if [[ -z "$CONSENT" ]]; then
+  _error "missing consent: pass --consent ${DESTINATION} to authorize hosted egress"
+  exit 4
+fi
+
+if [[ "$CONSENT" != "$DESTINATION" ]]; then
+  _error "consent mismatch: --consent '$CONSENT' does not name destination '${DESTINATION}'"
+  exit 4
+fi
+_info "consent confirmed for destination '${DESTINATION}'"
+
+# ---------------------------------------------------------------------------
+# All gates passed -> result on stdout
+# ---------------------------------------------------------------------------
+
+echo "egress-permitted destination=${DESTINATION} remote=${REMOTE_NAME} host=${HOST}"
+exit 0

--- a/.opencode-plugin/shared/scripts/visual-recap-collect.sh
+++ b/.opencode-plugin/shared/scripts/visual-recap-collect.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# visual-recap-collect.sh — remote-agnostic local diff collector for visual recap.
+#
+# Collects a diff bundle using ONLY local git refs so it behaves identically on
+# any remote (public GitHub or the private Forgejo). It NEVER calls a vendor PR
+# API and NEVER hardcodes a remote host or branch name.
+#
+# Usage:
+#   visual-recap-collect.sh [<base>..<head> | <branch>]
+#
+# Arguments:
+#   (none)            Collect the working-tree diff (git diff HEAD).
+#   <base>..<head>    Collect git diff <base>...<head> (explicit two endpoints).
+#   <branch>          Treat <branch> as head; compute base via `git merge-base`
+#                     against the tracked upstream (resolved from @{upstream}).
+#
+# Base resolution NEVER hardcodes a trunk branch: the upstream is resolved with
+#   git rev-parse --abbrev-ref --symbolic-full-name @{upstream}
+# and falls back gracefully to merge-base against HEAD when no upstream is set.
+#
+# Output:
+#   - Diff bundle written under docs/prps/reviews/visual/<slug>/
+#       diff.patch     full unified diff (local refs only)
+#       files.txt      changed-file name list
+#       metadata.txt   range/base/head/remote provenance
+#   - Results (bundle path + summary) on stdout.
+#   - All errors and progress notes on stderr.
+#
+# Exit codes:
+#   0 - Bundle collected successfully
+#   1 - Usage / git / I/O failure
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging helpers (stdout = results, stderr = diagnostics)
+# ---------------------------------------------------------------------------
+
+_error() {
+  echo "visual-recap-collect.sh: error: $*" >&2
+}
+
+_info() {
+  echo "visual-recap-collect.sh: $*" >&2
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  visual-recap-collect.sh [<base>..<head> | <branch>]
+
+Arguments:
+  (none)            Collect the working-tree diff (git diff HEAD).
+  <base>..<head>    Collect git diff <base>...<head>.
+  <branch>          Use <branch> as head; base = merge-base(@{upstream}, <branch>).
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing (strict case-based flag handling)
+# ---------------------------------------------------------------------------
+
+RANGE_ARG=""
+
+set_range_arg() {
+  if [[ -z "$RANGE_ARG" ]]; then
+    RANGE_ARG="$1"
+  else
+    _error "unexpected positional argument: $1"
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        set_range_arg "$1"
+        shift
+      done
+      break
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      set_range_arg "$1"
+      shift
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Git context
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository"
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+CURRENT_BRANCH="$(git branch --show-current || true)"
+
+# Resolve the tracked upstream without ever hardcoding a trunk branch name.
+resolve_upstream() {
+  git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true
+}
+
+# Resolve the remote URL for the given remote name (never hardcode a host).
+remote_url_for() {
+  local name="$1"
+  git remote get-url "$name" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Range / mode resolution
+# ---------------------------------------------------------------------------
+
+MODE=""
+BASE_REF=""
+HEAD_REF=""
+RANGE_LABEL=""
+
+if [[ -z "$RANGE_ARG" ]]; then
+  # Default: working-tree diff against HEAD.
+  MODE="worktree"
+  HEAD_REF="HEAD"
+  RANGE_LABEL="working-tree"
+elif [[ "$RANGE_ARG" == *".."* ]]; then
+  MODE="range"
+  BASE_REF="${RANGE_ARG%%..*}"
+  HEAD_REF="${RANGE_ARG##*..}"
+  if [[ -z "$BASE_REF" || -z "$HEAD_REF" ]]; then
+    _error "malformed range '$RANGE_ARG'; expected <base>..<head>"
+    exit 1
+  fi
+  RANGE_LABEL="${BASE_REF}...${HEAD_REF}"
+else
+  MODE="branch"
+  HEAD_REF="$RANGE_ARG"
+  if ! git rev-parse --verify --quiet "${HEAD_REF}^{commit}" >/dev/null; then
+    _error "not a valid ref: $HEAD_REF"
+    exit 1
+  fi
+  UPSTREAM="$(resolve_upstream)"
+  if [[ -n "$UPSTREAM" ]]; then
+    _info "tracked upstream: $UPSTREAM"
+    BASE_REF="$(git merge-base "$UPSTREAM" "$HEAD_REF" 2>/dev/null || true)"
+  fi
+  if [[ -z "$BASE_REF" ]]; then
+    _info "no upstream merge-base; falling back to merge-base against HEAD"
+    BASE_REF="$(git merge-base HEAD "$HEAD_REF" 2>/dev/null || true)"
+  fi
+  if [[ -z "$BASE_REF" ]]; then
+    _error "could not compute a merge-base for '$HEAD_REF'"
+    exit 1
+  fi
+  RANGE_LABEL="${BASE_REF}...${HEAD_REF}"
+fi
+
+# ---------------------------------------------------------------------------
+# Slug derivation (filesystem-safe; lowercase alnum + dashes)
+# ---------------------------------------------------------------------------
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -e 's#[^a-z0-9]\+#-#g' -e 's#^-\+##' -e 's#-\+$##'
+}
+
+case "$MODE" in
+  worktree)
+    SLUG_SOURCE="${CURRENT_BRANCH:-detached-head}"
+    ;;
+  range)
+    SLUG_SOURCE="${BASE_REF}-to-${HEAD_REF}"
+    ;;
+  branch)
+    SLUG_SOURCE="$HEAD_REF"
+    ;;
+esac
+
+SLUG="$(slugify "$SLUG_SOURCE")"
+if [[ -z "$SLUG" ]]; then
+  SLUG="recap"
+fi
+
+# ---------------------------------------------------------------------------
+# Collect the diff (LOCAL refs only — identical on GitHub and Forgejo)
+# ---------------------------------------------------------------------------
+
+OUT_DIR="docs/prps/reviews/visual/${SLUG}"
+mkdir -p "$OUT_DIR"
+
+DIFF_FILE="${OUT_DIR}/diff.patch"
+FILES_FILE="${OUT_DIR}/files.txt"
+META_FILE="${OUT_DIR}/metadata.txt"
+
+if [[ "$MODE" == "worktree" ]]; then
+  git diff HEAD >"$DIFF_FILE" || { _error "git diff failed"; exit 1; }
+  git diff --name-only HEAD >"$FILES_FILE" || { _error "git diff --name-only failed"; exit 1; }
+else
+  # Three-dot diff against the merge-base of base and head.
+  git diff "${BASE_REF}...${HEAD_REF}" >"$DIFF_FILE" || { _error "git diff failed"; exit 1; }
+  git diff --name-only "${BASE_REF}...${HEAD_REF}" >"$FILES_FILE" || { _error "git diff --name-only failed"; exit 1; }
+fi
+
+# Remote provenance: record every remote URL via `git remote get-url` so the
+# bundle is auditable without hardcoding any host.
+{
+  echo "generated-by: visual-recap-collect.sh"
+  echo "mode: ${MODE}"
+  echo "range: ${RANGE_LABEL}"
+  echo "base: ${BASE_REF:-<working-tree>}"
+  echo "head: ${HEAD_REF}"
+  echo "current-branch: ${CURRENT_BRANCH:-<detached>}"
+  echo "slug: ${SLUG}"
+  echo "remotes:"
+  while IFS= read -r _rname; do
+    [[ -z "$_rname" ]] && continue
+    echo "  - ${_rname}: $(remote_url_for "$_rname")"
+  done < <(git remote)
+} >"$META_FILE"
+
+CHANGED_COUNT="$(grep -c . "$FILES_FILE" 2>/dev/null)" || CHANGED_COUNT=0
+
+# ---------------------------------------------------------------------------
+# Results -> stdout
+# ---------------------------------------------------------------------------
+
+echo "$OUT_DIR"
+_info "collected ${CHANGED_COUNT} changed file(s) for range '${RANGE_LABEL}'"
+_info "bundle: ${OUT_DIR}/{diff.patch,files.txt,metadata.txt}"
+
+exit 0

--- a/.opencode-plugin/skills/parallel-plan/SKILL.md
+++ b/.opencode-plugin/skills/parallel-plan/SKILL.md
@@ -53,13 +53,14 @@ Parse arguments (flags first, then the feature name):
 - **--team**: Optional. (Claude Code only) Deploy the analysis and validation stages as teammates under a shared `spawn coordinated subagents`/`the todo tracker` with coordinated shutdown. Default is standalone parallel sub-agents via the `Task` tool. Cursor and Codex bundles lack team tools — do not pass `--team` there.
 - **--worktree**: Optional. (legacy — now default; safe to omit) Worktree annotations are emitted by default. Accepted as a silent no-op so existing pipelines continue to work.
 - **--no-worktree**: Optional. Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.
+- **--visual**: Optional. Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`.
 - **--dry-run**: Show what would be created without making changes. With `--team`, also prints the team name and teammate roster.
 - **feature-name**: Required. Matches directory name in `${PLANS_DIR}`.
 
 If no feature name provided, abort with usage instructions:
 
 ```
-Usage: /parallel-plan [--team] [--no-worktree] [feature-name] [--dry-run]
+Usage: /parallel-plan [--team] [--no-worktree] [--visual] [feature-name] [--dry-run]
 
 Examples:
   /parallel-plan user-authentication
@@ -68,7 +69,18 @@ Examples:
   /parallel-plan --team --dry-run user-authentication
   /parallel-plan user-authentication                     # worktree annotations included by default
   /parallel-plan --no-worktree user-authentication       # skip worktree annotations
+  /parallel-plan --visual user-authentication            # also render the plan as a visual artifact
 ```
+
+---
+
+## Visual mode
+
+`--visual` follows the canonical contract at `~/.config/opencode/shared/references/visual-mode.md`. It is a **terminal decorator**, not a dispatch mode: it does not change how the plan is researched, dispatched, or written, and composes orthogonally with `--team` and `--no-worktree`.
+
+When `VISUAL_MODE` is set and not `--dry-run`, after the final phase (plan written in Phase 4, validated in Phase 6 Step 21) the skill invokes `visual-plan <absolute-plan-path>` on the **actual written plan path** — the absolute path of `${feature_dir}/parallel-plan.md`. The bootstrap invocation lives in Step 21.5.
+
+When `--dry-run` is also present, `--visual` is short-circuited (see Step 4): the skill prints `visual generation would run` and generates no artifact, directory, or link.
 
 ---
 
@@ -90,7 +102,8 @@ Extract from `$ARGUMENTS`:
 1. **--team**: Boolean flag. Set `AGENT_TEAM_MODE=true` if present, else `false`.
 2. **--dry-run**: Boolean flag. Set `DRY_RUN=true` if present, else `false`.
 3. **--no-worktree / --worktree**: Default `WORKTREE_MODE=true`. Set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default).
-4. **feature-name**: First non-flag argument (required).
+4. **--visual**: Boolean flag. Set `VISUAL_MODE=true` if present, else `false`.
+5. **feature-name**: First non-flag argument (required).
 
 ```bash
 # Default ON; pass --no-worktree to opt out. --worktree accepted as legacy no-op.
@@ -100,7 +113,15 @@ case " $ARGUMENTS " in
 esac
 ARGUMENTS="${ARGUMENTS//--no-worktree/}"
 ARGUMENTS="${ARGUMENTS//--worktree/}"  # legacy no-op
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
+
+`--visual` is orthogonal — it composes with `--team`/`--no-worktree` and runs after the plan is written and validated. `--dry-run` short-circuits it (prints intent only); see Step 4 and the `## Visual mode` section.
 
 **Compatibility note**: When this skill is invoked from a Cursor or Codex bundle, `--team` must not be used (those bundles ship without team tools).
 
@@ -186,6 +207,14 @@ Teammates:      6 across 2 batches
 ```
 
 Do **not** call `spawn coordinated subagents`, `track the task`, `Agent`, `Task`, `send follow-up instructions`, or `end the coordinated run` in dry-run mode.
+
+If `VISUAL_MODE=true`, the `--visual` step is **short-circuited** by `--dry-run`: print intent ONLY and generate no visual artifact (`--dry-run` always wins over `--visual`):
+
+```
+visual generation would run
+```
+
+Do **not** invoke `visual-plan` or create any `visual/` directory or link in dry-run mode.
 
 **STOP HERE** - do not write files or deploy agents.
 
@@ -522,6 +551,21 @@ Run the validation script:
 ```
 
 Report any structural issues found.
+
+### Step 21.5: Visual Artifact (if `--visual`)
+
+If `VISUAL_MODE=false`, skip this step entirely.
+
+This step runs **only after** the plan has been written (Step 14) and validated (Step 21). Follow the canonical contract at `~/.config/opencode/shared/references/visual-mode.md`. `--visual` is a terminal decorator: it never re-runs research, dispatch, or plan generation.
+
+- If `DRY_RUN=true`, this step was already short-circuited in Step 4 (printed `visual generation would run`); do **not** generate anything here.
+- Otherwise, when `VISUAL_MODE=true` and not `--dry-run`, invoke `visual-plan` on the **actual written plan path** (the absolute path of `${feature_dir}/parallel-plan.md`):
+
+```
+visual-plan <absolute-path-to-${feature_dir}/parallel-plan.md>
+```
+
+Surface whatever link `visual-plan` prints (hosted shareable URL with `--share`, localhost preview, or `local files only`). Do not re-derive the output path — `visual-plan` derives `visual/` relative to the plan path and leaves the plan file byte-for-byte intact.
 
 ### Step 22: Clean Up Team (if `--team`)
 

--- a/.opencode-plugin/skills/plan-workflow/SKILL.md
+++ b/.opencode-plugin/skills/plan-workflow/SKILL.md
@@ -43,12 +43,13 @@ Parse arguments (flags first, then the feature name):
 - **--dry-run**: Show execution plan without running. With `--team`, also prints the team name and teammate roster.
 - **--worktree**: Optional. (legacy — now default; safe to omit) Worktree annotations are emitted in the generated `parallel-plan.md` by default. Accepted as a silent no-op so existing pipelines continue to work.
 - **--no-worktree**: Optional. Opt out of worktree annotations in the generated `parallel-plan.md`. No effect when `--research-only` is passed (no plan file is generated). Honored with `--plan-only`.
+- **--visual**: Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`.
 - **feature-name**: Required. Directory name in `${PLANS_DIR}/`
 
 If no feature name provided, abort with usage instructions:
 
 ```
-Usage: /plan-workflow [--team] [options] [feature-name]
+Usage: /plan-workflow [--team] [options] [--visual] [feature-name]
 
 Options:
   --team            (Claude Code only) Dispatch stages as agent team (default: standalone sub-agents)
@@ -59,6 +60,7 @@ Options:
   --dry-run         Show execution plan without running
   --worktree        (legacy — now default; safe to omit) Worktree annotations emitted by default
   --no-worktree     Opt out of worktree annotations in the generated parallel-plan.md
+  --visual          Render the finished plan as a visual artifact via visual-plan (local-files by default; hosted link requires --share)
 
 Examples:
   /plan-workflow user-authentication
@@ -69,7 +71,26 @@ Examples:
   /plan-workflow --team --dry-run new-feature
   /plan-workflow add-billing-dashboard                 # worktree annotations included by default
   /plan-workflow --no-worktree add-billing-dashboard   # skip worktree annotations
+  /plan-workflow --visual add-billing-dashboard        # render the finished plan as a visual artifact
 ```
+
+---
+
+## Visual mode
+
+See `~/.config/opencode/shared/references/visual-mode.md` for the canonical `--visual` contract shared by all planning skills.
+
+`--visual` is a **terminal decorator step**, not a dispatch mode. It is orthogonal to and composes with `--team`, `--optimized`, and `--no-worktree`, and runs once at the very end.
+
+When `VISUAL_MODE=true` and `--dry-run` is **not** set, after the final phase (the plan has been written and validated) the workflow invokes:
+
+```
+visual-plan <absolute-plan-path>
+```
+
+where `<absolute-plan-path>` is the **actual written plan path** — the feature-dir plan at `${feature_dir}/parallel-plan.md` resolved in Phase 0 — **not** a hardcoded `docs/prps/plans` path. `visual-plan` derives its `visual/` output directory relative to that plan path.
+
+When `--dry-run` is set, `--visual` is **short-circuited**: print `visual generation would run` and do not invoke `visual-plan`. `--research-only` produces no plan file, so `--visual` has nothing to render and does not run.
 
 ---
 
@@ -91,9 +112,16 @@ case " $ARGUMENTS " in
 esac
 ARGUMENTS="${ARGUMENTS//--no-worktree/}"
 ARGUMENTS="${ARGUMENTS//--worktree/}"  # legacy no-op
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
-4. **feature-name**: First non-flag argument (required).
+4. **--visual**: Boolean flag. Set `VISUAL_MODE=true` if present, else `false`. Terminal decorator — see [## Visual mode](#visual-mode).
+5. **feature-name**: First non-flag argument (required).
 
 Validate the feature name:
 
@@ -607,6 +635,26 @@ After validators complete:
 If `AGENT_TEAM_MODE=false`, skip this step — standalone sub-agents return on their own.
 
 Otherwise, send shutdown requests to all validation teammates.
+
+---
+
+## Phase 9.5: Visual Mode (if --visual)
+
+If `VISUAL_MODE=false`, skip this phase entirely.
+
+This step runs only after the plan has been written (Phase 8) and validated (Phases 8–9). It never re-orders, re-runs, or substitutes for any earlier phase. See `~/.config/opencode/shared/references/visual-mode.md`.
+
+### Step 32.5: Render Visual Artifact
+
+- If `--dry-run` is set, print `visual generation would run` and **STOP** this phase (the §2.1 short-circuit — no visual artifacts are produced).
+- If `--research-only` was used, no plan file was generated; skip this phase.
+- Otherwise, invoke `visual-plan` on the **actual written plan path** (the feature-dir plan resolved in Phase 0, not a hardcoded `docs/prps/plans` path):
+
+```
+visual-plan "${feature_dir}/parallel-plan.md"
+```
+
+`visual-plan` derives its `visual/` output directory relative to the supplied plan path and prints the resulting link (hosted URL, localhost preview, or `local files only`). Surface that link in the Phase 10 summary; do not re-derive the path yourself, and do not edit the plan file.
 
 ---
 

--- a/.opencode-plugin/skills/plan/SKILL.md
+++ b/.opencode-plugin/skills/plan/SKILL.md
@@ -32,6 +32,7 @@ Create a comprehensive implementation plan before writing any code. This is the 
 | `--dry-run`     | Valid with `--team` (prints team-coordinated roster) or `--enhanced` (prints standalone or team roster depending on whether `--team` is also present). Prints the roster, then exits without spawning any agents.                                                                                                                                                                                                                                                                                                                                                                                  |
 | `--worktree`    | (legacy — now default; safe to omit) Previously required to emit worktree annotations; the annotations are now emitted by default. Accepted as a silent no-op so existing pipelines continue to work.                                                                                                                                                                                                                                                                                                                                                                                              |
 | `--no-worktree` | Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `--visual`      | Force-write the plan to a file, then render it as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted link requires `--share`.                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 **Flag interaction**:
 
@@ -60,7 +61,7 @@ Use this skill when:
 
 ### Step 1 — Parse flags and the user's request
 
-**Flag parsing**: Extract `--parallel`, `--team`, `--enhanced`, `--dry-run`, `--no-worktree`, and `--worktree` from `$ARGUMENTS` before processing. Strip them out. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `ENHANCED_MODE=true|false`, `DRY_RUN=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). The remaining text is the user's request.
+**Flag parsing**: Extract `--parallel`, `--team`, `--enhanced`, `--dry-run`, `--no-worktree`, `--worktree`, and `--visual` from `$ARGUMENTS` before processing. Strip them out. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `ENHANCED_MODE=true|false`, `DRY_RUN=true|false`, `VISUAL_MODE=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). The remaining text is the user's request.
 
 ```bash
 # Default ON; pass --no-worktree to opt out. --worktree accepted as legacy no-op.
@@ -76,6 +77,12 @@ case " $ARGUMENTS " in
   *" --enhanced "*) ENHANCED_MODE=true ;;
 esac
 ARGUMENTS="${ARGUMENTS//--enhanced/}"
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
 **Validation**:
@@ -84,6 +91,7 @@ ARGUMENTS="${ARGUMENTS//--enhanced/}"
 - If `DRY_RUN=true` and both `AGENT_TEAM_MODE=false` and `ENHANCED_MODE=false` → abort with: `--dry-run requires --team or --enhanced (no-op for the single-agent path).`
 - If `--team` is invoked from a Cursor or Codex bundle, abort with the existing compatibility message: `--team requires team tools, which Cursor/Codex bundles do not ship. Use --parallel instead.`
 - `--enhanced` alone is supported in every bundle: Path C uses parallel `Agent` calls without team tools. Only the `--enhanced --team` combination requires opencode; in Cursor or Codex, abort with: `--enhanced --team requires team tools, which Cursor/Codex bundles do not ship. Drop --team to use the standalone 5-persona path.`
+- `--visual` is orthogonal and runs after the plan is produced. Because `/plan` writes no file by default, `--visual` forces a plan-file write first. `--dry-run` short-circuits it (prints intent only).
 
 Read the stripped `$ARGUMENTS`. If it references a file path, read that file for context. If the request is ambiguous, ask a single focused clarifying question **before** dispatching.
 
@@ -517,6 +525,50 @@ Valid user responses:
 **Team-mode re-dispatch note**: Path B's team is `end the coordinated run`d in Step B.8 _before_ the user sees the plan. Any re-dispatch from this step creates a **new** team (same name is fine — the old one no longer exists) with a fresh set of teammates. Do not attempt to send messages to teammates from the prior team.
 
 **Path C re-dispatch note**: Path C never created a team, so there is no teardown to worry about. Any re-dispatch from this step simply fires a fresh batch of 5 parallel `Agent` calls (no `team_name=`).
+
+---
+
+### Step 5 — Visual rendering (if `VISUAL_MODE=true`)
+
+This step runs **only after** the user confirms the plan in Step 4 (it is the terminal decorator step). It never re-orders or substitutes for any earlier phase.
+
+- **If `DRY_RUN=true`**: print `visual generation would run` and skip — do not force any write and do not invoke `visual-plan`. (`--dry-run` already exits earlier at the dispatch gate; this is the no-op contract for the combination.)
+- **Otherwise**:
+  1. **Force-write the plan to a file.** `/plan` keeps the plan in-chat and writes no artifact by default, so there is nothing on disk to visualize. Write the confirmed plan verbatim to a concrete path. Default location: `docs/prps/plans/<slug>.plan.md`, where `<slug>` is the user's request sanitized to kebab-case (same scheme as Path B §B.1: lowercase, non-`[a-z0-9-]` → `-`, collapse runs, trim, truncate to 20 chars, fallback `untitled`). Create the directory first (`mkdir -p docs/prps/plans`). Resolve the path to an **absolute** path.
+  2. **Invoke** `visual-plan <absolute-plan-path>` with the absolute path written in the previous step.
+  3. **Surface the link** that `visual-plan` prints (hosted URL, localhost preview, or `local files only`). Do not re-derive the output directory yourself.
+
+See the canonical contract for the full force-write-first rule and `--dry-run` short-circuit:
+
+```
+~/.config/opencode/shared/references/visual-mode.md
+```
+
+---
+
+## Visual mode
+
+`--visual` is the single, shared visual decorator described in
+`~/.config/opencode/shared/references/visual-mode.md`. It is a
+**terminal decorator step** — it does not change how the plan is researched,
+dispatched, or relayed. It runs once, last, on the confirmed plan.
+
+**FORCE-WRITE-FIRST (mandatory for `/plan`)**: unlike the other planning
+skills, `/plan` writes **no** plan artifact by default — the plan stays
+in-chat. There is therefore nothing on disk to visualize. When `VISUAL_MODE` is
+set (and **not** `--dry-run`), the skill MUST:
+
+1. **Write the otherwise-inline plan to a concrete file path first.** Default:
+   `docs/prps/plans/<slug>.plan.md` (absolute path; directory created if
+   missing). This forced write happens even though it would normally be skipped.
+2. **Then invoke** `visual-plan <absolute-plan-path>` with that absolute
+   path.
+
+Without the forced write there is no input for `visual-plan`, so the
+force-write is required, not optional. Under `--dry-run` this is moot: the
+skill prints `visual generation would run` and forces no write (see §2.1 and §4
+of the canonical reference). `visual-plan` derives its `visual/` output
+directory relative to the plan path it is handed and never edits the plan file.
 
 ---
 

--- a/.opencode-plugin/skills/prp-plan/SKILL.md
+++ b/.opencode-plugin/skills/prp-plan/SKILL.md
@@ -34,6 +34,7 @@ Extract flags from `$ARGUMENTS`:
 | `--no-worktree` | Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.                                                                                                                                                                                            |
 | `--dry-run`     | Only valid with `--team`. Prints the team name and teammate roster, then exits without spawning any teammates.                                                                                                                                                                                                               |
 | `--enhanced`    | Enhanced research mode: grow the research fan-out from 3 to 7 specialized researchers (api/business/tech/ux/security/practices/recommendations — same coverage as feature-research). Output is still a single PRP-compliant plan file. Composes with --parallel (default), --team (Claude Code only), and --no-worktree. |
+| `--visual`      | Render the finished plan as an Agent-Native visual artifact (MDX) via `visual-plan`; local-files by default, hosted shareable link requires `--share`.                                                                                                                                                                   |
 
 Strip the flags. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `DRY_RUN=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). Remaining text is the feature description or PRD path.
 
@@ -51,6 +52,12 @@ case " $ARGUMENTS " in
   *" --enhanced "*) ENHANCED_MODE=true ;;
 esac
 ARGUMENTS="${ARGUMENTS//--enhanced/}"
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
 **Validation**:
@@ -59,6 +66,7 @@ ARGUMENTS="${ARGUMENTS//--enhanced/}"
 - `--dry-run` requires `--team`. If `DRY_RUN=true` and `AGENT_TEAM_MODE=false` → abort with: `--dry-run requires --team.`
 - `--no-worktree` is **orthogonal** to `--parallel` and `--team` — it may be combined freely with either flag or used alone to suppress annotations.
 - If `--enhanced` is passed without `--parallel` or `--team`, default to standalone sub-agent dispatch (Path B equivalent at width 7). If `--enhanced --team` is invoked from a Cursor or Codex bundle, abort with the same compatibility message used today for plain `--team`. If `--dry-run` is passed, it requires `--team` (same constraint as today); `--enhanced --dry-run` alone is invalid.
+- `--visual` is orthogonal — it composes with `--parallel`/`--team`/`--enhanced`/`--no-worktree` and runs after the plan is written and validated. `--dry-run` short-circuits it (prints intent only).
 
 **Compatibility note**: When this skill is invoked from a Cursor or Codex bundle, `--team` must not be used (those bundles ship without team tools). Use `--parallel` instead.
 
@@ -385,6 +393,23 @@ Include a brief note in the report: "Plan validated with N warning(s) — see va
 
 ---
 
+## Phase 7 — VISUALIZE (optional)
+
+This step runs after the plan is written (Phase 6) and validated (Phase 6.5), regardless of the dispatch path taken (`--parallel`, `--team`, or sequential):
+
+- If `VISUAL_MODE=true` and `--dry-run` is NOT set, invoke `visual-plan <plan-path>` — passing the absolute path of the just-written `docs/prps/plans/{name}.plan.md` — and capture its printed link.
+- If `--dry-run` is set, print `visual generation would run` and skip the invocation.
+
+---
+
+## Visual mode
+
+This skill exposes the shared `--visual` decorator. The canonical contract lives at `~/.config/opencode/shared/references/visual-mode.md` — follow it for composition, timing, and hand-off rules.
+
+When `VISUAL_MODE` is set and `--dry-run` is NOT, the skill invokes `visual-plan <absolute-plan-path>` AFTER Phase 6, passing the just-written `.plan.md` path (the file written in Phase 6 and validated in Phase 6.5). `visual-plan` derives its own `visual/` output directory from that path and prints the resulting link; the skill surfaces that link in the Report block. When `--dry-run` is set, print `visual generation would run` and skip — no visual artifacts, directories, or links are produced.
+
+---
+
 ## Output
 
 ### Update PRD (if input was a PRD)
@@ -408,6 +433,8 @@ Update the phase status from `pending` to `in-progress` and add the plan file pa
 - **Research Dispatch**: [Sequential | Parallel sub-agents | Agent team | Enhanced (7 researchers)]
 - **Execution Mode**: [Sequential | Parallel (N batches, max width X)]
 - **Worktree Mode**: [Enabled (default) — plan includes ## Worktree Setup (single feature worktree — **Parent**: line only) | Disabled via --no-worktree]
+- **Visual Artifact**: [Generated via visual-plan | n/a (--visual not set)]
+- **Visual Link**: [hosted URL | http://127.0.0.1:PORT/... | local files only | n/a (--visual not set)]
 
 > Next step: Run `/prp-implement docs/prps/plans/{name}.plan.md` to execute this plan.
 ```

--- a/.opencode-plugin/skills/visual-plan/SKILL.md
+++ b/.opencode-plugin/skills/visual-plan/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: visual-plan
+description: Turn an existing text plan into a rich, interactive visual plan — diagrams,
+  file maps, annotated code, open questions, and an optional UI/prototype review surface.
+  Read-only with respect to the plan file. Use when the user asks to "make this plan
+  visual", "render a visual plan", "create a wireframe/canvas for this plan", "visualize
+  the implementation plan", says "/visual-plan", or when a planning skill hands off
+  via the shared `--visual` decorator.
+---
+
+# Visual Plan (Agent-Native Plans)
+
+Turn an ordinary text plan into a structured, reviewable visual plan. Build the
+plan a reader would normally skim in Markdown, but as a scannable document with
+editable blocks mixed in: inline diagrams, annotated code, open questions, and
+an optional top visual review surface (wireframe canvas, live prototype, or both
+in tabs). Architecture and backend plans stay document-only; UI and product
+plans start with the top canvas/prototype.
+
+`visual-plan` is the packaged entry point (slash command `/visual-plan`). It
+**consumes an existing plan** handed to it — it does not research, dispatch, or
+re-plan. The runtime is the Agent-Native Plans CLI/MCP connector; its install
+pin, auth/reconnect flow, connector names, localhost bridge, block-catalog
+lookup, and egress policy are defined ONCE in
+`~/.config/opencode/shared/references/agent-native-setup.md`. Read
+that file for any setup/auth/serve/egress detail rather than memorizing it here.
+
+## Contract (read first)
+
+This skill is the hand-off target of the shared `--visual` decorator. The full
+contract lives in `~/.config/opencode/shared/references/visual-mode.md`.
+The non-negotiable invariants:
+
+- **Accept ANY plan path.** Never assume `docs/prps/plans` or any fixed
+  location. The plan path is supplied by the caller and may live anywhere.
+- **Derive `visual/` relative to the given plan path.** Output goes into a
+  `visual/` sibling of the plan file — `<dirname of plan>/visual/` — computed
+  from the path handed in, never hardcoded.
+- **NEVER edit the plan file.** Read it; write only into the derived `visual/`
+  directory. The plan artifact stays byte-for-byte intact.
+- **NEVER re-run research or dispatch.** Only consume the existing plan.
+- **Print exactly one resulting link to stdout** — a hosted shareable URL, a
+  localhost preview `http://127.0.0.1:PORT/...`, or `local files only`.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- **`<path/to/plan.md>`** (required positional) — absolute or repo-relative path
+  to the source plan. Read it; derive `visual/` from its directory.
+- **`--share`** (optional, **consent flag**) — the explicit, named opt-in to
+  hosted egress (destination `plan.agent-native.com`). Without it, the skill
+  runs in **local-files** mode and nothing leaves the machine. See **Egress &
+  consent** below.
+
+## Mode selection (auto)
+
+Choose the review surface from the source plan's content — do not add visual
+chrome by default:
+
+- **UI-first** — work is primarily product UI; review should start with screens.
+  Top canvas is the primary surface (`create-ui-plan`).
+- **prototype-first** — review should start with a functional live prototype;
+  interaction is the main question (`create-prototype-plan`).
+- **design-first** — review needs full-fidelity branded screens
+  (`create-plan-design`).
+- **visual-intake** — only when the user explicitly asks for a questionnaire
+  before planning (`create-visual-questions`). Never run it as `/visual-plan`
+  preflight.
+- **document-only** — architecture, backend, data, refactor, or API plans get NO
+  top canvas; inline `diagram` blocks sit next to the relevant prose
+  (`create-visual-plan`).
+
+When the source plan is already a Codex / opencode / Markdown / pasted plan,
+use it as `planText` and build the review surface from it instead of starting
+over. Preserve its useful intent and codebase facts; publish a clean standalone
+proposal (no "this revision changes…" framing).
+
+## Block vocabulary — resolve at USE TIME
+
+> The MDX block vocabulary drifts upstream between releases. Do NOT author from a
+> memorized tag list — not from this skill, not from the references.
+
+At author time (use time), fetch the live block catalog FIRST:
+
+- Hosted / connected: call the **`get-plan-blocks`** MCP tool.
+- Offline / `local-files`: run `plan blocks --out <path>` (per
+  `agent-native-setup.md`) and read that file.
+
+Render plan MDX against the freshly-fetched list. The references in this skill
+describe block _families_ and quality bars; the catalog is the authority on
+exact tag names, required fields, and prop shapes.
+
+## Core workflow
+
+1. **Read the source plan.** Read the file at the given path (read-only). Derive
+   the output dir with the thin helper (it computes the `visual/` sibling per the
+   contract and never hardcodes a location):
+
+   ```
+   OUT="$(~/.config/opencode/skills/visual-plan/scripts/derive-visual-dir.sh <plan> --mkdir)"
+   ```
+
+   Gather the plan's exact text — do not invent source content.
+
+2. **Resolve blocks.** Call `get-plan-blocks` (or the offline `plan blocks`
+   fallback) for the authoritative catalog before authoring any MDX.
+3. **Create the plan** with the mode-matched create tool (see Mode selection),
+   passing the source as `planText`. For UI/product plans, compose the top canvas
+   first with the primary wireframes and annotated states, then write the
+   document body with native blocks. For non-visual plans, skip the top surface
+   and place `diagram` / `code` / `annotated-code` / `table` blocks next to the
+   relevant prose.
+4. **Emit files** into the derived `visual/` dir: `plan.mdx` plus, when a canvas
+   is used, `canvas.mdx` (and `prototype.mdx` for prototype plans). These are the
+   portable source artifacts (per `visual-mode.md`).
+5. **Surface the link.** Print exactly one link to stdout (see Contract). In
+   local-files mode this is the localhost bridge URL from `plan local serve`
+   (127.0.0.1, ephemeral port) or `local files only` if no server is available.
+   With `--share`, it is the hosted shareable URL returned by the create tool.
+6. **Read feedback** with `get-plan-feedback` before editing, after review, and
+   before the final response. Treat anchor details and resolver intent as the
+   source of truth for what each comment points at.
+7. **Apply changes** with `update-visual-plan`, preferring targeted
+   `contentPatches`: `patch-wireframe-html`, `patch-diagram-html`, `update-block`,
+   `replace-blocks`, `update-rich-text`, plus `read-visual-plan-source` /
+   `patch-visual-plan-source` for source-control-friendly MDX edits. Treat the
+   top-level `content` payload as a full replacement, never a partial merge — if a
+   full replacement is unavoidable, read the complete source first and carry
+   forward every existing block and surface.
+
+## Quality references — read before authoring
+
+These are provider-neutral quality bars. Read the relevant one IN FULL before
+authoring; do not paraphrase from memory:
+
+- `~/.config/opencode/skills/visual-plan/references/document-quality.md` — the
+  plan-document quality bar and block families.
+- `~/.config/opencode/skills/visual-plan/references/canvas.md` — canvas /
+  artboard / annotation mechanics and patch ops.
+- `~/.config/opencode/skills/visual-plan/references/wireframe.md` — the HTML
+  wireframe quality bar (`.wf-*` tokens, surfaces, icons, skeletons).
+- `~/.config/opencode/skills/visual-plan/references/exemplar.md` — a worked
+  example plus the anti-patterns to avoid.
+
+## Planning is read-only
+
+Make NO source edits while building or reviewing the visual plan, and never edit
+the input plan file. Begin editing code only after the user approves the
+direction. The plan is the approval gate: surface it, name which files/areas the
+work touches, and request sign-off.
+
+## Egress & consent (default OFF)
+
+Hosted upload is **OFF by default** and **consent-gated**. The full policy lives
+in `~/.config/opencode/shared/references/agent-native-setup.md`;
+the operational rules for this skill:
+
+- **Default = `local-files`.** Set `AGENT_NATIVE_PLANS_MODE=local-files`. In this
+  mode the runtime reads/writes plan files locally and never contacts
+  `plan.agent-native.com`. Preview via the localhost bridge
+  (`plan local serve --dir <OUT> --open`), which binds 127.0.0.1 on an ephemeral
+  port, performs no DB writes, and sends nothing remote — this is **not** egress.
+- **`--share` is the only opt-in.** It names the destination host
+  `plan.agent-native.com`. Only when the operator passes `--share` may any plan
+  content leave the machine.
+- **Route all hosted egress through the guard.** Before any MDX/diff payload is
+  uploaded, run:
+
+  ```
+  ~/.config/opencode/shared/scripts/visual-egress-guard.sh \
+    --payload <OUT> --destination plan.agent-native.com \
+    --consent plan.agent-native.com
+  ```
+
+  The guard scans the payload for secrets, refuses non-public/private remotes,
+  and requires a consent token matching the destination. If it exits non-zero,
+  STOP — do not upload; report the gate that failed.
+
+## Setup, auth, and the localhost bridge
+
+Do not duplicate install/reconnect/serve commands here. For the pinned install
+version, the one-time per-client reconnect, the `plan` MCP connector (legacy
+alias `agent-native-plans`), local-files mode, and the localhost bridge
+(`plan local check` / `plan local serve`), read
+`~/.config/opencode/shared/references/agent-native-setup.md`. If a
+Plans tool returns `needs auth` / `Unauthorized` / `Session terminated`, stop and
+give the user the reconnect step from that reference — never reinstall from
+scratch to fix auth, and never fall back to inline chat-only plan output.
+
+## Output
+
+Exactly one of the following is printed to stdout, per the `visual-mode.md`
+contract:
+
+- a hosted shareable URL under `https://plan.agent-native.com` (only with
+  `--share`, after the egress guard passes), or
+- a localhost preview `http://127.0.0.1:PORT/...` (default local-files mode), or
+- `local files only` when no server/host is available.
+
+The calling planning skill surfaces whatever link this skill prints.

--- a/.opencode-plugin/skills/visual-plan/references/canvas.md
+++ b/.opencode-plugin/skills/visual-plan/references/canvas.md
@@ -1,0 +1,121 @@
+# Canvas & artboard placement — single source of truth
+
+The canonical guide for how the visual-plan canvas works: artboard placement,
+lane layout, annotations, patching, and emitted files. Read it in full before
+authoring or editing any canvas/artboard content; do not author canvas layouts
+from memory. Resolve exact block/component tag names against the live catalog
+(`get-plan-blocks` or the offline `plan blocks` dump).
+
+---
+
+## Canvas block families
+
+A plan canvas is composed from these block families (resolve exact tag names and
+props via the catalog):
+
+- **`<DesignBoard>`** — the canvas root that holds the artboards and annotations.
+- **`<Section>`** — groups related artboards into a labeled region/lane.
+- **`<Artboard>`** — a single fixed-footprint frame; its size/aspect is locked by
+  `surface` (see `wireframe.md`). Carries an `html` wireframe or references a
+  wireframe block via `blockId`.
+- **`<Screen>`** — a product screen surface inside the board (a UI state under
+  review).
+- **`<Annotation>`** — a plain-text designer note anchored to a frame by
+  `targetId` + `placement`.
+- **`<Connector>`** — an arrow between neighboring steps of a real sequence.
+
+## Emitted files
+
+- `plan.mdx` — frontmatter plus markdown/document blocks (the plan body).
+- `canvas.mdx` — the `<DesignBoard>` / `<Section>` / `<Artboard>` / `<Screen>` /
+  `<Annotation>` / `<Connector>` tree.
+- `prototype.mdx` — present only for prototype plans (the functional flow).
+
+JSON is the canonical runtime shape; MDX is the repo-friendly authoring/export
+surface. Both live under the derived `visual/` directory.
+
+## The coordinate rule
+
+The `surface` locks each artboard's footprint and aspect — **never** set artboard
+width/height and **never** use coordinates inside the wireframe HTML. Board-level
+artboard `x`/`y` IS allowed when it creates clear lanes. Let canvas
+auto-placement handle simple one-row boards. Sizing is always via `surface`, not
+explicit pixels.
+
+## Lay out mixed canvases in lanes
+
+When a canvas contains broad `browser` / `desktop` frames plus compact `mobile`,
+`popover`, or `panel` surfaces, do not put everything in one horizontal strip.
+Use board-level artboard `x`/`y` to reserve lanes with generous empty space: main
+flow on one row, compact surfaces in their own column or row, loading/error
+states in a lower row. Keep at least **96px** between rendered artboard rectangles
+plus room for annotation gutters. Connect only neighboring steps; never draw a
+long connector that skips across unrelated frames. Before handoff, inspect the
+top canvas at default zoom and move any frame whose label, connector, or
+annotation crosses another frame.
+
+## Annotations are designer notes on the artboard
+
+When a top canvas is present, sprinkle Figma-style notes near the frames they
+explain: a short heading, supporting text, and bullets — plain text layers, never
+bordered or shadowed cards, and never a box around a frame. The renderer spaces
+notes away from frames, so place each note by the frame it describes. Use an
+arrow (`<Connector>`) only to point at one specific control or transition; for a
+broad frame-level note, write text beside the frame with no connector.
+
+**Do not create overlapping annotations.** Anchor each ordinary note to the frame
+it explains with `targetId` + `placement` (top/right/bottom/left), and omit
+`type` or use `type: "note"`. The renderer parks notes in a gutter beside the
+frame and lays them out automatically. Do not use `type: "callout"`,
+`type: "text"`, `type: "arrow"`, x/y, or points for ordinary notes; those are
+freeform review-markup layers reserved for intentional markup in open canvas
+space. Connectors are for real sequences only — never fake "Step 1 → Step 2"
+lines between independent states.
+
+## Patching
+
+Edit one wireframe, canvas annotation, diagram, or block with targeted
+`contentPatches` rather than regenerating the whole plan:
+
+- `patch-wireframe-html` — edit the HTML of one artboard's wireframe.
+- `patch-diagram-html` — edit the HTML/SVG of one diagram.
+- `update-block` / `replace-blocks` — replace a block by stable id.
+- `update-canvas-annotation` — edit one annotation.
+- `read-visual-plan-source` / `patch-visual-plan-source` — granular MDX AST
+  patches by stable block, artboard, annotation, component, or wireframe-node id
+  when working from exported source files.
+- `update-rich-text` — prose edits (agents use this or source patches; humans
+  edit prose inline in the browser).
+
+`contentPatches` are part of the public MCP action schema, so every host can make
+surgical edits. **Never** send a partial top-level `content` object as a shortcut
+to add a canvas, frame, or block: `content` is a full structured replacement, so
+omitted blocks or surfaces disappear. If a full replacement is truly unavoidable,
+read the complete source/JSON first, include every existing block and surface in
+the new payload, and verify the source/export immediately after the update.
+
+## Never emit a titled artboard with no interior wireframe content
+
+Every artboard must carry an `html` wireframe or reference a wireframe block via
+`blockId`; when using `blockId`, the referenced wireframe block must remain in the
+plan. If you remove a duplicate wireframe from the document body, first move its
+`data` inline onto the corresponding canvas frame. A label-only frame or a frame
+pointing at a deleted block renders empty and is rejected at parse time. If you
+only have a title, write it as a section header or annotation, not an empty
+artboard.
+
+## UI mockups belong in the top visual review area
+
+Static UI/product visuals live on the canvas; multi-step UI flows get both canvas
+wireframes and a `prototype`. When the user asks for a mockup, UI state, loading
+state, layout, screen, or visual comparison, make the canvas the primary home for
+that static visual. Architecture/code diagrams stay inline in the document
+(`document-quality.md` owns that rule) unless the user explicitly asks for a
+spatial board. A skeleton/loading mockup also lives in a canvas artboard — never
+move a mockup out of the canvas into a `custom-html` document block.
+
+For abstract product concepts, use the canvas to create the first "I get it"
+moment: one real app state near the top showing how the concept appears to a
+user, followed by separate annotations or diagrams for mechanics. Do not make the
+first artboard a hybrid of app UI and architecture notes; the app screen should be
+inspectable as product UI on its own.

--- a/.opencode-plugin/skills/visual-plan/references/document-quality.md
+++ b/.opencode-plugin/skills/visual-plan/references/document-quality.md
@@ -1,0 +1,169 @@
+# Plan document quality — single source of truth
+
+The canonical quality bar for the plan document below the canvas: how it reads,
+which block families to use, how open questions are surfaced, and the pre-handoff
+check. Read it in full before authoring the plan document. Resolve exact tag
+names and field shapes against the live catalog (`get-plan-blocks`, or the
+offline `plan blocks` dump) — the families below are the bar, the catalog is the
+authority.
+
+---
+
+**The document is a serious technical plan, not marketing.** Write it the way a
+strong implementation plan reads: outcome-first, prose-first, self-contained, and
+specific. State the objective and what "done" means, the scope and non-goals, the
+proposed approach with key decisions and their rationale, ordered steps that name
+real files / symbols / actions / data shapes, the risks, and a closing
+verification step (tests, build, or a checkable behavior). Replace vague prose
+with specifics; never ship a step like "make it work." No hero art, gradients,
+logos, nav bars, slogans, value props, giant landing-page headings, or marketing
+cards unless the user explicitly asks.
+
+**Every published plan must stand alone.** Even when revising an existing plan,
+the output is a plan to do the work, not a changelog of the conversation. Do not
+write phrases like "preserve the previous plan", "do not drop the old idea", "as
+discussed above", "this revision", "unlike the prior version", or "correction
+from the earlier plan". Fold the right decisions into the plan as normal
+objective, architecture, scope, and roadmap prose. A reviewer who opens the plan
+from a link with no chat history should understand it. Avoid negative framing
+that only makes sense against absent context ("not the old mode", "not just X")
+unless the contrast is defined in the plan and genuinely helps; state the
+positive model directly.
+
+**Make abstract plans instantly legible.** If the idea is broad, strategic, or
+intended for a third-party reviewer, put one concrete product snapshot near the
+top before dense architecture, mode tables, manifests, or roadmaps. For
+UI-capable concepts, that snapshot is usually a top-canvas app state plus a short
+paragraph that says what the user sees and what changes under the hood. Then put
+mechanics, data flow, sync boundaries, and implementation detail in separate
+diagrams or document sections.
+
+**Preserve the user's level of abstraction.** A motivating use case is not
+automatically the architecture. When the prompt describes a broader framework,
+product mode, or reusable primitive, separate the reusable core from specific
+apps, providers, customers, scripts, or launch examples. Use the concrete example
+to make the plan understandable, then make clear which parts are core, which are
+app-specific adapters, and which are future examples.
+
+**When top visuals exist, they and the document never duplicate each other.** For
+UI work, the UI story lives in the top visual surface: canvas artboards for static
+inspection, plus prototype tabs when the flow should be functional. The document
+carries the technical depth the visuals cannot show — concrete file/symbol maps,
+API and data contracts, code snippets, migration or implementation phases, risks,
+and validation. For architecture/code reviews, invert that: the document is the
+visual surface, and each recommendation carries its own nearby inline `diagram`
+block plus file evidence. Repeat a wireframe in the document only for a genuinely
+new detail view or comparison. Skip the visual surface entirely for non-visual
+work and write a clean rich document.
+
+## Block families (resolve exact tags via `get-plan-blocks`)
+
+Use the right block, and make it carry substance:
+
+- **`rich-text`** — plan prose with real bold/italic/code/links and nested lists.
+- **`annotated-code`** — the file map: for a load-bearing file, prefer the
+  annotated walkthrough over a bare `code` block. Carry the real,
+  syntax-highlighted code AND anchor short margin notes to the lines that
+  actually change (the new action, the changed schema, the wiring point). Each
+  annotation is `{ lines: "12" | "12-18"; label?; note }`; keep a few high-signal
+  notes per file, not one per line. Highlight only files worth reading.
+- **`code`** — a throwaway snippet with nothing to call out. When more than one
+  file matters, group blocks in a vertical `tabs` block rather than a bespoke
+  container.
+- **`tabs`** — multiple states, directions, or comparisons. A tab that reveals
+  only prose usually means the plan is under-specified — include a relevant visual
+  unless the tab is intentionally document-only.
+- **`columns`** — side-by-side before/after or current/target comparisons where
+  each side needs real nested blocks; label the columns clearly.
+- **`diagram`** — two-dimensional architecture, dependency, data-flow, or state
+  relationships, only when it clarifies something real. See **Diagram primitives**
+  below.
+- **`table`** — scannable structured data.
+- **`checklist`** — copy the catalog example verbatim: items need `id` and
+  `label`.
+- **`callout`** — for a decision you have committed to, use `tone="decision"`
+  (optionally with a `columns` block weighing the options). Use other tones for
+  concise assumptions or risks in the relevant section.
+- **`question-form`** — the bottom-only Open Questions block (see below).
+- **`custom-html`** — a bounded escape hatch only (see below).
+
+## Decisions
+
+- If the reviewer must still pick between a genuinely-open either/or, put it in
+  the bottom Open Questions `question-form` as a `single` question — one option
+  per real alternative, each with a short detail and `recommended: true` on the
+  one you would choose. Do not also restate the same choice elsewhere.
+- If you have already committed to an approach, state it as settled prose or a
+  `callout` with `tone="decision"` — never as a confusing mid-document form for a
+  question you have already answered.
+
+## Diagram primitives
+
+For architecture/code diagrams, prefer `data.html` / `data.css` with semantic
+HTML and inline SVG so the diagram can use panels, layers, matrices, arrows,
+annotations, and responsive layout directly. Author with renderer-owned
+primitives: `.diagram-panel`, `.diagram-card`, `.diagram-node`, `.diagram-box`,
+`.diagram-pill`, `.diagram-muted`, and `[data-rough]` for sketchy mode. They map
+to the theme variables `--wf-ink`, `--wf-muted`, `--wf-line`, `--wf-paper`,
+`--wf-card`, `--wf-accent`, `--wf-accent-soft`, `--wf-warn`, and `--wf-ok`, and
+switch to the sketch font plus rough.js outlines in sketchy mode.
+
+- Do NOT set `font-family` and do NOT hard-code hex, rgb, or hsl colors in
+  diagram HTML or CSS.
+- Prefer standard two-dimensional layouts — paired before/after panels, layered
+  diagrams, swimlanes, dependency maps, matrices, or grouped regions; do not
+  default to left-to-right chains, and use a line only when the relationship is
+  truly a sequence.
+- Leave room for the sketch font: keep labels short, give nodes generous width,
+  and place boundary/annotation labels in unused space — labels must not overlap
+  nodes, connectors, or each other.
+- For small text/SVG changes to an existing HTML diagram, use **`patch-diagram-html`**
+  with a unique `find`/`replace` snippet instead of resending the whole
+  `data.html` string. Use legacy `nodes` / `edges` only for small previews or
+  truly sequential flows.
+
+## Open questions live at the bottom as a form
+
+Surface answerable unresolved decisions in a final `question-form` block titled
+"Open Questions" so the renderer presents it as a distinct section. That bottom
+form is the ONLY place that enumerates the open questions: never add a second
+"Open Questions" heading, list, or recap of the same questions earlier in the
+document. A one-line pointer in the overview prose ("a few decisions are still
+open — see Open Questions below") is fine.
+
+- Use `single` or `multi` for clear choices, `freeform` for constraints,
+  `recommended: true` for the default you would pick. `single`/`multi` questions
+  always render a write-in field, so never add an explicit "Other" option
+  yourself; set `allowOther: false` only when a free-text answer makes no sense.
+- Copy the catalog example verbatim for required fields: each question needs
+  `id`, `title`, and `mode`; each option needs `id` and `label`.
+- Keep non-answerable assumptions or risks as concise `callout` blocks in the
+  relevant section. Never bury a questions/decisions wall inside the plan
+  narrative, and never ask the same question twice.
+
+For complex plans, do not end without an open-question audit. If architecture,
+scope, UX, data shape, rollout, provider mapping, or ownership still depends on a
+choice, either commit to a recommendation with rationale or add it to the bottom
+form with a recommended default.
+
+## `custom-html` is a bounded escape hatch only
+
+A single complete fragment inside a block, never `html`/`head`/`body`/`script`
+tags, never a generic placeholder, density demo, or proof that custom HTML works.
+Prefer native blocks for normal plans. For architecture/code reviews, use
+`diagram` `data.html` / `data.css` for rich local HTML/SVG diagrams instead of
+`custom-html`. For UI/product work, `custom-html` is never the primary home for a
+requested mockup, UI state, or visual comparison.
+
+## Verification must exercise the real workflow
+
+The final verification section should go beyond typecheck/unit tests when the
+plan changes UI, local files, sync, providers, browser behavior, or multi-app
+flows. Include at least one end-to-end smoke that matches the user journey — a
+fresh repo/folder, real manifest or data fixture, browser interaction, save/sync
+action, and an on-disk or database assertion. Name the command or manual browser
+path when it is known.
+
+**Before handoff, open the plan and check it.** Fix overlap, excessive
+whitespace, clipped fragments, misleading inactive controls, poor contrast, and
+unreadable diagrams before asking for approval.

--- a/.opencode-plugin/skills/visual-plan/references/exemplar.md
+++ b/.opencode-plugin/skills/visual-plan/references/exemplar.md
@@ -1,0 +1,113 @@
+# Good vs. bad exemplar — single source of truth
+
+The canonical worked example of a great plan (and the anti-patterns to avoid).
+Read it alongside `document-quality.md` and `canvas.md` before authoring a plan;
+it is the bar these plans must clear. Resolve exact block tags against the live
+catalog (`get-plan-blocks` / offline `plan blocks` dump) before emitting MDX.
+
+---
+
+## A worked example — UI-first plan MDX
+
+The following sketch shows the _shape_ of a strong UI-first plan: a top canvas
+with one real `desktop` artboard, plain-text designer notes off the frame, then a
+serious document below it. Treat the tags as families — confirm exact names/props
+against the catalog.
+
+```mdx
+---
+title: Inbox triage redesign
+mode: ui-first
+---
+
+{/* canvas.mdx — the top review surface */}
+
+<DesignBoard>
+  <Section label="Triage view">
+    <Artboard id="inbox-default" surface="desktop" label="Inbox — default">
+      {/* data.html is a real flex layout: a sidebar of links
+          (Inbox 12, Today 4, Done), a main column headed "Today",
+          accent .wf-pill filters, a muted "OVERDUE" section label,
+          and .wf-card task rows with real titles, due dates, and a
+          button.primary — styled only via bare elements, helper
+          classes, and --wf-* tokens. */}
+    </Artboard>
+    <Annotation targetId="inbox-default" placement="right">
+      Overdue items float to the top; the primary action stays in the header so triage never scrolls.
+    </Annotation>
+  </Section>
+</DesignBoard>
+
+{/* plan.mdx — the document body */}
+<rich-text>
+
+## Objective
+
+Cut inbox triage from many clicks to one. "Done" means an overdue item
+can be deferred or completed from the row without opening it.
+</rich-text>
+
+<tabs>
+  {/* one `code` / `annotated-code` block per load-bearing file:
+      the new defer action, the changed query, the row component */}
+</tabs>
+
+<callout tone="decision">
+  Defer writes a `snoozedUntil` timestamp rather than moving the row to a separate table — see the columns block for the
+  two options weighed.
+</callout>
+
+<question-form title="Open Questions">
+  {/* single/multi questions for genuinely-open decisions, each option
+      with id + label, recommended: true on the default */}
+</question-form>
+```
+
+If the task also changes a multi-step completion flow, the same top area gains a
+Prototype tab whose screens reuse the canvas labels and states.
+
+## GOOD — the bar
+
+- **UI-first todo/inbox plan.** A canvas `desktop` artboard whose `data.html` is a
+  real flex layout (sidebar links, a "Today" heading, accent `.wf-pill` filters, a
+  muted `OVERDUE` label, `.wf-card` task rows with real titles/dates and a
+  `button.primary`), styled only through bare elements, helper classes, and
+  `--wf-*` tokens. Plain-text designer notes sit spaced off the frame, pointing
+  only at controls that need explanation. Below it, a strong document: objective
+  and done-criteria, a few `code` blocks (grouped in a vertical `tabs` block when
+  more than one) showing the real shape of load-bearing files, a `callout` with
+  `tone="decision"` stating the chosen approach with a `columns` block weighing the
+  two real options, and a validation step — none of it repeating the canvas.
+- **Broad product-architecture plan.** Opens with a plain recommendation and one
+  concrete app state before the abstraction. The first canvas artboard is pure
+  product UI that matches the current app shell; nearby notes explain the
+  user-visible delta. A separate `diagram` below shows the mechanics. The document
+  separates the reusable core from app/provider adapters and examples, covers
+  contracts and schema shape, roadmap, non-goals, a bottom Open Questions form, and
+  a verification section with at least one realistic end-to-end smoke.
+- **Backend architecture review.** No top canvas. The document opens with context
+  and a legend, then repeats recommendation cards: title, confidence/category
+  badges, a monospace grid of real file paths, one inline two-dimensional
+  before/after or layered architecture `diagram` (using space to show boundaries
+  and ownership, not a default left-to-right chain), and terse
+  Problem/Solution/Why bullets in the codebase's vocabulary. Ends with a top
+  recommendation and a bottom `question-form` only if the next direction is
+  genuinely open.
+
+## BAD — never produce this
+
+- A `data.html` with hard-coded hex colors, a `font-family`, or fixed pixel
+  width/height.
+- Gray placeholder bars "insinuating" text on a non-skeleton frame.
+- A forced `desktop` + `mobile` pair for a popover.
+- Floating bordered annotation cards hugging the frames.
+- A multi-step UI flow with only static frames and no prototype tab.
+- A mockup escaped into a document `custom-html` block.
+- A marketing-style document with a hero heading and value props that just
+  restates what the canvas already shows.
+- An architecture-only plan forced into a top canvas of labeled boxes with
+  overlapping text, where the real code evidence lives elsewhere.
+- A product wireframe that mixes a real screen with repo names, file-contract
+  arrows, architecture explanations, or a made-up permanent inspector.
+- A plan that describes itself as a revision of a prior conversation instead of a
+  standalone proposal.

--- a/.opencode-plugin/skills/visual-plan/references/wireframe.md
+++ b/.opencode-plugin/skills/visual-plan/references/wireframe.md
@@ -1,0 +1,210 @@
+# HTML wireframe quality — single source of truth
+
+The canonical quality bar for HTML wireframe content. Read it in full before
+authoring ANY wireframe; do not author wireframes from memory or paraphrase these
+rules per mode.
+
+---
+
+**A wireframe is an HTML mockup. The renderer owns the look; you write the
+content.** Set `data.html` to a self-contained, semantic HTML fragment of the
+screen and set `data.surface`. The renderer owns the surface footprint/aspect, the
+dark/light theme, the hand-drawn font, and the sketch overlay — you never write
+`<style>` / `<link>` / `<font>` tags or any width/height/coordinates. You write
+real HTML layout and real product content; the renderer styles and roughens it.
+
+**A wireframe block's data is an HTML screen plus a surface:**
+
+```json
+{
+  "surface": "browser",
+  "html": "<div style=\"display:flex;flex-direction:column;gap:10px;padding:16px;height:100%\"><h1>Sign in</h1><p class=\"wf-muted\">Use your work email to continue.</p><div class=\"wf-card\" style=\"display:flex;flex-direction:column;gap:10px\"><label>Email<input value=\"jane@acme.co\" /></label><label>Password<input value=\"********\" /></label><label style=\"display:flex;align-items:center;gap:8px\"><input type=\"checkbox\" checked /> Remember me</label><button class=\"primary\">Sign in</button></div><a href=\"#\">Forgot password?</a></div>"
+}
+```
+
+**Write PLAIN semantic HTML and let the renderer style it.** Bare elements
+(`h1`/`h2`/`h3`, `p`, `button`, `input`, `label`, `a`, `hr`) are auto-themed — no
+classes needed. Helper classes carry the rest:
+
+- `.wf-card` / `.wf-box` — a bordered, padded container (a panel, a list item).
+- `.wf-pill` / `.wf-chip` — a rounded tag or filter; add `.accent` for the
+  accent-filled variant.
+- `.wf-muted` — secondary/muted text.
+- `button.primary` or any element with `[data-primary]` — the accent-filled
+  primary button.
+
+**No decorative shadows around mockups.** Do not put `box-shadow`,
+`filter: drop-shadow(...)`, Tailwind `shadow-*` classes, or other fake depth on a
+wireframe frame, root container, `.wf-card` / `.wf-box`, or canvas artboard.
+Mockups should read as flat, bordered surfaces; use spacing, borders, labels, and
+annotations for separation. Only show a shadow when the real product UI already
+has it and it is essential to the change being reviewed.
+
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker with
+`[data-icon]` (e.g. `<span data-icon="search"></span>`). The renderer replaces it
+with a Tabler-style SVG and the `.wf-icon` class sizes it to the surrounding text.
+Supported names and aliases include: `mail`/`email`, `lock`/`password`, `search`,
+`plus`/`add`, `x`/`close`, `check`, `chevronDown`, `chevronUp`, `chevronLeft`,
+`chevronRight`, `dots`/`more`, `chevron`/`caret`/`dropdown` (down chevron), `user`,
+`settings`, `calendar`, `bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do
+not put visible words like "email", "lock", "search", "chevron", or "more" where
+the product UI would show an icon; use text only when it is a real label a user
+would read.
+
+**Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips
+these on light/dark, so referencing tokens is what keeps a mockup correct in both
+themes. For any inline border, background, or text color, reference a token:
+`style="border:1.4px solid var(--wf-line)"`. The tokens are `--wf-ink` (text),
+`--wf-muted` (secondary text), `--wf-line` (borders/dividers), `--wf-paper` (page
+background), `--wf-card` (container surface), `--wf-accent` / `--wf-accent-fg` /
+`--wf-accent-soft` (brand action), `--wf-warn`, `--wf-ok`, and `--wf-radius`.
+**Never hard-code a hex (or rgb/hsl) color and never set `font-family`** — the
+renderer owns the sketch/clean font.
+
+**Lay out with inline `style` flex/grid.** You write the real layout —
+`display:flex; flex-direction:column; gap:10px; padding:16px` — and the renderer
+never repositions anything. Compose the actual product: reproduce the current
+screen, then show the modification. Real labels, real counts, real dates, real
+button text grounded in the screen you read; not lorem or gray bars.
+
+**Surface presets — match the real footprint, never default to desktop+mobile.**
+Pick the `surface` that matches what the user will actually see:
+
+- `browser`: a web page that needs a browser chrome frame around it.
+- `desktop`: a full desktop app page or app shell.
+- `mobile`: a phone screen, only when the work is genuinely mobile.
+- `popover`: a small floating menu, dropdown, or inline popover.
+- `panel`: a side panel, inspector, or sidebar widget.
+
+A sidebar popover renders as a small surface, not a desktop page and a phone
+frame. Do not emit `desktop` + `mobile` variants unless responsive behavior
+actually changes the layout.
+
+**Model the actual component shell for small surfaces.** A rendered UI change
+belongs in a wireframe; reserve `diagram` for architecture, dependency, state, or
+data-flow relationships. Popovers, dropdown menus, command palettes, and context
+menus use `surface: "popover"` unless the surrounding page placement is the point
+of the change. Dialogs, sheets, inspectors, sidebars, and long property panels use
+the matching `panel` / `desktop` surface. Show the real chrome: trigger/anchor
+when it matters, title/header row, top-right actions, separators, fields, options,
+selected states, body content, and visible footer actions.
+
+**Modify, don't redesign.** When the task changes an existing screen, reproduce
+the current screen's real layout and footprint FIRST, then change only the delta
+and call it out with a single annotation. Do not restack the page into a new
+layout. For net-new surfaces, compose from the real app shell.
+
+**Keep product screens pure.** A product wireframe shows the app state a user
+would actually see. Do not embed file contracts, architecture arrows, repo pills,
+mode explanations, or implementation callouts inside the screen just to explain
+the plan. Put those in canvas annotations, a separate diagram, or the document
+body.
+
+**Zoom in on sub-surfaces, don't redraw the page.** For a small sub-surface (a
+popover, menu, dialog, toast), show the full screen once, then add a small
+separate artboard whose `html` contains ONLY that sub-surface — do not re-draw the
+whole page around it, and do not scale a duplicate up. Pick the matching `surface`
+(e.g. `popover`) so the footprint is right; never widen a popover to page width.
+
+**Loading / skeleton states.** Set `data.skeleton: true` on the wireframe and fill
+the `html` with neutral, textless placeholder geometry — boxes and bars built as
+`<div>`s with `background:var(--wf-line)` and explicit heights/widths, no labels
+or copy. The renderer drops borders, sketch, and color into the skeleton register
+automatically. Never escape to a `custom-html` document block to fake a loader.
+
+**Editing an existing mockup.** To change one element, text, or color, call
+`update-visual-plan` with
+`contentPatches: [{ op: "patch-wireframe-html", blockId, edits: [{ find, replace }] }]`.
+Each `find` is a unique snippet of the current html (read it first); set
+`all: true` on an edit to replace every occurrence. The result is re-sanitized.
+
+**Treat the wireframe border as part of the visible design.** Always wrap HTML
+wireframe content in a root container with real inner padding before drawing
+cards, fields, pills, labels, or controls. Use at least 14-16px of padding,
+`box-sizing: border-box`, `height: 100%`, and `gap` between child rows so the
+first row never sits flush against the screen border.
+
+**Lay out children safely so they never collide.** Use HTML flex/grid with `gap`,
+`min-width: 0`, and sensible overflow. Avoid negative margins, absolute
+positioning, or fixed child widths that can collide across light/dark, sketch/clean,
+or zoom levels.
+
+**Do not wrap intentionally single-line labels.** For toolbars, tab rails,
+breadcrumbs, chip/filter rows, branch and file names, and code filenames — any
+deliberately single-line row — put `white-space: nowrap` on the row (and
+`overflow: hidden; text-overflow: ellipsis` on labels that can grow). Use
+horizontally scrollable or clipped rails for overflow.
+
+**Fill the frame; keep labels short.** Each artboard is a fixed-size surface —
+compose enough realistic HTML to fill it top to bottom with even vertical rhythm;
+never leave a large empty band. On desktop/app-shell sidebars, let the nav stack
+flex to fill (`flex:1`) and add any persistent bottom action/status after it. On
+mobile, flow real rows down the whole screen rather than a header floating above a
+gap. Keep every label short enough to sit on one line within its column.
+
+**Persistent chrome bars span the full frame width.** Top bars, app headers,
+toolbars, and bottom tab/nav bars are full-width chrome, not centered content. Lay
+each one out as a single flex row that fills the frame
+(`style="display:flex;align-items:center;width:100%"`) and push trailing actions to
+the right edge with a flex spacer (`<div style="flex:1"></div>`) between the
+leading and trailing groups — never center a bar inside a narrow block, and never
+let it collapse to the width of its contents.
+
+**Pin bottom bars to the bottom of the frame.** For mobile tab bars, footers, and
+any persistent bottom action row, make the frame itself a flex column at
+`height:100%` (`style="display:flex;flex-direction:column;height:100%"`), give the
+scrolling body `flex:1`, and place the bar as the LAST child (or set
+`margin-top:auto`). The bar then sits flush at the bottom instead of floating with
+an empty band beneath it.
+
+**Before / after must be comparable.** When showing a state change, preserve the
+unchanged controls in both states so the reviewer can see exactly what moved or
+appeared; do not show an added control as a generic box floating elsewhere. Place
+the new/changed affordance where the implementation puts it. Use the same frame
+size, scale, outer padding, border radius, and visual density on both sides unless
+the change itself alters those properties.
+
+**Name the states with the column header, never inside the frame.** For
+document-body wireframes, put the two states in a `columns` block and set each
+column's `label` to `Before` and `After` — the renderer draws that label as a
+heading above each frame. Do NOT bake a `Before`/`After` pill, title, or heading
+into the wireframe `html`. On a canvas, place the two state artboards as neighbors
+with frame labels — never encode Before/After inside the html.
+
+**Let the surface choose side-by-side vs. stacked.** For document-body wireframes,
+the `columns` renderer lays narrow surfaces (`mobile`, `popover`, `panel`) out
+side by side, and automatically stacks wide surfaces (`desktop`, `browser`)
+vertically at full document width so a large frame is never crushed into a
+half-width column. Author both wireframes with the real `surface` and matching
+`Before`/`After` column labels.
+
+**Good example — a contacts list, surface `browser`.** A small, real screen
+composed from the helper classes and tokens, layout in inline flex, no fonts or
+hex colors:
+
+```html
+<div style="display:flex;flex-direction:column;gap:12px;padding:16px;height:100%">
+  <div style="display:flex;align-items:center;justify-content:space-between">
+    <h1>Contacts</h1>
+    <button class="primary">New contact</button>
+  </div>
+  <div style="display:flex;gap:6px">
+    <span class="wf-pill accent">All 128</span>
+    <span class="wf-pill">Favorites</span>
+    <span class="wf-pill">Archived</span>
+  </div>
+  <div class="wf-card" style="display:flex;flex-direction:column;gap:0;padding:0">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-bottom:1.4px solid var(--wf-line)">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Jane Cooper</strong><br /><small>jane@acme.co</small></div>
+      <span class="wf-pill">Lead</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Marcus Lee</strong><br /><small>marcus@globex.io</small></div>
+      <span class="wf-pill">Customer</span>
+    </div>
+  </div>
+</div>
+```

--- a/.opencode-plugin/skills/visual-plan/scripts/derive-visual-dir.sh
+++ b/.opencode-plugin/skills/visual-plan/scripts/derive-visual-dir.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# derive-visual-dir.sh — compute the visual/ output directory for a plan path.
+#
+# The visual-plan contract (skills/_shared/references/visual-mode.md) requires
+# the output to live in a `visual/` sibling of the input plan file, derived from
+# the path handed in — never hardcoded. This thin wrapper performs that single
+# derivation so the skill never improvises the path.
+#
+# Usage:
+#   derive-visual-dir.sh <path/to/plan.md> [--mkdir]
+#
+# Arguments:
+#   <path/to/plan.md>   Source plan path (absolute or relative). Must exist.
+#   --mkdir             Create the derived directory if it does not exist.
+#
+# Output:
+#   The derived visual/ directory path on stdout.
+#
+# Exit codes:
+#   0 - Derived (and created, if --mkdir) successfully
+#   1 - Usage error or plan path missing
+#
+set -euo pipefail
+
+_error() {
+  echo "derive-visual-dir.sh: error: $*" >&2
+}
+
+PLAN_PATH=""
+DO_MKDIR=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mkdir)
+      DO_MKDIR=1
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: derive-visual-dir.sh <path/to/plan.md> [--mkdir]" >&2
+      exit 0
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      exit 1
+      ;;
+    *)
+      if [[ -n "$PLAN_PATH" ]]; then
+        _error "unexpected extra argument: $1"
+        exit 1
+      fi
+      PLAN_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$PLAN_PATH" ]]; then
+  _error "a plan path is required"
+  echo "Usage: derive-visual-dir.sh <path/to/plan.md> [--mkdir]" >&2
+  exit 1
+fi
+
+if [[ ! -f "$PLAN_PATH" ]]; then
+  _error "plan file not found: $PLAN_PATH"
+  exit 1
+fi
+
+PLAN_DIR="$(cd "$(dirname "$PLAN_PATH")" && pwd)"
+OUT_DIR="${PLAN_DIR}/visual"
+
+if [[ "$DO_MKDIR" -eq 1 ]]; then
+  mkdir -p "$OUT_DIR"
+fi
+
+echo "$OUT_DIR"
+exit 0

--- a/.opencode-plugin/skills/visual-recap/SKILL.md
+++ b/.opencode-plugin/skills/visual-recap/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: visual-recap
+description: Turn a finished change — a git range, branch, or working-tree diff —
+  into a LOCAL-ONLY interactive visual recap (annotated diffs, file map, schema/API
+  deltas, diagrams, wireframes) under docs/prps/reviews/visual/, previewed in the
+  browser via the localhost bridge. Use when the user asks to "recap this branch",
+  "show what changed visually", "visual recap", "review the diff visually", or says
+  "/visual-recap". Never uploads code to a hosted service; remote-agnostic (identical
+  on the public GitHub remote and the private Forgejo origin).
+---
+
+# Visual Recap (LOCAL-ONLY)
+
+`/visual-recap` builds a visual plan **from** a diff, not toward one. It is the
+reverse of forward planning: instead of describing the change you are about to
+make, you describe the change that was just made, at a higher altitude than
+line-by-line review. Schema, API, file, and architecture changes become the same
+`data-model`, `api-endpoint`, `file-tree`, and `diagram` blocks a forward plan
+would use, only now they summarize work that exists. A reviewer scans the shape
+of the change before spending attention on the literal lines.
+
+## LOCAL-ONLY mandate — read this first
+
+> This ycc port **inverts** the upstream BuilderIO `visual-recap` skill. Upstream
+> ALWAYS publishes the recap to the hosted Agent-Native Plan database and FORBIDS
+> inline output ("a recap's entire value is the hosted plan"). **This skill does the
+> opposite.** It is permanently pinned to local-files mode and MUST NOT regress to
+> any hosted Plan create tool.
+
+Hard rules for this skill:
+
+- **`AGENT_NATIVE_PLANS_MODE=local-files` is always set.** Export it before running
+  any runtime command. The recap never writes to the hosted Plan database.
+- **NEVER call a hosted Plan create/publish tool.** The hosted recap-create tool,
+  `create-visual-plan`, `import-visual-plan-source`, `update-visual-plan`,
+  `patch-visual-plan-source`, `get-plan-feedback`, `export-visual-plan`, and
+  `set-resource-visibility` are all **disabled** in this skill. They are listed only
+  to be explicitly excluded — do not invoke them.
+- **The ONLY permitted network call is `get-plan-blocks`** (schema-only block catalog;
+  offline fallback `plan blocks --out`). It carries no recap content. Everything else
+  stays on this machine.
+- **The deliverable is local MDX** under `docs/prps/reviews/visual/<slug>/`, served via
+  the localhost bridge (`plan local serve --open`, 127.0.0.1, ephemeral port). There is
+  no hosted link and no shareable URL.
+- **Diffs are sourced through the shared collector**
+  `~/.config/opencode/shared/scripts/visual-recap-collect.sh`, which uses
+  local git refs only — so it behaves identically against the public `github` remote and
+  the private Forgejo `origin` (no vendor PR API, no hardcoded host or trunk branch).
+
+For the pinned `@agent-native/*` install, the `plan` MCP connector (legacy alias
+`agent-native-plans`), the localhost-bridge command surface, and the hosted-egress
+policy, read — do not duplicate —
+`~/.config/opencode/shared/references/agent-native-setup.md`.
+
+## When to use
+
+Build a recap when a change is large, multi-file, or touches schema, API contracts,
+or architecture, and a reviewer would benefit from seeing the change mapped to
+structured blocks before reading the raw diff. Skip it for small, single-file, or
+obvious diffs — a recap is review overhead, and a tiny change reviews faster as plain
+diff.
+
+## Phase 0 — Collect the diff (remote-agnostic, local refs only)
+
+Set local-files mode, then drive the shared collector with `$ARGUMENTS`:
+
+```bash
+export AGENT_NATIVE_PLANS_MODE=local-files
+
+# (none)         → working-tree diff vs HEAD
+# <base>..<head> → explicit range
+# <branch>       → branch as head; base = merge-base against tracked upstream
+BUNDLE_DIR="$(~/.config/opencode/shared/scripts/visual-recap-collect.sh $ARGUMENTS)"
+```
+
+The collector writes a bundle under `docs/prps/reviews/visual/<slug>/`:
+
+- `diff.patch` — full unified diff (local refs only)
+- `files.txt` — changed-file name list
+- `metadata.txt` — range / base / head / remote provenance (every remote URL via
+  `git remote get-url`, never a hardcoded host)
+
+`$BUNDLE_DIR` (printed on stdout) is the slug directory the recap MDX is written into.
+Read `diff.patch` and `files.txt` to ground every block. **Print the resolved
+range and remote provenance from `metadata.txt` before authoring** so it is obvious
+which refs the recap covers.
+
+## Phase 1 — Scope the work unit
+
+Default scope is the whole change in the collected range, not only the most recent
+edit. Separate the changes that belong to this work unit from unrelated pre-existing
+dirty work. If the scope is genuinely ambiguous, state the assumption or ask a concise
+question before authoring.
+
+Make a short surface/state inventory from the diff before writing any block: changed
+routes, components, popovers/dialogs, role/access states, empty/error/loading states,
+and shared abstractions. The final recap must either represent each meaningful item
+with a block or intentionally omit it as tiny/redundant/not-user-visible.
+
+## Phase 2 — Fetch the block catalog (the one permitted network call)
+
+> GOTCHA: The MDX block vocabulary drifts upstream between releases. Do NOT author
+> from memorized JSX tags — they silently produce wrong tags that error on import.
+
+Before writing any structured MDX, fetch the live block catalog:
+
+- Connected: call `get-plan-blocks` on the `plan` MCP connector (schema-only; no recap
+  content leaves the machine).
+- Offline / `local-files` fallback: run `plan blocks --out plan-blocks.md` and read it
+  first (calls the public no-auth `get-plan-blocks` route; sends no recap content).
+
+Author every block against the tags and schemas that call returns. The scratch
+`plan-blocks.md` is git-ignored — do not commit it.
+
+## Phase 3 — Map the diff to blocks
+
+Derive every structured block mechanically from the real diff (real paths, real fields,
+real method/path, real before/after text). The names below are CONCEPTUAL block types;
+resolve each to its exact tag + props via `get-plan-blocks`.
+
+- **Schema / migration change** → `data-model` for the resulting entities, fields, and
+  relations. Flag each field/entity with `change: "added" | "modified" | "removed" |
+"renamed"`; for a changed type set `was` to the prior value. The diff-aware
+  `data-model` is the headline; add a split `diff` of literal SQL only when the exact
+  statement still matters.
+- **API / action / route change** → `api-endpoint` with the post-change method, path,
+  params, request, and responses. Flag each changed param/response with `change` (and
+  `was` when a type/shape changed); set `change` on the endpoint root for a wholly added
+  or removed route; mark removed routes `deprecated: true`. Author each request/response
+  example as a single valid JSON value.
+- **Files added / removed / renamed** → `file-tree` with each entry's `change` flag
+  (`added`, `removed`, `modified`, `renamed`) and a short `note`.
+- **Any meaningful code hunk** → `diff` with **split view as the default** (`mode:
+"split"`), carrying the real `before`/`after` text plus `filename`/`language`. Give
+  every `diff` a one-line `summary`; attach a few high-signal `annotations` to the key
+  files. Reserve `mode: "unified"` for a genuinely narrow standalone hunk. Group the key
+  files under a `## Key changes` heading in a single horizontal `tabs` block (one file
+  per tab) so the selected split diff gets full document width.
+- **Brand-new file with no meaningful "before"** → `annotated-code` rather than a
+  one-sided split `diff`.
+- **Rendered UI / interaction change** → `wireframe` blocks (see below) showing the
+  visible delta before any code.
+- **Architecture or data-flow shift** → `diagram` (`data.html`/`data.css` two-panel
+  before/after, layered, or swimlane; or `mermaid` for a quick graph). Use `--wf-*`
+  theme tokens and `.diagram-*` primitives — never hex, rgb/hsl, or `font-family`. Do
+  not use `diagram` as a stand-in for rendered UI; UI changes need `wireframe`.
+- **Outcome-first narrative** → `rich-text` for the "what changed and why": the
+  objective, key decisions visible in the diff, and risks. This is the only place the
+  model writes freely.
+
+### Canonical shape
+
+A strong recap follows one skeleton, top to bottom:
+
+1. UI-impact headline — wireframes first, when the diff changed rendered UI.
+2. Short outcome narrative (`rich-text`): what changed and why, 1–3 paragraphs.
+3. `data-model` / `api-endpoint` blocks for schema and contract changes.
+4. `file-tree` of the changed files with `change` flags.
+5. `## Key changes` — one horizontal `tabs` block of `diff` / `annotated-code`
+   (3–8 focused tabs; prefer under ~150 lines per tab).
+
+Keep the body lean: no boilerplate intro/disclaimer/provenance prose. Add prose only
+when it tells the reviewer something the structured blocks do not.
+
+## UI impact requires wireframes (MANDATORY)
+
+When the diff changes rendered UI, layout, density, visual state, interaction
+affordances, navigation, controls, menus, dialogs, or design tokens, the recap **MUST**
+include one or more `wireframe` blocks. Prose and file diffs are not a substitute for
+showing what changed visually.
+
+Before authoring ANY wireframe, **read
+`~/.config/opencode/skills/visual-recap/references/wireframe.md` in full** — it is the
+single source of truth for HTML wireframe quality (`.wf-*` classes, `[data-icon]` Tabler
+set, `surface` presets, `--wf-*` tokens, before/after comparability, skeleton states).
+Do not author wireframes from memory. Show the changed entry point, the main changed
+interaction surface, and the resulting/destination state; for UI-heavy changes a single
+before/after of the entry surface is not enough.
+
+## Phase 4 — Write and serve the local recap
+
+Write the recap as a local MDX folder inside the collected bundle directory:
+
+- `docs/prps/reviews/visual/<slug>/plan.mdx` (required), optional `canvas.mdx`, and
+  optional `.plan-state.json`. Set `kind: "recap"` and `localOnly: true` in the source
+  frontmatter/state.
+
+Validate, then serve via the localhost bridge:
+
+```bash
+plan local check --dir docs/prps/reviews/visual/<slug>
+plan local serve --dir docs/prps/reviews/visual/<slug> --kind recap --open
+```
+
+`serve` binds **127.0.0.1** on an ephemeral CLI-chosen port and opens the preview. It
+performs **no DB writes and sends nothing to any server** — it is a purely local render
+of the on-disk MDX. Report the local bridge URL from stdout (or `<slug>/.plan-url`, a
+local token file — do not commit it). The URL is not shareable across machines.
+
+Treat review feedback as file/chat feedback: edit the MDX directly, rerun
+`plan local serve`, and report the new local bridge URL. Hosted comments, sharing,
+screenshots, and PR sticky-comment publishing are intentionally unavailable.
+
+## Grounding & security
+
+- **Grounding rule.** `diff`, `data-model`, `api-endpoint`, and `file-tree` blocks must
+  be built mechanically from the real changed lines — never inferred, rounded, or
+  invented. Mark anything the model inferred (not extracted) as inferred in prose. When
+  the diff does not contain a fact, leave it out.
+- **Never transcribe secrets.** A diff can contain API keys, tokens, webhook URLs,
+  signing secrets, or `.env` values. Never copy these into any block, snippet, caption,
+  or note — redact them (`sk-•••`). This mirrors the repo's hardcoded-secret rule.
+- **No egress.** This skill performs no hosted upload. The shared
+  `~/.config/opencode/shared/scripts/visual-egress-guard.sh` exists for the
+  consent-gated hosted path used by `visual-plan`; it is NOT invoked here because
+  this recap never leaves the machine.
+
+## Output
+
+- Local MDX recap under `docs/prps/reviews/visual/<slug>/` (`plan.mdx` + bundle).
+- A `127.0.0.1` localhost-bridge preview URL printed to stdout.
+- **No hosted link, no shareable URL, no PR comment, no GitHub/Forgejo Action.**
+
+## Related
+
+- `visual-plan` — forward planning; faithful hosted+local MDX workflow with
+  consent-gated egress. Shares the wireframe quality bar word-for-word.
+- `~/.config/opencode/shared/references/agent-native-setup.md` — runtime
+  contract (install pin, connector, bridge, egress policy).

--- a/.opencode-plugin/skills/visual-recap/references/wireframe.md
+++ b/.opencode-plugin/skills/visual-recap/references/wireframe.md
@@ -1,0 +1,234 @@
+# HTML wireframe quality — single source of truth
+
+This file is the canonical quality bar for HTML wireframes / `WireframeBlock`
+content, shared word for word by `visual-plan` and `visual-recap`. Read it in
+full before authoring ANY wireframe; do not author wireframes from memory or paraphrase
+these rules per command.
+
+**A wireframe is an HTML mockup. The renderer owns the look; you write the content.**
+Set `data.html` to a self-contained, semantic HTML fragment of the screen and set
+`data.surface`. The renderer owns the surface footprint/aspect, the dark/light theme,
+the hand-drawn font, and the sketch overlay — you never write `<html>`/`<body>`/`<svg>`
+tags or any width/height/coordinates. You write real HTML layout and real product
+content; the renderer styles and roughens it.
+
+**A wireframe block's data is an HTML screen plus a surface:**
+
+```json
+{
+  "surface": "browser",
+  "html": "<div style=\"display:flex;flex-direction:column;gap:10px;padding:16px;height:100%\"><h1>Sign in</h1><p class=\"wf-muted\">Use your work email to continue.</p><div class=\"wf-card\" style=\"display:flex;flex-direction:column;gap:10px\"><label>Email<input value=\"jane@acme.co\" /></label><label>Password<input value=\"••••••••\" /></label><label style=\"display:flex;align-items:center;gap:8px\"><input type=\"checkbox\" checked /> Remember me</label><button class=\"primary\">Sign in</button></div><a href=\"#\">Forgot password?</a></div>"
+}
+```
+
+**Write PLAIN semantic HTML and let the renderer style it.** Bare elements
+(`h1`/`h2`/`h3`, `p`, `button`, `input`, `label`, `a`, `hr`) are auto-themed — no
+classes needed. Helper classes carry the rest:
+
+- `.wf-card` / `.wf-box` — a bordered, padded container (a panel, a list item).
+- `.wf-pill` / `.wf-chip` — a rounded tag or filter; add `.accent` for the
+  accent-filled variant.
+- `.wf-muted` — secondary/muted text.
+- `button.primary` or any element with `[data-primary]` — the accent-filled primary
+  button.
+
+**No decorative shadows around mockups.** Do not put `box-shadow`,
+`filter: drop-shadow(...)`, Tailwind `shadow-*` classes, or other fake depth effects on
+a wireframe frame, root container, `.wf-card` / `.wf-box`, or canvas artboard. Mockups
+should read as flat, bordered surfaces; use spacing, borders, labels, and annotations
+for separation. Only show a shadow when the real product UI already has that shadow and
+it is essential to the change being reviewed.
+
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading icons
+inside fields, chips, menu items, and toolbars, write an empty marker such as
+`<i data-icon="mail"></i>` or `<span data-icon="search"></span>`. The renderer replaces
+it with a Tabler-style SVG and the `.wf-icon` class sizes it to the surrounding text.
+Supported names and aliases: `mail`/`email`, `lock`/`password`, `search`, `plus`/`add`,
+`x`/`close`, `check`, `chevronDown`, `chevronUp`, `chevronLeft`, `chevronRight`,
+`dots`/`more`, `chevron`/`caret`/`dropdown` (down chevron), `user`, `settings`,
+`calendar`, `bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do not put visible
+words like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
+**Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips these on
+light/dark, so reading them is what keeps a mockup correct in both themes. For any
+inline border, background, or text color, reference a token:
+`style="border:1.4px solid var(--wf-line)"`. The tokens are `--wf-ink` (text),
+`--wf-muted` (secondary text), `--wf-line` (borders/dividers), `--wf-paper` (page
+background), `--wf-card` (container surface), `--wf-accent` / `--wf-accent-fg` /
+`--wf-accent-soft` (brand action), `--wf-warn`, `--wf-ok`, and `--wf-radius`. Never
+hard-code a hex color and never set `font-family` — the renderer owns the sketch/clean
+font.
+
+**Lay out with inline `style` flex/grid.** You write the real layout —
+`display:flex; flex-direction:column; gap:10px; padding:16px` and so on — and the
+renderer never repositions anything. Compose the actual product: reproduce the current
+screen, then show the modification. Real labels, real counts, real dates, real button
+text grounded in the screen you read; not lorem or gray bars.
+
+**Surface presets — match the real footprint, never default to desktop+mobile.** Pick
+the `surface` that matches what the user will actually see:
+
+- `browser`: a web page that needs a browser chrome frame around it.
+- `desktop`: a full desktop app page or app shell.
+- `mobile`: a phone screen, only when the work is genuinely mobile.
+- `popover`: a small floating menu, dropdown, or inline popover.
+- `panel`: a side panel, inspector, or sidebar widget.
+
+A sidebar popover renders as a small surface, not a desktop page and a phone frame. Do
+not emit `desktop` + `mobile` variants unless responsive behavior actually changes the
+layout. For a component or widget, show one broader app-context frame only when
+placement affects understanding, then the focused component states.
+
+**Model the actual component shell for small surfaces.** A rendered UI change belongs in
+a wireframe; reserve `diagram` for architecture, dependency, state, or data-flow
+relationships. Popovers, dropdown menus, command palettes, and context menus use
+`surface: "popover"` unless the surrounding page placement is the point of the change.
+Dialogs, sheets, inspectors, sidebars, and long property panels use the matching
+`panel` / `desktop` surface as appropriate. Show the real chrome: trigger or anchor when
+it matters, title/header row, top-right actions, separators, fields, options, selected
+states, body content, and footer actions that are visible in the workflow.
+
+**Modify, don't redesign.** When the task changes an existing screen, reproduce the
+current screen's real layout and footprint FIRST, then change only the delta and call it
+out with a single annotation. Do not restack the page into a new layout. For net-new
+surfaces, compose from the real app shell. Inspect the actual app components before
+drawing an existing product: sidebar density, toolbar actions, overflow menus, property
+panels, and framework chrome should match the product unless the plan intentionally
+changes them.
+
+**Keep product screens pure.** A product wireframe shows the app state a user would
+actually see. Do not embed file contracts, architecture arrows, repo pills, mode
+explanations, or implementation callouts inside the screen just to explain the plan. Put
+those in canvas annotations, a separate diagram, or the document body. Secondary UI such
+as properties, history, sync, export, or agent controls should appear where the real
+product would put them: an overflow popover, sheet, panel, or separate framework sidebar
+state, not a generic permanent right inspector unless that inspector is the actual
+design.
+
+**Classify mockup scope before implementation.** Before turning a plan mockup into
+source code, decide whether each artboard represents the whole page/app shell, a route
+body inside an existing shell, or a component/sub-surface. If an artboard includes
+navigation, sidebars, auth banners, or a signup/login form, map those pieces to the real
+shared shell/auth components instead of nesting the entire mockup inside the current
+page. When a mockup references the product's standard signup/login page, find and reuse
+that existing implementation; do not approximate it from the wireframe.
+
+**Zoom in on sub-surfaces, don't redraw the page.** For a small sub-surface (a popover,
+menu, dialog, toast), show the full screen once, then add a small separate artboard
+whose `html` contains ONLY that sub-surface — do not re-draw the whole page around it,
+and do not scale a duplicate up. Pick the matching `surface` (e.g. `popover`) so the
+footprint is right; never widen a popover to page width.
+
+**Loading / skeleton states.** Set `data.skeleton: true` on the wireframe and fill the
+`html` with neutral, textless placeholder geometry — boxes and bars built as `<div>`s
+with `background:var(--wf-line)` and explicit heights/widths, no labels or copy. The
+renderer drops borders, sketch, and color into the skeleton register automatically.
+Never escape to a `custom-html` document block to fake a loader.
+
+**Editing an existing mockup.** Because this skill is LOCAL-ONLY, edit the MDX source
+file directly (no hosted patch tool), then rerun `plan local serve` to re-render. Read
+the current `html` first so each replacement targets a unique snippet; the result is
+re-sanitized on reload.
+
+**Treat the wireframe border as part of the visible design.** Always wrap HTML wireframe
+content in a root container with real inner padding before drawing cards, fields, pills,
+labels, or controls. Use at least 14–16px of padding, `box-sizing: border-box`,
+`height: 100%`, and `gap` between child rows so the first row never sits flush against
+the screen border. Keep text away from borders: every container, field, button, menu
+item, and annotation needs enough padding and line-height to read cleanly in the
+rendered Plan view.
+
+**Lay out children safely so they never collide.** Use HTML flex/grid with `gap`,
+`min-width: 0`, and sensible overflow. Avoid negative margins, absolute positioning, or
+fixed child widths that can collide when the renderer switches between light/dark,
+sketch/clean, or different zoom levels.
+
+**Do not wrap intentionally single-line labels.** For toolbars, tab rails, breadcrumbs,
+chip/filter rows, branch and file names, file chips, and code filenames — any
+deliberately single-line row — do not let long text wrap. Put `white-space: nowrap` on
+the row (and `overflow: hidden; text-overflow: ellipsis` on the individual labels that
+can grow), so the wireframe demonstrates the actual layout behavior instead of producing
+ugly stacked or vertical text. Use horizontally scrollable or clipped rails for
+overflow.
+
+**Fill the frame; keep labels short.** Each artboard is a fixed-size surface — compose
+enough realistic HTML to fill it top to bottom with even vertical rhythm; never leave a
+large empty band. On desktop/app-shell sidebars, let the nav stack flex to fill
+(`flex:1`) and add any persistent bottom action/status after it so the rail reads
+complete in taller frames. On mobile especially, flow real rows down the whole screen
+(status bar, header, then list/detail content) rather than a header floating above a
+gap. Keep every label short enough to sit on one line within its column — shorten the
+copy rather than relying on the frame to absorb it.
+
+**Persistent chrome bars span the full frame width.** Top bars, app headers, toolbars,
+and bottom tab/nav bars are full-width chrome, not centered content. Lay each one out as
+a single flex row that fills the frame (`style="display:flex;align-items:center;width:100%"`)
+and push trailing actions to the right edge with a flex spacer
+(`<div style="flex:1"></div>`) between the leading group and the trailing group — never
+center a bar inside a narrow, centered block, and never let it collapse to the width of
+its contents. In a Before/After pair the bar stays full-width in BOTH states even when
+one state has fewer controls; the spacer absorbs the difference so the remaining controls
+hold their edge alignment.
+
+**Pin bottom bars to the bottom of the frame.** For mobile tab bars, footers, and any
+persistent bottom action row, make the frame itself a flex column at `height:100%`
+(`style="display:flex;flex-direction:column;height:100%"`), give the scrolling body
+`flex:1` so it absorbs the slack, and place the bar as the LAST child of the frame (or
+set `margin-top:auto` on it). The bar then sits flush at the bottom of the surface
+instead of floating directly under the content with an empty band beneath it.
+
+**Before / after must be comparable.** When showing a state change, preserve the
+unchanged controls in both states so the reviewer can see exactly what moved or
+appeared; do not show an added control as a generic box floating elsewhere in the
+surface. Place the new/changed affordance where the implementation puts it — for
+example, a new `Edit with AI` action in a popover header belongs in the top-right header
+slot, aligned with the title, not in the body or footer. Use the same frame size, scale,
+outer padding, border radius, and visual density on both sides unless the change itself
+alters those properties, and let the frame height fit the content rather than leaving a
+tall empty lower half.
+
+**Name the states with the column header, never inside the frame.** For document-body
+wireframes (recaps), put the two states in a `columns` block and set each column's
+`label` to `Before` and `After` — the renderer draws that label as an `h4` heading above
+each frame. Do NOT bake a `Before`/`After` pill, title, or heading into the wireframe
+`html`: a label placed inside reads as part of the product UI, lands in a random corner,
+and clutters the comparison. The column header is the one and only place the state name
+belongs.
+
+**Let the surface choose side-by-side vs. stacked.** For document-body wireframes
+(recaps), the `columns` renderer lays narrow surfaces (`mobile`, `popover`, `panel`) out
+side by side, and automatically stacks wide surfaces (`desktop`, `browser`) vertically
+at full document width so a large frame is never crushed into a half-width column and
+cropped. Author both wireframes with the real `surface` and the matching `Before`/`After`
+column labels; do not hand-stack the pair into separate top-level wireframes or duplicate
+the state name as body content.
+
+**Good example — a contacts list, surface `browser`.** A small, real screen composed
+from the helper classes and tokens, layout in inline flex, no fonts or hex colors:
+
+```html
+<div style="display:flex;flex-direction:column;gap:12px;padding:16px;height:100%">
+  <div style="display:flex;align-items:center;justify-content:space-between">
+    <h1>Contacts</h1>
+    <button class="primary">New contact</button>
+  </div>
+  <div style="display:flex;gap:6px">
+    <span class="wf-pill accent">All 128</span>
+    <span class="wf-pill">Favorites</span>
+    <span class="wf-pill">Archived</span>
+  </div>
+  <div class="wf-card" style="display:flex;flex-direction:column;gap:0;padding:0">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-bottom:1.4px solid var(--wf-line)">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Jane Cooper</strong><br /><small>jane@acme.co</small></div>
+      <span class="wf-pill">Lead</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Marcus Lee</strong><br /><small>marcus@globex.io</small></div>
+      <span class="wf-pill">Customer</span>
+    </div>
+  </div>
+</div>
+```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A single Claude Code plugin (`ycc`) bundling workflow orchestration, parallel pl
 
 <!-- BEGIN:GENERATED-COUNTS -->
 
-The source plugin ships **48 skills**, **47 slash commands** (most skills have a matching command), and **54 agents**.
+The source plugin ships **50 skills**, **49 slash commands** (most skills have a matching command), and **54 agents**.
 
 <!-- END:GENERATED-COUNTS -->
 
@@ -62,6 +62,8 @@ The source plugin ships **48 skills**, **47 slash commands** (most skills have a
 | `/ycc:shared-context`      | Build shared context documentation for a feature — gathers files, conventions, dependencies, and existing patterns into a single artifact that downstream planning stages can refere... |
 | `/ycc:ts-patterns`         | Idiomatic TypeScript patterns — strict type system, discriminated unions, generic inference, `satisfies`, branded types, errors as values, ESM/CJS modules with `exports` maps, Prom... |
 | `/ycc:ts-testing`          | TypeScript testing patterns using Vitest as the primary runner — TDD workflow, unit tests, integration tests, async tests with fake timers, parameterized tests via `test.each`, pro... |
+| `/ycc:visual-plan`         | Turn an existing text plan into a rich, interactive visual plan — diagrams, file maps, annotated code, open questions, and an optional UI/prototype review surface.                     |
+| `/ycc:visual-recap`        | Turn a finished change (git range, branch, or working-tree diff) into a LOCAL-ONLY interactive visual recap — annotated split diffs, file map, schema/API deltas, diagrams, and wire... |
 | `/ycc:write-docs`          | Orchestrate 5 specialized documentation agents in parallel to analyze codebase and create comprehensive documentation.                                                                  |
 
 <!-- END:GENERATED-COMMANDS -->

--- a/docs/inventory.json
+++ b/docs/inventory.json
@@ -189,6 +189,14 @@
       "description": "TypeScript testing patterns using Vitest as the primary runner \u2014 TDD workflow, unit tests, integration tests, async tests with fake timers, parameterized tests via `test.each`, property-based testing with fast-check, mocking with `vi.mock` / `vi.fn` / `vi.spyOn`, type-level testing with `expectTypeOf` / `expect-type` / `tsd`, benchmarks with `vitest bench`, and v8 coverage. Follows TDD methodology. Use when the user is writing TypeScript tests, adding test coverage to TypeScript code, asks about Vitest, `describe` / `it` / `expect`, `vi.useFakeTimers`, `test.each`, fast-check, `expectTypeOf` or `tsd`, `vitest bench`, coverage targets, or wants TDD guidance for a TypeScript project."
     },
     {
+      "name": "visual-plan",
+      "description": "Turn an existing text plan into a rich, interactive visual plan \u2014 diagrams, file maps, annotated code, open questions, and an optional UI/prototype review surface. Read-only with respect to the plan file. Use when the user asks to \"make this plan visual\", \"render a visual plan\", \"create a wireframe/canvas for this plan\", \"visualize the implementation plan\", says \"/visual-plan\", or when a planning skill hands off via the shared `--visual` decorator."
+    },
+    {
+      "name": "visual-recap",
+      "description": "Turn a finished change \u2014 a git range, branch, or working-tree diff \u2014 into a LOCAL-ONLY interactive visual recap (annotated diffs, file map, schema/API deltas, diagrams, wireframes) under docs/prps/reviews/visual/, previewed in the browser via the localhost bridge. Use when the user asks to \"recap this branch\", \"show what changed visually\", \"visual recap\", \"review the diff visually\", or says \"/visual-recap\". Never uploads code to a hosted service; remote-agnostic (identical on the public GitHub remote and the private Forgejo origin)."
+    },
+    {
       "name": "write-docs",
       "description": "Orchestrate 5 specialized documentation agents in parallel to analyze codebase and create comprehensive documentation. Includes audit, gap analysis, parallel agent deployment, and quality assurance."
     }
@@ -377,6 +385,14 @@
     {
       "name": "ts-testing",
       "description": "TypeScript testing patterns using Vitest as the primary runner \u2014 TDD workflow, unit tests, integration tests, async tests with fake timers, parameterized tests via `test.each`, property-based testing with fast-check, mocking with `vi.mock` / `vi.fn` / `vi.spyOn`, type-level testing with `expectTypeOf` / `expect-type` / `tsd`, benchmarks with `vitest bench`, and v8 coverage. Follows TDD methodology. Use when the user is writing TypeScript tests, adding test coverage to TypeScript code, asks about Vitest, `describe` / `it` / `expect`, `vi.useFakeTimers`, `test.each`, fast-check, `expectTypeOf` or `tsd`, `vitest bench`, coverage targets, or wants TDD guidance for a TypeScript project."
+    },
+    {
+      "name": "visual-plan",
+      "description": "Turn an existing text plan into a rich, interactive visual plan \u2014 diagrams, file maps, annotated code, open questions, and an optional UI/prototype review surface. Reads the plan (never edits it) and writes plan.mdx + canvas.mdx into a sibling visual/ directory. Hosted sharing is consent-gated behind --share; default is a local-files localhost preview."
+    },
+    {
+      "name": "visual-recap",
+      "description": "Turn a finished change (git range, branch, or working-tree diff) into a LOCAL-ONLY interactive visual recap \u2014 annotated split diffs, file map, schema/API deltas, diagrams, and wireframes \u2014 written under docs/prps/reviews/visual/ and previewed in the browser via the 127.0.0.1 localhost bridge. Never uploads code; remote-agnostic across the public GitHub remote and the private Forgejo origin."
     },
     {
       "name": "write-docs",
@@ -602,8 +618,8 @@
     }
   ],
   "counts": {
-    "skills": 48,
-    "commands": 47,
+    "skills": 50,
+    "commands": 49,
     "agents": 54
   },
   "parity": {

--- a/docs/prps/plans/completed/visual-planning-skills.plan.md
+++ b/docs/prps/plans/completed/visual-planning-skills.plan.md
@@ -1,0 +1,568 @@
+# Plan: Visual Planning Skills (visual-plan + visual-recap + `--visual` flag)
+
+## Summary
+
+Port the BuilderIO `visual-plan` and `visual-recap` skills (pinned upstream commit
+`a0726717ab0402e85eadca46183d8be50bc3a102`) into the `ycc` bundle as `ycc:visual-plan`
+and `ycc:visual-recap`, and add a `--visual` flag to four planning skills (`prp-plan`,
+`plan`, `plan-workflow`, `parallel-plan`) that bootstraps the visual workflow after the
+text plan is written. `ycc:visual-plan` keeps the faithful Agent-Native integration
+(MDX, hosted shareable links, `npx @agent-native/*` tooling, localhost bridge) but gates
+network egress behind explicit consent; `ycc:visual-recap` is local-only and
+remote-agnostic (works against both the GitHub and private Forgejo remotes). No GitHub
+Action is ported.
+
+## User Story
+
+As a developer running `/ycc:prp-plan`, `/ycc:plan`, `/ycc:plan-workflow`, or
+`/ycc:parallel-plan`, I want a `--visual` flag that turns my finished plan into an
+Agent-Native, browser-reviewable MDX document (hosted link or localhost preview), so that
+I can review and share the plan visually before any code is written — instead of only a
+static `.plan.md`.
+
+As a developer who just finished an implementation, I want `/ycc:visual-recap` to generate
+a **local-only** visual summary of what changed (annotated diffs, file map, schema/API
+deltas), so that I can review the result in the browser without uploading private code to a
+third-party service.
+
+## Problem → Solution
+
+Planning skills today emit only static Markdown (`docs/prps/plans/{name}.plan.md`,
+feature-dir `parallel-plan.md`, or nothing for `/ycc:plan`) with no visual review surface,
+and there is no post-implementation visual recap. → The `ycc/` bundle gains two new
+source-of-truth skills (`ycc:visual-plan`, `ycc:visual-recap`) plus a `--visual`
+decorator on the four planning skills, all conforming to repo conventions, with the
+Cursor/Codex/opencode bundles regenerated and all validators green.
+
+## Metadata
+
+- **Complexity**: Large (10+ files: 2 new skills + 2 new commands + 4 skill edits + 4
+  command edits + shared refs/scripts + bundle regeneration)
+- **Source PRD**: N/A (free-form feature request)
+- **PRD Phase**: N/A
+- **Estimated Files**: ~22 source files touched/created (excluding regenerated bundles)
+- **Upstream pin**: `BuilderIO/skills@a0726717ab0402e85eadca46183d8be50bc3a102`
+- **Pinned dependency**: `@agent-native/core` / `@agent-native/skills` — pin an exact
+  version (see Task 1.1); never `@latest` in committed content.
+
+## Batches
+
+Tasks grouped by dependency for parallel execution. Tasks within a batch run concurrently
+(no two touch the same file); batches run in order.
+
+| Batch | Tasks              | Depends On | Parallel Width |
+| ----- | ------------------ | ---------- | -------------- |
+| B1    | 1.1, 1.2, 1.3, 1.4 | —          | 4              |
+| B2    | 2.1, 2.2           | B1         | 2              |
+| B3    | 3.1, 3.2, 3.3, 3.4 | B2         | 4              |
+| B4    | 4.1                | B1,B2,B3   | 1              |
+| B5    | 5.1                | B4         | 1              |
+
+- **Total tasks**: 12
+- **Total batches**: 5
+- **Max parallel width**: 4
+
+---
+
+## UX Design
+
+### Before
+
+- `/ycc:prp-plan <feature>` → one markdown plan at `docs/prps/plans/{name}.plan.md`
+  (`ycc/skills/prp-plan/SKILL.md:327`) plus a text "Report to User" block
+  (`SKILL.md:417-434`); the only artifact shown is a repo-relative path.
+- Flags today: `--parallel | --team | --worktree | --no-worktree | --enhanced | --dry-run`
+  (`ycc/commands/prp-plan.md:37-44`). No `--visual`; no visual artifact; no recap skill.
+
+### After
+
+- `/ycc:prp-plan --visual <feature>` writes the same `.plan.md`, then bootstraps
+  `ycc:visual-plan` on that file → an MDX visual artifact under a sibling `visual/` dir and
+  either a hosted shareable link (consent-gated) or a localhost preview URL.
+- Report block gains two fields: `Visual Artifact:` and `Visual Link:`
+  (`<hosted-url | http://127.0.0.1:PORT/... | "local files only">`).
+- New `/ycc:visual-plan <plan-path>` (render an existing plan standalone) and
+  `/ycc:visual-recap [base..head | branch]` (local-only recap → `docs/prps/reviews/visual/`).
+- `--visual` is orthogonal — composes with `--parallel`/`--team`/`--enhanced`/`--no-worktree`;
+  short-circuited by `--dry-run`; `/ycc:plan --visual` force-writes a plan file first.
+
+### Interaction Changes
+
+| Touchpoint                                                                                           | Before           | After                               | Notes                                   |
+| ---------------------------------------------------------------------------------------------------- | ---------------- | ----------------------------------- | --------------------------------------- |
+| 4 command flag tables (`prp-plan.md:37-44`, `plan.md:32-41`, `plan-workflow.md`, `parallel-plan.md`) | no `--visual`    | `--visual` row added                | Identical wording across all four       |
+| 4 command Usage grammars                                                                             | no `[--visual]`  | `[--visual]` added                  | Keeps existing mutual-exclusion notes   |
+| 4 SKILL flag-parse blocks                                                                            | no `VISUAL_MODE` | `VISUAL_MODE` boolean parsed        | Mirror the `--enhanced` case+strip pair |
+| `prp-plan` Report block (`SKILL.md:417-434`)                                                         | 12 fields        | + `Visual Artifact` + `Visual Link` | Link value depends on consent/mode      |
+| NEW `/ycc:visual-plan` help                                                                          | does not exist   | full Usage/Examples/Output          | hosted or localhost preview             |
+| NEW `/ycc:visual-recap` help                                                                         | does not exist   | full Usage/Examples/Output          | local-only; no hosted link; no Action   |
+
+**Forgejo / two-remote impact**: `origin` is the **private** Forgejo
+(`git.azules-celsius.ts.net`); `github` is the public remote. Hosted links are generated
+from local MDX and are remote-agnostic; in-artifact repo links must use
+`git remote get-url <name>` (never hardcode `github.com`); recap is local-only so it emits
+no remote-tied link. Report/artifact path fields stay repo-relative.
+
+---
+
+## Mandatory Reading
+
+Files that MUST be read before implementing:
+
+| Priority       | File                                                        | Lines                                                                                  | Why                                                                                                                     |
+| -------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| P0 (critical)  | `ycc/skills/prp-plan/SKILL.md`                              | 44-82, 323-371, 417-434                                                                | Canonical flag-parse block, validation gate, GENERATE chunking, Report block — the exact pattern `--visual` must mirror |
+| P0 (critical)  | `ycc/skills/bundle-author/SKILL.md`                         | all                                                                                    | Sanctioned scaffolder for a new skill+command; encodes the source-of-truth split                                        |
+| P0 (critical)  | `ycc/skills/bundle-author/references/surface-map.md`        | all                                                                                    | `${CLAUDE_PLUGIN_ROOT}` path conventions, skill/command surface layout                                                  |
+| P0 (critical)  | `CLAUDE.md`                                                 | "Plugin Development Conventions", "Generated Compatibility Targets", "Testing Changes" | Naming, source-vs-generated split, regenerate+validate loop                                                             |
+| P1 (important) | `ycc/skills/plan/SKILL.md`                                  | 81-102                                                                                 | Second instance of the flag-parse/validation pattern (no-artifact skill — force-write case)                             |
+| P1 (important) | `ycc/skills/parallel-plan/SKILL.md`                         | 67-119                                                                                 | Arg-parse + dry-run roster pattern                                                                                      |
+| P1 (important) | `ycc/skills/plan-workflow/SKILL.md`                         | 52-114                                                                                 | Arg-parse + usage block pattern                                                                                         |
+| P1 (important) | `ycc/skills/_shared/references/target-capability-matrix.md` | 11-30                                                                                  | Confirms `--visual` must branch in the SKILL body (Codex has no command layer)                                          |
+| P1 (important) | `ycc/skills/clean/scripts/validate-safety.sh`               | 8-14, 71-100, 238                                                                      | Protected-path/secret denylist + exit-code conventions to mirror in the egress guard                                    |
+| P1 (important) | `ycc/skills/_shared/scripts/prepare-feature-branch.sh`      | 18-21, 69-92                                                                           | Strict flag parsing + stdout/stderr discipline for new scripts                                                          |
+| P2 (reference) | `ycc/commands/prp-plan.md`                                  | 1-68                                                                                   | Thin command-doc shape (frontmatter + flag table + Usage/Examples)                                                      |
+| P2 (reference) | `scripts/validate.sh` / `scripts/sync.sh`                   | headers, `:113-119`                                                                    | The regenerate + validate pipeline (CI loop), `--only` targets                                                          |
+| P2 (reference) | `ycc/skills/_shared/references/goal-pairing.md`             | all                                                                                    | `/goal` pairing recipe — decide include/skip for new skills                                                             |
+
+## External Documentation
+
+| Topic                          | Source                                                 | Key Takeaway                                                                                                                                                                                                                                    |
+| ------------------------------ | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| visual-plan skill body         | `BuilderIO/skills@a072671:skills/visual-plan/SKILL.md` | Entry `/visual-plan`; auto-selects mode (UI-first / prototype-first / design-first / visual-intake). Read-only. Flow: `get-plan-blocks` (block catalog) → mode create tool → surface link → `get-plan-feedback` → `update-visual-plan` patches. |
+| visual-recap skill body        | `…:skills/visual-recap/SKILL.md`                       | `/visual-recap` turns diffs into a published Plan via `create-visual-recap`; upstream FORBIDS inline Markdown ("value is the hosted plan") — **this is the exact rule we invert for local-only**.                                               |
+| npx installer                  | `…:README.md`                                          | `npx @agent-native/skills@latest add` picker (skills, storage hosted/local-files/self-hosted, client, scope, optional GitHub Action). We pin a version and skip the Action.                                                                     |
+| Runtime CLI                    | upstream SKILL setup                                   | Install `npx @agent-native/core@latest skills add <skill>`; auth `npx -y @agent-native/core@latest reconnect https://plan.agent-native.com --client [codex\|claude-code\|all]` (one-time per client).                                           |
+| Hosted Plans app               | upstream SKILL                                         | Origin `https://plan.agent-native.com`; create tools return an absolute shareable URL; private-repo plans are org-gated (viewer must sign in).                                                                                                  |
+| Plan MCP connector             | `…:visual-recap/SKILL.md`                              | Connector `plan` (legacy alias `agent-native-plans`). `get-plan-blocks` is the ONLY tool callable in local mode (schema-only; offline fallback `plan blocks --out`).                                                                            |
+| Localhost bridge (local-files) | upstream SKILL Local-Files                             | Write MDX → `plan local check --dir plans/<slug>` → `plan local serve --dir plans/<slug> --open`. Serves the hosted UI against local files; **no DB writes, nothing sent to servers**. Port is CLI-chosen.                                      |
+| Local recap diff collection    | `…:visual-recap/SKILL.md`                              | `npx @agent-native/core@latest recap collect-diff` shells to local `git` → **remote-agnostic** (identical on GitHub or Forgejo; no vendor PR API).                                                                                              |
+| MDX vocab — PLAN doc blocks    | `…:references/document-quality.md`, `exemplar.md`      | `rich-text`, `annotated-code`, `code`, `tabs`, `columns`, `diagram`, `table`, `checklist`, `callout` (`tone="decision"`), `question-form` (bottom only), `custom-html`.                                                                         |
+| MDX vocab — PLAN canvas blocks | `…:references/canvas.md`                               | `<DesignBoard>`, `<Section>`, `<Artboard>`, `<Screen>`, `<Annotation>`, `<Connector>`. Files: `plan.mdx` + `canvas.mdx`; artboard size via `surface`; ≥96px spacing.                                                                            |
+| MDX vocab — RECAP blocks       | `…:visual-recap/SKILL.md`                              | `data-model` (field `change` flags), `api-endpoint`, `file-tree`, `diff` (split default), `diagram`, `wireframe` (MANDATORY when UI affected).                                                                                                  |
+| Wireframe classes/tokens       | `…:references/wireframe.md`                            | `.wf-*` classes, `[data-icon]` Tabler set, surfaces `browser/desktop/mobile/popover/panel`, colors via `--wf-*` tokens only (no hex). `data.skeleton:true` for loading.                                                                         |
+| Diagram primitives             | `…:references/document-quality.md`                     | `.diagram-*` classes, `[data-rough]` sketchy mode; patch via `patch-diagram-html`.                                                                                                                                                              |
+| Content patch ops              | `…:references/canvas.md`                               | `patch-wireframe-html`, `patch-diagram-html`, `update-block`, `replace-blocks`, `read/patch-visual-plan-source`, `update-rich-text` — inside `update-visual-plan` `contentPatches`.                                                             |
+| Upstream packaging             | `…:.claude-plugin/plugin.json`                         | Single plugin `builder-skills`, `"skills": "./skills/"` glob, no per-skill registration → maps cleanly onto `ycc/skills/<name>/`.                                                                                                               |
+| GitHub Action (SKIPPED)        | `…:README.md`                                          | The PR-automation Action is GENERATED by `--with-github-action`, NOT committed at this commit. Skipping = simply not emitting it. Nothing to port-and-delete.                                                                                   |
+| Forgejo Actions                | Forgejo convention                                     | GitHub-Actions-compatible YAML under `.forgejo/workflows/*.yml`. Recap is local-only (`git diff`/`collect-diff`) so no PR API and no Action is needed; documented for the record only.                                                          |
+
+---
+
+## Patterns to Mirror
+
+Code patterns discovered in the codebase. Follow these exactly.
+
+### NAMING_CONVENTION
+
+```
+// SOURCE: CLAUDE.md "Naming" + ycc/skills/bundle-author/references/surface-map.md:28-33
+ycc/skills/visual-plan/        -> skill id ycc:visual-plan   (kebab-case dir)
+ycc/commands/visual-plan.md    -> slash command /ycc:visual-plan
+// in-body self-refs:
+${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/references/<name>.md
+${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/scripts/<name>.sh
+```
+
+### FLAG_PARSE (the exact model for `--visual` — copy `--enhanced`)
+
+```
+// SOURCE: ycc/skills/prp-plan/SKILL.md:70-74
+ENHANCED_MODE=false
+case " $ARGUMENTS " in
+  *" --enhanced "*) ENHANCED_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--enhanced/}"
+// → add one analogous VISUAL_MODE case+strip pair per skill
+```
+
+### FLAG_VALIDATION / COMMAND_FLAG_TABLE
+
+```
+// SOURCE: ycc/skills/prp-plan/SKILL.md:77-82 (prose Validation bullets)
+- --parallel and --team are **mutually exclusive**. ...
+// SOURCE: ycc/commands/plan.md:32-41 (command-doc flag table)
+**Flags**:
+- --parallel — Instruct the ycc:planner agent ...
+- --no-worktree — Opt out ...
+```
+
+### SKILL_FRONTMATTER (mirror prp-plan; allowed-tools lists the script glob)
+
+```yaml
+# SOURCE: ycc/skills/prp-plan/SKILL.md:1-30
+---
+name: visual-plan
+description: <triggering description>
+argument-hint: '[--share] <path/to/plan.md>'
+allowed-tools:
+  - Read
+  - Bash(${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/scripts/*.sh:*)
+---
+```
+
+### COMMAND_FRONTMATTER (thin body — logic lives in the skill)
+
+```
+// SOURCE: ycc/commands/prp-plan.md:1-27
+---
+description: <one line>
+argument-hint: '...'
+---
+Load and follow the ycc:visual-plan skill, passing through $ARGUMENTS.
+```
+
+### ERROR_HANDLING (new scripts mirror these exactly)
+
+```bash
+# SOURCE: ycc/skills/git-workflow/scripts/create-pr.sh:1-2
+#!/usr/bin/env bash
+set -euo pipefail
+# SOURCE: ycc/skills/clean/scripts/validate-safety.sh:29-38 (arg present + exists, errors→stderr)
+if [[ -z "$ARG" ]]; then echo "ERROR: ... required" >&2; exit 1; fi
+if [[ ! -f "$ARG" ]]; then echo "ERROR: ... not found" >&2; exit 1; fi
+```
+
+### PROTECTED_PATH_DENYLIST (egress guard mirrors clean/validate-safety.sh)
+
+```bash
+# SOURCE: ycc/skills/clean/scripts/validate-safety.sh:71-72,98-100,238
+declare -a PROTECTED=( ".git" ".env" ".env.*" "*.pem" "*.key" )
+if [[ -L "$full_path" ]]; then ((symlink_violations+=1)); fi
+# distinct exit codes per failure class (header :8-14)
+```
+
+### TEST_STRUCTURE (the project's verification loop)
+
+```bash
+# SOURCE: CLAUDE.md "Testing Changes" + scripts/validate.sh:113-119
+./scripts/sync.sh        # regenerate every bundle (accepts --only inventory,cursor,codex,opencode,json)
+./scripts/validate.sh    # run every validator (CI loop); includes python3 -m json.tool on both manifests
+find ycc/skills -name "*.sh" -not -executable   # must output nothing
+```
+
+---
+
+## Files to Change
+
+| File                                                                                  | Action             | Justification                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ycc/skills/_shared/references/agent-native-setup.md`                                 | CREATE             | DRY runtime contract: pinned `@agent-native/*` install/reconnect, MCP `plan` connector (alias `agent-native-plans`), `local-files` mode, localhost-bridge commands, hosted-egress policy. Shared by both skills. |
+| `ycc/skills/_shared/references/visual-mode.md`                                        | CREATE             | Canonical `--visual` decorator contract referenced by all four planning skills (post-generation, orthogonal, `--dry-run` short-circuit, plan-path hand-off, `/ycc:plan` force-write).                            |
+| `ycc/skills/_shared/scripts/visual-recap-collect.sh`                                  | CREATE             | Remote-agnostic local diff collector (`git merge-base` + `git diff <base>...<head>`, `git remote get-url`); writes under `docs/prps/reviews/visual/<slug>/`.                                                     |
+| `ycc/skills/_shared/scripts/visual-egress-guard.sh`                                   | CREATE             | Pre-upload secret/denylist scan + non-public-remote refusal + consent gate; single shared guard reused by hosted paths (mirrors `clean/validate-safety.sh`).                                                     |
+| `ycc/skills/visual-plan/SKILL.md`                                                     | CREATE             | Ported visual-plan body; faithful hosted+local MDX workflow; egress consent-gated; `${CLAUDE_PLUGIN_ROOT}`-relative refs.                                                                                        |
+| `ycc/skills/visual-plan/references/{canvas,wireframe,document-quality,exemplar}.md`   | CREATE             | Quality references the skill mandates reading before authoring (provider-neutral port).                                                                                                                          |
+| `ycc/skills/visual-plan/scripts/*.sh`                                                 | CREATE (if needed) | Thin wrappers over shared `_shared/scripts` helpers; executable, strict-mode.                                                                                                                                    |
+| `ycc/commands/visual-plan.md`                                                         | CREATE             | Pairing policy: every skill needs a matching command (or `command: false`).                                                                                                                                      |
+| `ycc/skills/visual-recap/SKILL.md`                                                    | CREATE             | Ported recap body, **rewritten local-only**: deliverable under `docs/prps/reviews/visual/`, served via `plan local serve`; hosted `create-visual-recap` disabled; inverts the upstream "always hosted" mandate.  |
+| `ycc/skills/visual-recap/references/wireframe.md`                                     | CREATE             | Wireframe quality ref required by recap.                                                                                                                                                                         |
+| `ycc/commands/visual-recap.md`                                                        | CREATE             | Pairing policy; local-only help doc.                                                                                                                                                                             |
+| `docs/prps/reviews/visual/.gitkeep`                                                   | CREATE             | Establish the local-only recap output location.                                                                                                                                                                  |
+| `.gitignore`                                                                          | UPDATE             | Ignore local-serve scratch (`plan-blocks.md`, served-plan temp dirs) so runs don't dirty the tree.                                                                                                               |
+| `ycc/skills/prp-plan/SKILL.md`                                                        | UPDATE             | `--visual` case+strip (near :70-74), flag table (:50-57), validation bullet (:77-82), Worktree/Visual block, post-Phase-6 bootstrap, Report fields (:417-434).                                                   |
+| `ycc/commands/prp-plan.md`                                                            | UPDATE             | `--visual` flag row + Usage grammar + one example.                                                                                                                                                               |
+| `ycc/skills/plan/SKILL.md`                                                            | UPDATE             | `--visual` parse (:90-94), table (:43-50), validation (:97-102), **force-write artifact** + post-confirmation bootstrap.                                                                                         |
+| `ycc/commands/plan.md`                                                                | UPDATE             | `--visual` flag row + Usage + example.                                                                                                                                                                           |
+| `ycc/skills/plan-workflow/SKILL.md`                                                   | UPDATE             | `--visual` arg parse (:96-114), arg list (:52-64), usage, post-final-phase bootstrap.                                                                                                                            |
+| `ycc/commands/plan-workflow.md`                                                       | UPDATE             | `--visual` flag docs/usage.                                                                                                                                                                                      |
+| `ycc/skills/parallel-plan/SKILL.md`                                                   | UPDATE             | `--visual` arg parse (:104-119), arg list (:67-73), dry-run roster/usage, post-final-phase bootstrap.                                                                                                            |
+| `ycc/commands/parallel-plan.md`                                                       | UPDATE             | `--visual` flag docs/usage.                                                                                                                                                                                      |
+| `mcp-configs/mcp.json`                                                                | UPDATE             | Register the `plan` Agent-Native MCP connector (accept legacy alias `agent-native-plans`) so opencode `opencode.json` MCP translation picks it up for the hosted path.                                           |
+| `.cursor-plugin/**`, `.codex-plugin/**`, `.opencode-plugin/**`, `docs/inventory.json` | REGENERATE         | Produced by `./scripts/sync.sh` from `ycc/` — never hand-edit.                                                                                                                                                   |
+| `.claude-plugin/marketplace.json`, `ycc/.claude-plugin/plugin.json`                   | NO EDIT            | Discovery is directory-based (`source: ./ycc`); no per-skill manifest entry. Version bumps are owned by `bundle-release`, not this plan.                                                                         |
+
+## NOT Building
+
+- **No GitHub Action / no `.github/workflows/visual-*.yml`** — explicitly out of scope; the
+  upstream Action is installer-generated, not committed, so there is nothing to port.
+- **No second marketplace plugin** — both skills ship inside the existing single `ycc`
+  bundle; a second `.claude-plugin/marketplace.json` entry is forbidden by repo policy.
+- **No custom MDX/HTML renderer, browser, or screenshot engine** — rely on the upstream
+  `@agent-native` hosted UI + localhost bridge as-is; ported skills are prompt + reference
+  content only.
+- **No `--visual` on non-planning skills** — scope is exactly the four named skills; do not
+  retrofit `implement-plan`, `prp-implement`, etc.
+- **visual-recap is NOT wired into the four planning skills** — it pairs with review flows,
+  local-only.
+- **No changes to existing research/dispatch logic** of the four skills — `--visual` adds a
+  terminal decorator step only.
+- **No auto-publish / auto-commit** of generated MDX or hosted links (matches repo posture).
+- **No new validators** — reuse the existing `--check`-gated generator/validator pipeline.
+- **No upstream npm/`package.json` runtime deps vendored** — repo uses npm for lint/format
+  only; the Agent-Native tooling runs via pinned `npx` at use time.
+- **`/goal` pairing deferred (decide explicitly)** — see Notes; not added to the new skills
+  in this pass unless the user opts in.
+
+---
+
+## Step-by-Step Tasks
+
+> Hierarchical IDs map to the Batches table. No two tasks in the same batch touch the same
+> file. `--visual` is added by **copying** the `--enhanced` flag-parse pattern verbatim and
+> a single shared `## Visual mode` block into each of the four skills.
+
+### Task 1.1: Shared Agent-Native setup reference — Depends on [none]
+
+- **BATCH**: B1
+- **ACTION**: Create `ycc/skills/_shared/references/agent-native-setup.md`.
+- **IMPLEMENT**: Document the runtime contract once: pinned install (`npx -y @agent-native/core@<PINNED_VERSION> skills add <skill>`), `reconnect https://plan.agent-native.com --client [claude-code|codex|all]`, the `plan` MCP connector (legacy alias `agent-native-plans`), `AGENT_NATIVE_PLANS_MODE=local-files`, the localhost-bridge commands (`plan local check`, `plan local serve --open`), and the egress policy (hosted OFF by default, consent-gated). Resolve and record the exact `@agent-native/core` version to pin (check `npm view @agent-native/core version`); never write `@latest` into committed content.
+- **MIRROR**: NAMING_CONVENTION; `_shared/references/*.md` style (e.g. `target-capability-matrix.md`).
+- **GOTCHA**: Block vocabulary drifts upstream — the doc must instruct the runtime author step to call `get-plan-blocks` (or offline `plan blocks --out`) at use time rather than trusting the hardcoded component list.
+- **VALIDATE**: File exists; no `@latest` token (`! grep -q '@latest' ycc/skills/_shared/references/agent-native-setup.md`); referenced by both new skills.
+
+### Task 1.2: Shared visual-mode contract reference — Depends on [none]
+
+- **BATCH**: B1
+- **ACTION**: Create `ycc/skills/_shared/references/visual-mode.md`.
+- **IMPLEMENT**: Define the canonical `--visual` decorator contract used by all four planning skills: runs AFTER the plan is written + validated; orthogonal to `--parallel`/`--team`/`--enhanced`/`--no-worktree`; **short-circuited by `--dry-run`** (print "visual generation would run"); hand-off = invoke `ycc:visual-plan <absolute-plan-path>`, which derives a sibling `visual/` output dir and prints the link to stdout; visual-plan never re-runs research/dispatch and never edits the plan; `/ycc:plan --visual` must force a plan-file write first (nothing to visualize otherwise).
+- **MIRROR**: The shared worktree-strategy reference pattern (one canonical block reused across skills).
+- **GOTCHA**: The four skills write plans to different paths (`docs/prps/plans/*.plan.md`, feature-dir `parallel-plan.md`, or none) — the contract must instruct visual-plan to accept ANY plan path and derive `visual/` relative to it.
+- **VALIDATE**: File exists; all four skills reference it after Batch 3.
+
+### Task 1.3: Shared remote-agnostic recap collector + egress guard — Depends on [none]
+
+- **BATCH**: B1
+- **ACTION**: Create `ycc/skills/_shared/scripts/visual-recap-collect.sh` and `ycc/skills/_shared/scripts/visual-egress-guard.sh`; `chmod +x` both.
+- **IMPLEMENT**: `visual-recap-collect.sh` — strict-mode bash; arg = `<base..head | branch>` (default working-tree diff); compute base via `git merge-base` against the tracked upstream, NEVER hardcode `origin/main`; resolve remote URL via `git remote get-url <name>`; write diff bundle under `docs/prps/reviews/visual/<slug>/`; results→stdout, errors→stderr. `visual-egress-guard.sh` — pre-upload secret/denylist scan (mirror `clean/validate-safety.sh` PROTECTED list: `.env*`, `*.pem`, `*.key`), refuse when the resolved remote is the private Forgejo `origin` (non-public), require explicit consent token; distinct exit codes per failure class.
+- **MIRROR**: ERROR_HANDLING + PROTECTED_PATH_DENYLIST; `_shared/scripts/prepare-feature-branch.sh:69-92` strict flag parsing.
+- **IMPORTS**: source nothing external; reuse `_shared/scripts` conventions.
+- **GOTCHA**: `collect-diff` must use local git refs only (`git diff <base>...<head>`) — never a vendor PR API — so it is identical on GitHub and Forgejo.
+- **VALIDATE**: `bash -n` both scripts; `find ycc/skills -name "*.sh" -not -executable` empty; pinned `shellcheck` clean.
+
+### Task 1.4: Create `docs/prps/reviews/visual/` + `.gitignore` scratch ignores — Depends on [none]
+
+- **BATCH**: B1
+- **ACTION**: Create `docs/prps/reviews/visual/.gitkeep`; append local-serve scratch ignores to `.gitignore`.
+- **IMPLEMENT**: Add ignore entries for `plan-blocks.md` and served-plan temp dirs so visual runs don't dirty the working tree. Keep `.gitkeep` so the local-only recap output dir exists.
+- **MIRROR**: Existing `.gitignore` grouping.
+- **VALIDATE**: `git check-ignore` matches the scratch patterns; `.gitkeep` tracked.
+
+### Task 2.1: Port `ycc:visual-plan` (skill + references + command) — Depends on [1.1, 1.2]
+
+- **BATCH**: B2
+- **ACTION**: Scaffold via `ycc:bundle-author`, then port content. Create `ycc/skills/visual-plan/{SKILL.md,references/{canvas,wireframe,document-quality,exemplar}.md}`, optional `scripts/`, and `ycc/commands/visual-plan.md`.
+- **IMPLEMENT**: Port BuilderIO visual-plan @ `a072671` faithfully — keep MDX vocab, hosted Agent-Native app, localhost bridge, mode auto-selection, `get-plan-blocks`→create→feedback→`update-visual-plan` flow. Rewrite all paths to `${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/...`; reference `_shared/references/agent-native-setup.md` for runtime + the egress guard; make hosted/shareable egress consent-gated (default local-files). Drop the GitHub Action entirely.
+- **MIRROR**: SKILL_FRONTMATTER, COMMAND_FRONTMATTER, NAMING_CONVENTION.
+- **GOTCHA**: Hosted create tools upload MDX (real paths/symbols/snippets) to `plan.agent-native.com`; SKILL must make hosted-vs-local an explicit defaulted choice (local default) and route egress through `visual-egress-guard.sh`.
+- **VALIDATE**: `python3 -m json.tool` n/a; `head -1` frontmatter valid; `ycc/skills/_shared/scripts/validate-file-paths.sh` resolves `${CLAUDE_PLUGIN_ROOT}` refs; command/skill pairing present.
+
+### Task 2.2: Port `ycc:visual-recap` (local-only) (skill + references + command) — Depends on [1.1, 1.3]
+
+- **BATCH**: B2
+- **ACTION**: Scaffold via `ycc:bundle-author`, then port. Create `ycc/skills/visual-recap/{SKILL.md,references/wireframe.md}`, optional `scripts/`, and `ycc/commands/visual-recap.md`.
+- **IMPLEMENT**: Port recap body but **invert the hosted mandate**: set `AGENT_NATIVE_PLANS_MODE=local-files`, never call `create-visual-recap`/hosted Plan MCP; deliverable is local MDX under `docs/prps/reviews/visual/<slug>/`, served via `plan local serve --open`. Source diffs through `_shared/scripts/visual-recap-collect.sh` (remote-agnostic). `get-plan-blocks` (schema-only, offline fallback) is the only permitted network call.
+- **MIRROR**: SKILL_FRONTMATTER, ERROR_HANDLING; visual-plan reference layout.
+- **GOTCHA**: Upstream forbids inline Markdown and forces hosting — the ported skill must explicitly state local-only and must not regress to hosted create tools.
+- **VALIDATE**: `grep -q 'local-files' ycc/skills/visual-recap/SKILL.md`; `! grep -q 'create-visual-recap' ycc/skills/visual-recap/SKILL.md`; pairing present.
+
+### Task 3.1: Add `--visual` to `prp-plan` — Depends on [2.1]
+
+- **BATCH**: B3
+- **ACTION**: Edit `ycc/skills/prp-plan/SKILL.md` and `ycc/commands/prp-plan.md`.
+- **IMPLEMENT**: Add a `VISUAL_MODE` case+strip pair to the Phase-0 flag-parse block (copy `--enhanced` at :70-74); add a `--visual` flag-table row (:50-57) and a validation bullet (`--visual` orthogonal; `--dry-run` short-circuits) at :77-82; add a `## Visual mode` block that references `_shared/references/visual-mode.md`; add a post-Phase-6 step "if `VISUAL_MODE` and not `--dry-run`, invoke `ycc:visual-plan <plan-path>`"; add `Visual Artifact`/`Visual Link` fields to the Report block (:417-434). Update command flag row + Usage + one example.
+- **MIRROR**: FLAG_PARSE, FLAG_VALIDATION / COMMAND_FLAG_TABLE.
+- **GOTCHA**: `--visual` runs after plan write regardless of `--parallel`/`--team` dispatch — keep it dispatch-agnostic.
+- **VALIDATE**: `grep -q 'VISUAL_MODE' ycc/skills/prp-plan/SKILL.md`; `grep -q -- '--visual' ycc/commands/prp-plan.md`.
+
+### Task 3.2: Add `--visual` to `plan` (force-write artifact) — Depends on [2.1]
+
+- **BATCH**: B3
+- **ACTION**: Edit `ycc/skills/plan/SKILL.md` and `ycc/commands/plan.md`.
+- **IMPLEMENT**: Same flag-parse/table/validation pattern (parse near :90-94, table :43-50, validation :97-102). Because `/ycc:plan` writes no artifact by default, `--visual` must **force a plan-file write first**, then invoke `ycc:visual-plan` on it (post-confirmation). Reference `_shared/references/visual-mode.md`.
+- **MIRROR**: FLAG_PARSE; Task 3.1 wording (identical canonical block).
+- **GOTCHA**: Do not visualize an unwritten plan — the force-write is mandatory for this skill only.
+- **VALIDATE**: `grep -q 'VISUAL_MODE' ycc/skills/plan/SKILL.md`; force-write path documented; `grep -q -- '--visual' ycc/commands/plan.md`.
+
+### Task 3.3: Add `--visual` to `plan-workflow` — Depends on [2.1]
+
+- **BATCH**: B3
+- **ACTION**: Edit `ycc/skills/plan-workflow/SKILL.md` and `ycc/commands/plan-workflow.md`.
+- **IMPLEMENT**: Add `--visual` to the arg-parse step (:96-114), the arg list (:52-64), and the usage block; add the post-final-phase bootstrap invoking `ycc:visual-plan` on the produced plan (feature-dir `parallel-plan.md`). Reference `_shared/references/visual-mode.md`.
+- **MIRROR**: FLAG_PARSE; Task 3.1 canonical block.
+- **GOTCHA**: Hand off the actual written plan path (feature-dir), not a fixed `docs/prps/plans` path.
+- **VALIDATE**: `grep -q -- '--visual' ycc/skills/plan-workflow/SKILL.md ycc/commands/plan-workflow.md`.
+
+### Task 3.4: Add `--visual` to `parallel-plan` — Depends on [2.1]
+
+- **BATCH**: B3
+- **ACTION**: Edit `ycc/skills/parallel-plan/SKILL.md` and `ycc/commands/parallel-plan.md`.
+- **IMPLEMENT**: Add `--visual` to the arg-parse step (:104-119), arg list (:67-73), dry-run roster/usage; add the post-final-phase bootstrap. Ensure `--visual --dry-run` only prints intent. Reference `_shared/references/visual-mode.md`.
+- **MIRROR**: FLAG_PARSE; Task 3.1 canonical block.
+- **GOTCHA**: Respect the existing `--dry-run` semantics — short-circuit visual generation in dry-run.
+- **VALIDATE**: `grep -q -- '--visual' ycc/skills/parallel-plan/SKILL.md ycc/commands/parallel-plan.md`.
+
+### Task 4.1: Register `plan` MCP connector + regenerate all bundles — Depends on [1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 3.1, 3.2, 3.3, 3.4]
+
+- **BATCH**: B4
+- **ACTION**: Edit `mcp-configs/mcp.json` to register the `plan` Agent-Native connector (accept legacy alias `agent-native-plans`), then run `./scripts/sync.sh`.
+- **IMPLEMENT**: Add the MCP entry so opencode `opencode.json` translation exposes the hosted path. Run `./scripts/sync.sh` to regenerate inventory + Cursor + Codex + opencode (new skills propagate to all three; new commands propagate to opencode only). Do NOT hand-edit generated files.
+- **MIRROR**: Existing `mcp-configs/mcp.json` entry shape.
+- **GOTCHA**: This task is the single point where same-file generated bundles are written — it must run after all source edits (hence B4).
+- **VALIDATE**: `python3 -m json.tool mcp-configs/mcp.json`; `git status` shows regenerated `.cursor-plugin/`, `.codex-plugin/`, `.opencode-plugin/`, `docs/inventory.json` containing both new skills.
+
+### Task 5.1: Validate (CI loop) — Depends on [4.1]
+
+- **BATCH**: B5
+- **ACTION**: Run `./scripts/validate.sh` and the JSON manifest checks.
+- **IMPLEMENT**: `./scripts/validate.sh` runs inventory (skill↔command pairing — confirms both new skills have matching commands), cursor/codex/opencode `--check` validators (drift = fail), and JSON manifest checks. Also run `python3 -m json.tool` on `.claude-plugin/marketplace.json` and `ycc/.claude-plugin/plugin.json`, and `find ycc/skills -name "*.sh" -not -executable`.
+- **MIRROR**: TEST_STRUCTURE.
+- **GOTCHA**: Any drift means Batch 4 regeneration was skipped/partial — re-run `./scripts/sync.sh` then re-validate.
+- **VALIDATE**: `./scripts/validate.sh` exits 0; both manifests parse; no non-executable scripts.
+
+---
+
+## Testing Strategy
+
+This repo's verification is structural (no unit-test runner). "Tests" = the validator
+pipeline plus targeted greps.
+
+### Validator / Integration
+
+| Check                 | Command                                             | Expected                                  |
+| --------------------- | --------------------------------------------------- | ----------------------------------------- |
+| Skill↔command pairing | `./scripts/validate.sh --only inventory`            | both new skills paired; no orphan command |
+| Cursor bundle drift   | `./scripts/validate.sh --only cursor`               | no drift                                  |
+| Codex bundle drift    | `./scripts/validate.sh --only codex`                | no drift                                  |
+| opencode bundle drift | `./scripts/validate.sh --only opencode`             | no drift (skills + commands)              |
+| JSON manifests        | `./scripts/validate.sh --only json`                 | both parse                                |
+| Scripts executable    | `find ycc/skills -name "*.sh" -not -executable`     | empty                                     |
+| Path refs resolve     | `ycc/skills/_shared/scripts/validate-file-paths.sh` | all `${CLAUDE_PLUGIN_ROOT}` refs resolve  |
+
+### Edge Cases Checklist
+
+- [ ] `--visual --dry-run` prints intent only; no visual artifact written
+- [ ] `/ycc:plan --visual` force-writes a plan file before visualizing
+- [ ] `--visual --parallel` and `--visual --team` both run visual generation after dispatch completes
+- [ ] visual-recap against the **Forgejo** `origin` produces a local artifact and refuses hosted upload
+- [ ] visual-recap against the **github** remote behaves identically (remote-agnostic)
+- [ ] egress guard aborts when `.env`/key material is present in the diff
+- [ ] hosted link generation fails soft — MDX is still written locally if the link step fails
+
+---
+
+## Validation Commands
+
+### Static / Structural
+
+```bash
+./scripts/sync.sh
+./scripts/validate.sh
+```
+
+EXPECT: regeneration clean; validator exits 0
+
+### JSON Manifests
+
+```bash
+python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
+python3 -m json.tool ycc/.claude-plugin/plugin.json >/dev/null
+python3 -m json.tool mcp-configs/mcp.json >/dev/null
+```
+
+EXPECT: all parse, no second plugin entry introduced
+
+### Script Hygiene
+
+```bash
+find ycc/skills -name "*.sh" -not -executable
+bash -n ycc/skills/_shared/scripts/visual-recap-collect.sh
+bash -n ycc/skills/_shared/scripts/visual-egress-guard.sh
+```
+
+EXPECT: no non-executable scripts; no syntax errors; pinned `shellcheck` clean
+
+### Flag Presence
+
+```bash
+for s in prp-plan plan plan-workflow parallel-plan; do
+  grep -q -- '--visual' "ycc/skills/$s/SKILL.md" "ycc/commands/$s.md" || echo "MISSING: $s"
+done
+```
+
+EXPECT: no `MISSING:` output
+
+### Manual Validation
+
+- [ ] `/ycc:prp-plan --visual <feature>` writes `.plan.md` then a `visual/` MDX artifact + link
+- [ ] `/ycc:visual-plan docs/prps/plans/<name>.plan.md` renders standalone
+- [ ] `/ycc:visual-recap` produces `docs/prps/reviews/visual/<slug>/` with no network upload
+
+---
+
+## Acceptance Criteria
+
+- [ ] `ycc/skills/visual-plan/SKILL.md` + `ycc/skills/visual-recap/SKILL.md` exist with valid frontmatter; reachable as `ycc:visual-plan` / `ycc:visual-recap`
+- [ ] `ycc/commands/visual-plan.md` + `ycc/commands/visual-recap.md` exist (pairing satisfied)
+- [ ] `--visual` present in `argument-hint` + flag table of all four planning skills and their command docs
+- [ ] Each of the four skills sets `VISUAL_MODE` and routes to `ycc:visual-plan` post-generation; `--dry-run` short-circuits; `/ycc:plan` force-writes first
+- [ ] `ycc:visual-plan` keeps MDX + hosted link + npx tooling + localhost bridge; contains NO GitHub Action reference; hosted egress consent-gated
+- [ ] `ycc:visual-recap` is local-only → `docs/prps/reviews/visual/`; no hosted publish step
+- [ ] Both new skills appear in `docs/inventory.json` and all three generated bundles after `./scripts/sync.sh`
+- [ ] `./scripts/validate.sh` exits 0; both JSON manifests parse; `ycc:` namespace unchanged; no second plugin entry
+- [ ] All new `*.sh` executable + strict-mode + pass pinned `shellcheck`
+- **S1** `npx @agent-native/*` invoked at a pinned exact version; pin + egress documented in SKILL
+- **S2** hosted upload OFF by default; shareable link requires explicit `--share`/consent naming the destination host
+- **S3** visual-recap performs no remote fetch/upload by default
+- **S4** diff/recap remote sourcing explicit; upload refused when resolved remote is the private Forgejo `origin`
+- **S5** pre-upload secret/denylist scan (`.env*`, keys) aborts on hit
+- **S6** localhost bridge binds `127.0.0.1`, ephemeral port + per-session token, origin allowlist
+- **S7** new scripts: strict mode, input guards, `case` flag parsing, stdout/stderr discipline, exit 0/1
+- **S8** shared bridge/egress/consent logic in one `_shared/scripts` helper reused by all four `--visual` skills
+- **S9** `find ycc/skills -name "*.sh" -not -executable` empty; pinned `shellcheck` clean
+
+## Completion Checklist
+
+- [ ] Code follows discovered patterns (FLAG_PARSE, SKILL/COMMAND_FRONTMATTER, ERROR_HANDLING)
+- [ ] `--visual` wording identical across all four skills via the shared `visual-mode.md` block
+- [ ] Single hand-off contract documented (input = absolute plan path; output = sibling `visual/` + link to stdout)
+- [ ] No GitHub Action added; Forgejo posture documented (no `.forgejo/workflows/` created)
+- [ ] Remote-agnostic verified (`git remote get-url`/`git merge-base`; no hardcoded `github.com`/`origin/main`); tested against both remotes
+- [ ] `npx @agent-native/*` version pinned and recorded in setup reference + command docs
+- [ ] `mcp-configs/mcp.json` registers `plan` (alias accepted); manifests validated
+- [ ] `./scripts/sync.sh` run; `./scripts/validate.sh` green (CI loop)
+- [ ] All `${CLAUDE_PLUGIN_ROOT}` paths resolve; no generated files hand-edited
+- [ ] `/goal` pairing decision recorded (include or explicitly skip)
+- [ ] No unnecessary scope additions
+
+## Risks
+
+| Risk                                                                                                                               | Likelihood | Impact   | Mitigation                                                                                                                               |
+| ---------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `npx @agent-native/skills@latest` fetches+executes unpinned remote code with full shell/repo privileges (supply-chain / typosquat) | Medium     | Critical | Pin exact version; gate behind explicit `--visual` opt-in; document egress; consider `--ignore-scripts`/lockfile review                  |
+| Hosted shareable links upload MDX (may embed private Forgejo code) to `plan.agent-native.com`; cached even after deletion          | High       | Critical | Local-files default; per-invocation consent gate (`--share`) naming the host; never auto-publish; route through `visual-egress-guard.sh` |
+| Hosted-link / diff-base hardcodes `github.com` or `origin/main`, breaking the Forgejo `origin`                                     | High       | High     | `git remote get-url <name>` + `git merge-base` only; user-selectable remote; refuse upload on non-public remote                          |
+| recap sources refs from whichever remote resolves first; private Forgejo branches leak into a hosted recap                         | Medium     | High     | recap local-only by default; explicit `--remote`; print remote+refspec before generating                                                 |
+| localhost bridge over-permissive — any page reads repo content / triggers writes                                                   | Medium     | High     | bind `127.0.0.1`, ephemeral port, per-session token + short TTL, origin allowlist                                                        |
+| secrets (`.env`, tokens) serialized into MDX and shipped                                                                           | Medium     | High     | pre-upload denylist scan mirroring `clean/validate-safety.sh`; redact or abort                                                           |
+| Four compatibility bundles drift (source edited, bundles not regenerated)                                                          | High       | Medium   | `./scripts/sync.sh` + `./scripts/validate.sh` as a hard completion gate; CI catches drift                                                |
+| `--visual` composes inconsistently across the four different plan-output paths                                                     | High       | Medium   | single hand-off contract; visual-plan derives `visual/` from any plan path; `/ycc:plan` force-writes                                     |
+| `--visual` added to flag tables but interaction rules (dry-run short-circuit, no-artifact case) omitted on some skills             | Medium     | Medium   | one canonical `visual-mode.md` block referenced by all four                                                                              |
+| `--visual` made command-only → silently dropped on Codex, degraded on Cursor                                                       | Medium     | Medium   | implement `--visual` as a SKILL-body branch (skills supported on all targets); command layer documents only                              |
+
+## Notes
+
+- **Confidence: 7/10.** Flag-composition and the bootstrap hand-off are clean and grounded in
+  the four skills' existing flag tables (`--enhanced` is the exact model). The soft spot is the
+  faithful hosted Agent-Native integration: it pulls an unpinned external toolchain and can
+  upload private code — hence the security hardening (consent gate, pinning, egress guard,
+  local-files default) layered on top of the faithful port. Pin the `@agent-native/core`
+  version during Task 1.1 before writing any committed `npx` invocation.
+- **`--visual` is a post-generation decorator, not a dispatch mode.** It runs after the plan is
+  written + validated and is invisible to `--parallel`/`--team` dispatch (same property as the
+  dispatch-agnostic `validate-prp-plan.sh`). `--dry-run` short-circuits it.
+- **Two remotes are real and asymmetric**: `origin` = private Forgejo
+  (`git.azules-celsius.ts.net`), `github` = public. Treat `origin` as non-public for egress
+  decisions. There is NO `.forgejo/workflows/` today — "Forgejo-aware" here means
+  remote-agnostic git sourcing, not authoring CI. If CI recap is ever wanted, mirror to both
+  `.forgejo/workflows/` and `.github/workflows/`.
+- **`get-plan-blocks` drift**: the upstream block vocabulary changes; the runtime author step
+  must re-fetch the live catalog (or offline `plan blocks --out`) rather than trust the
+  hardcoded MDX component list in the ported references.
+- **MCP connector naming**: register `plan` and accept the legacy alias `agent-native-plans`,
+  or hosted tool calls silently no-op.
+- **`/goal` pairing decision needed**: `plan.md` is already `/goal`-paired. Adding `/goal`
+  support to the new visual skills follows the repo's 4-part recipe (`goal-pairing.md`). This
+  plan defers it (NOT Building) — flag to the user whether to fold it in now or as a follow-up.
+- **Use `ycc:bundle-author`** to scaffold both new skill+command surfaces rather than
+  hand-creating the directory tree; it encodes the source-of-truth split.

--- a/docs/prps/reports/visual-planning-skills-report.md
+++ b/docs/prps/reports/visual-planning-skills-report.md
@@ -1,0 +1,136 @@
+# Implementation Report: Visual Planning Skills
+
+## Summary
+
+Ported the BuilderIO `visual-plan` and `visual-recap` skills (pinned upstream commit
+`a0726717ab0402e85eadca46183d8be50bc3a102`) into the `ycc` bundle as `ycc:visual-plan` and
+`ycc:visual-recap`, and added an orthogonal `--visual` decorator flag to the four planning
+skills (`prp-plan`, `plan`, `plan-workflow`, `parallel-plan`). `ycc:visual-plan` keeps the
+faithful Agent-Native integration (MDX, hosted shareable links, `npx @agent-native/*` tooling,
+localhost bridge) but gates hosted egress behind explicit `--share` consent and routes it
+through a shared egress guard; `ycc:visual-recap` is rewritten local-only and remote-agnostic.
+The `plan` Agent-Native MCP connector (legacy alias `agent-native-plans`) was registered, and
+all Cursor / Codex / opencode bundles plus `docs/inventory.json` were regenerated and validated.
+
+## Assessment vs Reality
+
+| Metric        | Predicted (Plan)           | Actual                                       |
+| ------------- | -------------------------- | -------------------------------------------- |
+| Complexity    | Large (10+ files)          | Large — confirmed                            |
+| Confidence    | 7/10                       | High — implemented as planned                |
+| Files Changed | ~22 source (excl. bundles) | 22 source files; 38 regenerated bundle files |
+
+## Execution Mode
+
+- **Mode**: Parallel sub-agents (`--parallel --no-worktree`)
+- **Batches**: 5 (B1 width 4, B2 width 2, B3 width 4, B4 width 1, B5 width 1)
+- **Branch**: `feat/visual-planning-skills` (from `main`)
+
+## Tasks Completed
+
+| #   | Task                                                 | Status   | Notes                                             |
+| --- | ---------------------------------------------------- | -------- | ------------------------------------------------- |
+| 1.1 | Shared `agent-native-setup.md` reference             | Complete | Pinned `@agent-native/core@0.59.1` (no `@latest`) |
+| 1.2 | Shared `visual-mode.md` contract reference           | Complete |                                                   |
+| 1.3 | `visual-recap-collect.sh` + `visual-egress-guard.sh` | Complete | Distinct exit codes; remote-agnostic              |
+| 1.4 | `docs/prps/reviews/visual/.gitkeep` + `.gitignore`   | Complete | `.gitkeep` recreated after a B1 cleanup race      |
+| 2.1 | Port `ycc:visual-plan` (skill + 4 refs + command)    | Complete | + thin `derive-visual-dir.sh`; no GitHub Action   |
+| 2.2 | Port `ycc:visual-recap` (local-only)                 | Complete | Inverts hosted mandate; `local-files` enforced    |
+| 3.1 | `--visual` on `prp-plan`                             | Complete | + `Visual Artifact`/`Visual Link` report fields   |
+| 3.2 | `--visual` on `plan` (force-write artifact)          | Complete | Force-writes plan file first                      |
+| 3.3 | `--visual` on `plan-workflow`                        | Complete | Hands off actual feature-dir plan path            |
+| 3.4 | `--visual` on `parallel-plan`                        | Complete | `--dry-run` short-circuit honored                 |
+| 4.1 | Register `plan` MCP connector + `./scripts/sync.sh`  | Complete | Regenerated all bundles + inventory               |
+| 5.1 | `./scripts/validate.sh` CI loop                      | Complete | Green after one fix (see Deviations)              |
+
+## Validation Results
+
+| Level                      | Status | Notes                                                        |
+| -------------------------- | ------ | ------------------------------------------------------------ |
+| Structural (`validate.sh`) | Pass   | inventory + cursor/codex/opencode `--check` + JSON manifests |
+| JSON manifests             | Pass   | marketplace.json, plugin.json, mcp.json all parse            |
+| Script hygiene             | Pass   | new `*.sh` executable, `bash -n` clean, `shellcheck` clean   |
+| Lint (markdown/prettier)   | Pass   | `npm run lint:modified` clean after auto-fix                 |
+| Flag presence              | Pass   | `--visual`/`VISUAL_MODE`/`visual-mode.md` on all 4 skills    |
+
+> Note: this repo has no unit-test runner; "tests" are the validator pipeline + targeted greps,
+> per the plan's Testing Strategy.
+
+## Files Changed
+
+### Created (source)
+
+| File                                                                                | Action  |
+| ----------------------------------------------------------------------------------- | ------- |
+| `ycc/skills/_shared/references/agent-native-setup.md`                               | CREATED |
+| `ycc/skills/_shared/references/visual-mode.md`                                      | CREATED |
+| `ycc/skills/_shared/scripts/visual-recap-collect.sh`                                | CREATED |
+| `ycc/skills/_shared/scripts/visual-egress-guard.sh`                                 | CREATED |
+| `ycc/skills/visual-plan/SKILL.md`                                                   | CREATED |
+| `ycc/skills/visual-plan/references/{canvas,wireframe,document-quality,exemplar}.md` | CREATED |
+| `ycc/skills/visual-plan/scripts/derive-visual-dir.sh`                               | CREATED |
+| `ycc/commands/visual-plan.md`                                                       | CREATED |
+| `ycc/skills/visual-recap/SKILL.md`                                                  | CREATED |
+| `ycc/skills/visual-recap/references/wireframe.md`                                   | CREATED |
+| `ycc/commands/visual-recap.md`                                                      | CREATED |
+| `docs/prps/reviews/visual/.gitkeep`                                                 | CREATED |
+
+### Updated (source)
+
+| File                                | Action  |
+| ----------------------------------- | ------- |
+| `.gitignore`                        | UPDATED |
+| `mcp-configs/mcp.json`              | UPDATED |
+| `ycc/skills/prp-plan/SKILL.md`      | UPDATED |
+| `ycc/commands/prp-plan.md`          | UPDATED |
+| `ycc/skills/plan/SKILL.md`          | UPDATED |
+| `ycc/commands/plan.md`              | UPDATED |
+| `ycc/skills/plan-workflow/SKILL.md` | UPDATED |
+| `ycc/commands/plan-workflow.md`     | UPDATED |
+| `ycc/skills/parallel-plan/SKILL.md` | UPDATED |
+| `ycc/commands/parallel-plan.md`     | UPDATED |
+
+### Regenerated (never hand-edited)
+
+`.cursor-plugin/**`, `.codex-plugin/**`, `.opencode-plugin/**`, `docs/inventory.json`,
+`README.md` — 38 generated files, produced by `./scripts/sync.sh`.
+
+## Deviations from Plan
+
+- **opencode install-coverage failure (fixed)**: The first `validate.sh` run failed because
+  `agent-native-setup.md`'s intro cited `${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/...` with a
+  literal `...` ellipsis, which the install-coverage validator tried to resolve as a real file.
+  Repointed the two references to the concrete `SKILL.md` files, regenerated, and re-validated
+  green.
+- **B1 race condition (recovered)**: Task 1.3's functional smoke tests transiently removed the
+  `docs/prps/reviews/visual/.gitkeep` created by Task 1.4 (shared checkout, no worktree). The
+  parent recreated it during B1 validation.
+
+## Issues Encountered
+
+- Two pre-existing non-executable scripts (`ycc/skills/formatters/scripts/bundle/lib/shellcheck-resolve.sh`,
+  `shellcheck-version.sh`) are tracked mode `100644` (sourced `lib/` files, not executables).
+  They predate this work and are not flagged by `validate.sh`; left untouched.
+
+## Security Posture (plan S1–S9)
+
+- **S1** `npx @agent-native/*` pinned to exact `0.59.1`; pin + egress documented in setup ref.
+- **S2** Hosted upload OFF by default; `--share` required, naming `plan.agent-native.com`.
+- **S3** `visual-recap` performs no remote fetch/upload by default (`local-files`).
+- **S4** Remote sourcing explicit via `git remote get-url`; upload refused on private Forgejo `origin`.
+- **S5** Pre-upload `.env*`/key denylist scan aborts on hit (`visual-egress-guard.sh`).
+- **S6** Localhost bridge binds `127.0.0.1`, ephemeral port (documented in setup ref).
+- **S7** New scripts: strict mode, input guards, `case` parsing, stdout/stderr discipline, distinct exit codes.
+- **S8** Shared egress/guard logic in one `_shared/scripts` helper.
+- **S9** `find ycc/skills -name "*.sh" -not -executable` lists only pre-existing libs; `shellcheck` clean.
+
+## /goal Pairing Decision
+
+Deferred (per plan "NOT Building"). `/goal` pairing was NOT added to the new visual skills in
+this pass. Revisit as a follow-up if autonomous visual generation is desired.
+
+## Next Steps
+
+- [ ] Code review via `/code-review`
+- [ ] Create PR via `/prp-pr`
+- [ ] (Optional) Decide on `/goal` pairing for the new visual skills

--- a/mcp-configs/mcp.json
+++ b/mcp-configs/mcp.json
@@ -4,6 +4,13 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "envFile": "${userHome}/.config/env/github-env-mcp"
+    },
+    "plan": {
+      "command": "npx",
+      "args": ["-y", "@agent-native/core@0.59.1", "mcp"],
+      "env": {
+        "AGENT_NATIVE_PLANS_MODE": "local-files"
+      }
     }
   }
 }

--- a/ycc/commands/parallel-plan.md
+++ b/ycc/commands/parallel-plan.md
@@ -1,6 +1,6 @@
 ---
 description: Generate a detailed parallel implementation plan with task dependencies, file ownership, and batch ordering. Step 2 of the planning workflow — requires shared-context output. Produces parallel-plan.md ready for implement-plan. Defaults to standalone parallel sub-agents via the Task tool; pass --team (Claude Code only) to orchestrate the analysis and validation stages as teammates under a shared TeamCreate/TaskList with coordinated shutdown.
-argument-hint: '[--team] [--no-worktree] [feature-name] [--dry-run]'
+argument-hint: '[--team] [--no-worktree] [--visual] [feature-name] [--dry-run]'
 ---
 
 # Parallel Plan Command
@@ -16,6 +16,7 @@ The skill analyzes the shared context, designs independent task batches with exp
 - `--team` — (Claude Code only) Dispatch the 3 analysis agents and 3 validation agents as teammates under a shared `TeamCreate`/`TaskList` with coordinated shutdown and inter-teammate `SendMessage` coordination. Default is standalone parallel sub-agents via the `Task` tool. Cursor and Codex bundles lack team tools — do not pass `--team` there.
 - `--worktree` — (legacy — now default; pass `--no-worktree` to opt out) Worktree annotations are emitted by default. This flag is accepted as a silent no-op so existing pipelines continue to work.
 - `--no-worktree` — Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.
+- `--visual` — Render the finished plan as an Agent-Native visual artifact (MDX) via `ycc:visual-plan`; local-files by default, hosted link requires `--share`. Runs only after the plan is written and validated; `--dry-run` short-circuits it (prints intent only).
 - `--dry-run` — Preview the execution plan without deploying agents. With `--team`, also prints the team name and teammate roster.
 
 **Examples**:
@@ -26,5 +27,6 @@ The skill analyzes the shared context, designs independent task batches with exp
 /ycc:parallel-plan add a billing dashboard                    # worktree annotations included by default
 /ycc:parallel-plan --no-worktree add a billing dashboard      # skip worktree annotations
 /ycc:parallel-plan --team user-authentication                 # team mode with worktree annotations (default)
+/ycc:parallel-plan --visual user-authentication               # also render the plan as a visual artifact
 /ycc:parallel-plan payment-integration --dry-run
 ```

--- a/ycc/commands/plan-workflow.md
+++ b/ycc/commands/plan-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: Unified planning workflow — research, analyze, and generate parallel implementation plans in one command. Combines shared-context and parallel-plan with checkpoint support. Defaults to standalone parallel sub-agents via the Task tool; pass --team (Claude Code only) to orchestrate research, analysis, and validation stages as teammates under a shared TeamCreate/TaskList with coordinated shutdown.
-argument-hint: '[--team] [--research-only] [--plan-only] [--no-checkpoint] [--optimized] [--dry-run] [--no-worktree] [feature-name]'
+argument-hint: '[--team] [--research-only] [--plan-only] [--no-checkpoint] [--optimized] [--dry-run] [--no-worktree] [--visual] [feature-name]'
 ---
 
 # Plan Workflow Command
@@ -21,6 +21,7 @@ The skill orchestrates research → shared-context → parallel-plan in a single
 - `--dry-run` — Preview the execution plan without deploying agents. With `--team`, also prints the team name and teammate roster.
 - `--worktree` — (legacy — now default; pass `--no-worktree` to opt out) Worktree annotations are emitted by default. This flag is accepted as a silent no-op so existing pipelines continue to work.
 - `--no-worktree` — Opt out of worktree annotations in the generated `parallel-plan.md`. No effect with `--research-only`. Honored with `--plan-only`. See `ycc/skills/_shared/references/worktree-strategy.md`.
+- `--visual` — Render the finished plan as an Agent-Native visual artifact (MDX) via `ycc:visual-plan`; local-files by default, hosted link requires `--share`. Terminal decorator — runs after the plan is written and validated; `--dry-run` short-circuits it. See `ycc/skills/_shared/references/visual-mode.md`.
 
 **Examples**:
 
@@ -29,4 +30,5 @@ The skill orchestrates research → shared-context → parallel-plan in a single
 /ycc:plan-workflow --no-worktree add a billing dashboard         # skip worktree annotations
 /ycc:plan-workflow --team user-authentication                    # team mode with worktree annotations (default)
 /ycc:plan-workflow --team --no-worktree user-authentication      # team mode, no worktree annotations
+/ycc:plan-workflow --visual add a billing dashboard              # render the finished plan as a visual artifact
 ```

--- a/ycc/commands/plan.md
+++ b/ycc/commands/plan.md
@@ -1,6 +1,6 @@
 ---
 description: Lightweight conversational planner. Restates requirements, identifies risks, outlines phases, then WAITS for explicit confirmation before any code is written. Lighter than /ycc:plan-workflow (parallel research) and /ycc:prp-plan (PRD-driven, artifact-producing).
-argument-hint: '[--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree] <what you want to plan>'
+argument-hint: '[--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree] [--visual] <what you want to plan>'
 allowed-tools:
   - Read
   - Grep
@@ -37,11 +37,12 @@ This is the lightweight planner. For an artifact-producing plan with codebase pa
 - `--dry-run` — Only valid with `--team` or `--enhanced`. Prints the roster (3 baseline or 5 enhanced) and dispatch mode (standalone sub-agents or team), then exits without spawning any agents.
 - `--worktree` — (legacy — now default; pass `--no-worktree` to opt out) Worktree annotations are emitted by default. This flag is accepted as a silent no-op so existing pipelines continue to work.
 - `--no-worktree` — Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.
+- `--visual` — Force-write the plan to a file, then render it as an Agent-Native visual artifact (MDX) via `ycc:visual-plan`; local-files by default, hosted link requires `--share`. Because `/ycc:plan` writes no file by default, `--visual` forces a plan-file write first. Orthogonal to the dispatch flags; `--dry-run` short-circuits it (prints intent only).
 
 `--parallel`, `--team`, and `--enhanced` are **independent and combinable**. `--parallel` shapes the plan's output format; `--team` switches the dispatch mechanism to a coordinated team; `--enhanced` widens the persona roster (3 → 5). With `--enhanced` alone (no `--team`), the 5 personas run as standalone parallel sub-agents. Pass any combination for a richer or more parallel-ready plan.
 
 ```
-Usage: /ycc:plan [--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree] <what you want to plan>
+Usage: /ycc:plan [--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree] [--visual] <what you want to plan>
 
 Examples:
   /ycc:plan add real-time notifications when a market resolves
@@ -56,6 +57,7 @@ Examples:
   /ycc:plan --enhanced --parallel add a public webhook endpoint         # 5 standalone subs + parallel-shaped plan
   /ycc:plan --parallel add a billing dashboard                          # worktree annotations included by default
   /ycc:plan --no-worktree --parallel add a billing dashboard            # skip worktree annotations
+  /ycc:plan --visual add a billing dashboard                            # force-write plan, then render visual artifact
 
 The skill will:
   1. Parse flags and restate requirements in clear terms

--- a/ycc/commands/prp-plan.md
+++ b/ycc/commands/prp-plan.md
@@ -1,6 +1,6 @@
 ---
 description: Create a single-pass implementation plan from a feature description or PRD. Runs codebase pattern extraction and optional external research, then writes docs/prps/plans/{name}.plan.md. Use --enhanced to grow research from 3 to 7 specialized researchers (same dimensions as ycc:feature-research) while keeping a single PRP-compliant plan file.
-argument-hint: '[--parallel | --team] [--enhanced] [--no-worktree] [--dry-run] <feature description | path/to/prd.md>'
+argument-hint: '[--parallel | --team] [--enhanced] [--no-worktree] [--visual] [--dry-run] <feature description | path/to/prd.md>'
 allowed-tools:
   - Read
   - Grep
@@ -41,12 +41,13 @@ The skill detects whether the argument is a PRD file (selects the next pending p
 - `--worktree` — (legacy — now default; pass `--no-worktree` to opt out) Worktree annotations are emitted by default. This flag is accepted as a silent no-op so existing pipelines continue to work.
 - `--no-worktree` — Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.
 - `--enhanced` — Enhanced research mode. Grows the research fan-out from 3 to 7 specialized researchers (api / business / tech / ux / security / practices / recommendations — same coverage as `ycc:feature-research`). Output remains a single PRP-compliant plan file at `docs/prps/plans/{name}.plan.md`. Composes orthogonally with `--parallel`, `--team`, and `--no-worktree`. When passed alone, defaults to standalone sub-agent dispatch (Path B at width 7); combine with `--team` (Claude Code only) for team-coordinated dispatch.
+- `--visual` — Render the finished plan as an Agent-Native visual artifact (MDX) via `ycc:visual-plan`; local-files by default, hosted shareable link requires `--share`.
 - `--dry-run` — Only valid with `--team`. Prints the team name and teammate roster, then exits without spawning any teammates.
 
 `--parallel` and `--team` are **mutually exclusive** — pick one. `--no-worktree` is orthogonal and may be combined with either.
 
 ```
-Usage: /ycc:prp-plan [--parallel | --team] [--no-worktree] [--dry-run] <feature | path/to/prd.md>
+Usage: /ycc:prp-plan [--parallel | --team] [--enhanced] [--no-worktree] [--visual] [--dry-run] <feature | path/to/prd.md>
 
 Examples:
   /ycc:prp-plan add rate limiting to the API gateway
@@ -60,6 +61,7 @@ Examples:
   /ycc:prp-plan --enhanced "add JWT refresh flow"
   /ycc:prp-plan --enhanced --team docs/prps/prds/notifications.prd.md
   /ycc:prp-plan --enhanced --no-worktree "add rate limiting"
+  /ycc:prp-plan --visual "add JWT refresh flow"                                # render the finished plan as a visual artifact
 
 Next step after plan is written:
   /ycc:prp-implement docs/prps/plans/{name}.plan.md              # sequential execution

--- a/ycc/commands/visual-plan.md
+++ b/ycc/commands/visual-plan.md
@@ -1,0 +1,44 @@
+---
+description: Turn an existing text plan into a rich, interactive visual plan — diagrams, file maps, annotated code, open questions, and an optional UI/prototype review surface. Reads the plan (never edits it) and writes plan.mdx + canvas.mdx into a sibling visual/ directory. Hosted sharing is consent-gated behind --share; default is a local-files localhost preview.
+argument-hint: '[--share] <path/to/plan.md>'
+---
+
+# Visual Plan Command
+
+Render an existing plan as a structured, reviewable visual plan.
+
+**Load and follow the `ycc:visual-plan` skill, passing through `$ARGUMENTS`.**
+
+The skill reads the plan at the given path (read-only), auto-selects a review
+mode from its content (UI-first / prototype-first / design-first / visual-intake,
+or document-only), resolves the live block catalog at use time, and emits
+`plan.mdx` (plus `canvas.mdx` when a canvas is used) into a `visual/` sibling of
+the input plan. It prints exactly one link: a localhost preview by default, or a
+hosted shareable URL when `--share` is passed.
+
+**Flags**:
+
+- `--share` — Opt in to hosted egress (destination `plan.agent-native.com`).
+  Hosted upload is OFF by default and consent-gated: without `--share` the skill
+  runs in local-files mode and nothing leaves the machine. Egress is routed
+  through the shared `visual-egress-guard.sh`, which scans for secrets, refuses
+  non-public remotes, and requires a consent token naming the destination.
+
+```
+Usage: /ycc:visual-plan [--share] <path/to/plan.md>
+
+Examples:
+  /ycc:visual-plan docs/prps/plans/notifications.plan.md          # local-files preview (default)
+  /ycc:visual-plan --share docs/prps/plans/notifications.plan.md  # hosted shareable URL (consent-gated)
+  /ycc:visual-plan .work/feature-x/parallel-plan.md               # any plan path; visual/ derived from it
+
+Output (exactly one of):
+  https://plan.agent-native.com/...   # hosted shareable URL (only with --share)
+  http://127.0.0.1:PORT/...           # localhost preview (default)
+  local files only                    # when no server/host is available
+```
+
+Invoked automatically as the hand-off target of the shared `--visual` decorator
+on `/ycc:prp-plan`, `/ycc:plan`, `/ycc:parallel-plan`, and `/ycc:plan-workflow`.
+The decorator runs only after a plan is written and validated, then calls
+`ycc:visual-plan <absolute-plan-path>`.

--- a/ycc/commands/visual-recap.md
+++ b/ycc/commands/visual-recap.md
@@ -1,0 +1,55 @@
+---
+description: Turn a finished change (git range, branch, or working-tree diff) into a LOCAL-ONLY interactive visual recap — annotated split diffs, file map, schema/API deltas, diagrams, and wireframes — written under docs/prps/reviews/visual/ and previewed in the browser via the 127.0.0.1 localhost bridge. Never uploads code; remote-agnostic across the public GitHub remote and the private Forgejo origin.
+argument-hint: '[base..head | branch]'
+allowed-tools:
+  - Read
+  - Write
+  - Bash(npx:*)
+  - Bash(plan:*)
+  - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/visual-recap-collect.sh:*)'
+  - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/visual-egress-guard.sh:*)'
+---
+
+# Visual Recap Command
+
+Generate a LOCAL-ONLY visual recap of what a change touched.
+
+**Load and follow the `ycc:visual-recap` skill, passing through `$ARGUMENTS`.**
+
+The skill sources the diff through the remote-agnostic collector (local git refs only —
+identical on the public `github` remote and the private Forgejo `origin`), fetches the
+live block catalog, and authors MDX (`data-model`, `api-endpoint`, `file-tree`, split
+`diff`, `diagram`, and mandatory `wireframe` blocks when UI changed) under
+`docs/prps/reviews/visual/<slug>/`. The recap is previewed via the localhost bridge.
+
+**LOCAL-ONLY — what this command will NOT do:**
+
+- No hosted publish, no shareable hosted link, no Plan database write.
+- No hosted recap-create / publish tool — `AGENT_NATIVE_PLANS_MODE=local-files` is always set.
+- No PR comment and no GitHub/Forgejo Action.
+- The only permitted network call is the schema-only `get-plan-blocks` catalog lookup
+  (offline fallback `plan blocks --out`).
+
+**Arguments**:
+
+- _(none)_ — Recap the working-tree diff against `HEAD`.
+- `<base>..<head>` — Recap an explicit two-endpoint range.
+- `<branch>` — Treat `<branch>` as head; the base is computed via `git merge-base`
+  against the tracked upstream (never a hardcoded trunk).
+
+```
+Usage: /ycc:visual-recap [base..head | branch]
+
+Examples:
+  /ycc:visual-recap                       # working-tree diff vs HEAD
+  /ycc:visual-recap feat/rate-limiting    # branch vs merge-base(upstream)
+  /ycc:visual-recap main..HEAD            # explicit range
+  /ycc:visual-recap v1.2.0..v1.3.0        # release-to-release recap
+
+Output:
+  docs/prps/reviews/visual/<slug>/        # local MDX recap + diff bundle
+  http://127.0.0.1:<port>/...             # localhost-bridge preview (not shareable)
+```
+
+**Related**: `/ycc:visual-plan` renders a forward plan (hosted egress is consent-gated
+there); `/ycc:visual-recap` is strictly local and emits no remote link.

--- a/ycc/skills/_shared/references/agent-native-setup.md
+++ b/ycc/skills/_shared/references/agent-native-setup.md
@@ -1,0 +1,102 @@
+# Agent-Native Runtime — Shared Setup Contract
+
+Reference for ycc skills that drive the Agent-Native visual-planning runtime — currently
+`${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/SKILL.md` and
+`${CLAUDE_PLUGIN_ROOT}/skills/visual-recap/SKILL.md`. Both skills cite this doc so the install
+pin, the auth/reconnect flow, the connector names, the localhost bridge, and the egress
+policy stay convergent. Fix them here, not per skill (DRY).
+
+The pinned version below was resolved with `npm view @agent-native/core version` at authoring
+time. Re-resolve and re-pin before a release if the runtime has advanced — never substitute a
+floating `latest` dist-tag into committed content.
+
+---
+
+## Install (pinned)
+
+Install a skill from the Agent-Native core CLI with an **explicit pinned version**:
+
+```
+npx -y @agent-native/core@0.59.1 skills add <skill>
+```
+
+- The pin (`0.59.1`) is the version resolved via `npm view @agent-native/core version`.
+- Never commit a floating `latest` dist-tag — the block vocabulary and CLI surface drift
+  between releases, so an unpinned install can silently change behavior. Pin, verify, then bump
+  deliberately.
+
+## Reconnect / auth (one-time per client)
+
+Authorize the runtime against the hosted Plans origin once per client. This is a one-time
+step per machine/client, not per skill run:
+
+```
+npx -y @agent-native/core@0.59.1 reconnect https://plan.agent-native.com --client [claude-code|codex|all]
+```
+
+- `--client all` reconnects every detected client at once.
+- Re-run only when credentials are revoked or the client is reinstalled.
+
+## MCP connector
+
+The runtime exposes an MCP connector named **`plan`**. The legacy alias **`agent-native-plans`**
+still resolves to the same connector — accept either name when detecting an existing
+connection, but prefer `plan` in new guidance.
+
+## Local-only operation
+
+For local-only operation (no hosted calls, no auth required), set:
+
+```
+AGENT_NATIVE_PLANS_MODE=local-files
+```
+
+In this mode the runtime reads and writes plans on the local filesystem only; it does not
+contact `plan.agent-native.com`.
+
+## Localhost bridge
+
+To preview a plan locally, use the `plan local` bridge commands against the plan directory:
+
+```
+plan local check --dir plans/<slug>
+plan local serve --dir plans/<slug> --open
+```
+
+- `check` validates the plan files under `plans/<slug>` without serving.
+- `serve` binds **127.0.0.1** on an **ephemeral, CLI-chosen port** and opens the preview with
+  `--open`.
+- The bridge performs **no DB writes** and sends **nothing to any server** — it is a purely
+  local render of the on-disk plan.
+
+## Block vocabulary (resolve at USE TIME)
+
+> GOTCHA: The MDX block vocabulary drifts upstream between releases. Do **not** trust any
+> hardcoded component/block list in skill bodies or in this doc.
+
+At the runtime-author step (use time, not authoring time), fetch the live block catalog:
+
+- Hosted/connected: call the **`get-plan-blocks`** MCP tool.
+- Offline / `local-files` fallback: run `plan blocks --out <path>` to dump the current catalog.
+
+Always render plan MDX against the freshly-fetched block list, never a list memorized in a
+skill.
+
+## Egress policy
+
+Hosted upload is **OFF by default** and **consent-gated**:
+
+- No plan content leaves the machine unless the operator passes an explicit `--share` flag
+  that names the destination host `plan.agent-native.com`.
+- All hosted egress MUST be routed through
+  `${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/visual-egress-guard.sh` so the consent check
+  and destination allowlist are enforced in one place.
+- Localhost bridge usage (above) is not egress: it stays on 127.0.0.1 and writes nothing
+  remote.
+
+## Hosted Plans app
+
+- Hosted origin: `https://plan.agent-native.com`.
+- Create tools return **absolute, shareable URLs** under that origin.
+- Plans backed by a **private repo are org-gated** — only members of the owning org can open
+  the shared URL.

--- a/ycc/skills/_shared/references/visual-mode.md
+++ b/ycc/skills/_shared/references/visual-mode.md
@@ -1,0 +1,152 @@
+# Visual Mode — Canonical Reference
+
+Used by `ycc:prp-plan`, `ycc:plan`, `ycc:parallel-plan`, and `ycc:plan-workflow`
+to expose a uniform `--visual` decorator. This file documents the **single
+`--visual` contract** shared by all four planning skills: when it runs, how it
+composes with other flags, how `--dry-run` short-circuits it, and the hand-off
+to `ycc:visual-plan`. Individual skills own their own flag plumbing and the path
+where they write a plan; the shared **invariant** lives here.
+
+`--visual` is a **terminal decorator step**, not a dispatch mode. It does not
+change how a plan is researched, dispatched, or written — it only runs once,
+**after** the plan exists and has been validated, to produce a visual rendering
+of that plan.
+
+See [worktree-strategy.md](./worktree-strategy.md) for where plan artifacts live
+and [agent-team-dispatch.md](./agent-team-dispatch.md) for the team lifecycle
+that `--team` layers on top of planning.
+
+---
+
+## 0. Default Behavior
+
+`--visual` is **off by default** on all four planning skills. When omitted, the
+skill behaves exactly as it does today and writes no visual output.
+
+| Skill               | Writes a plan artifact by default?   | `--visual` target                         |
+| ------------------- | ------------------------------------ | ----------------------------------------- |
+| `ycc:prp-plan`      | yes — `docs/prps/plans/*.plan.md`    | the written plan file                     |
+| `ycc:parallel-plan` | yes — feature-dir `parallel-plan.md` | the written plan file                     |
+| `ycc:plan-workflow` | yes — feature-dir `parallel-plan.md` | the written plan file                     |
+| `ycc:plan`          | **no** — plan kept in-chat           | a plan file `--visual` is forced to write |
+
+The plan path differs per skill (and `ycc:plan` writes none by default). The
+contract therefore never hardcodes `docs/prps/plans`; it passes whatever
+absolute plan path the skill produced to `ycc:visual-plan` and lets that skill
+derive its output directory. See §3 (hand-off) and §4 (`ycc:plan` special case).
+
+---
+
+## 1. Timing — runs AFTER write AND validation
+
+`--visual` is the **last** step of a planning run. The order is fixed:
+
+1. Research / dispatch / plan generation (unchanged by `--visual`).
+2. Write the plan artifact to its skill-specific path.
+3. **Validate** the plan per the skill's existing rules.
+4. **Only then** run the `--visual` decorator step.
+
+If steps 1–3 do not complete (research aborts, write fails, or validation
+fails), the `--visual` step does **not** run. There is nothing valid to
+visualize, so the skill reports the upstream failure and stops.
+
+`--visual` never re-orders, re-runs, or substitutes for any earlier phase.
+
+---
+
+## 2. Composition with other flags
+
+`--visual` is **orthogonal** to and **composes with** the dispatch/runtime
+flags. It is applied once, at the end, regardless of which of these are present:
+
+| Flag            | Interaction with `--visual`                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------------ |
+| `--parallel`    | Independent. Parallel dispatch finishes, plan is written + validated, then `--visual` runs once. |
+| `--team`        | Independent. Team lifecycle completes first; `--visual` decorates the final plan.                |
+| `--enhanced`    | Independent. Enhancement affects plan content; `--visual` renders the enhanced result.           |
+| `--no-worktree` | Independent. Worktree opt-out does not affect whether or how `--visual` runs.                    |
+| `--dry-run`     | **Short-circuits** `--visual` (see §2.1).                                                        |
+
+Because `--visual` is a terminal decorator, the combination
+`--parallel --team --visual` (etc.) means: do the parallel/team planning, write
+
+- validate the plan, then run the single `--visual` step on the result.
+
+### 2.1 `--dry-run` short-circuit
+
+When `--dry-run` is present, `--visual` is **short-circuited**: the skill prints
+
+```
+visual generation would run
+```
+
+and does **not** generate anything and does **not** invoke `ycc:visual-plan`.
+`--dry-run` always wins over `--visual`; no visual artifacts, directories, or
+links are produced in a dry run.
+
+---
+
+## 3. Hand-off to `ycc:visual-plan`
+
+When `--visual` runs for real (not `--dry-run`), the planning skill invokes:
+
+```
+ycc:visual-plan <absolute-plan-path>
+```
+
+passing the **absolute path** of the plan file it wrote and validated.
+
+Contract for `ycc:visual-plan`:
+
+- **Accept ANY plan path.** It must not assume `docs/prps/plans` or any other
+  fixed location. The plan path is supplied by the caller and may live anywhere
+  (e.g. `docs/prps/plans/<name>.plan.md`, a feature-dir `parallel-plan.md`, or a
+  forced-write file from `ycc:plan`).
+- **Derive `visual/` relative to the given plan path.** The output directory is
+  a `visual/` sibling of the plan file — i.e. `<dirname of plan>/visual/` —
+  computed from the path it was handed, never hardcoded.
+- **Print the resulting link to stdout.** Exactly one of:
+  - a hosted shareable URL, or
+  - a localhost preview `http://127.0.0.1:PORT/...`, or
+  - `local files only` when no server/host is available.
+- **NEVER re-run research or dispatch.** It only consumes an existing plan.
+- **NEVER edit the plan file.** It reads the plan and writes only into the
+  derived `visual/` directory; the plan artifact is left byte-for-byte intact.
+
+The planning skill surfaces whatever link `ycc:visual-plan` prints; it does not
+re-derive the path itself.
+
+---
+
+## 4. `/ycc:plan --visual` special case — force a write FIRST
+
+`ycc:plan` writes **no** artifact by default (the plan stays in-chat). There is
+therefore nothing on disk to visualize. When `--visual` is passed to
+`ycc:plan`:
+
+1. `ycc:plan` **MUST force a plan-file write first**, producing an absolute plan
+   path on disk (this write happens even though it would normally be skipped).
+2. That forced write is then validated like any other plan.
+3. Only after a valid file exists does `ycc:plan` hand the absolute path to
+   `ycc:visual-plan <absolute-plan-path>`.
+
+Without the forced write there is no input for `ycc:visual-plan`, so the
+force-write rule is mandatory — not optional — for `ycc:plan --visual`. Under
+`--dry-run` this is moot: the §2.1 short-circuit applies and `ycc:plan` prints
+`visual generation would run` without forcing any write.
+
+---
+
+## 5. NAMING_CONVENTION
+
+In-body references to skill assets use the plugin-root variable, e.g.:
+
+- `${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/SKILL.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/plan/SKILL.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/prp-plan/SKILL.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/parallel-plan/SKILL.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/plan-workflow/SKILL.md`
+
+The hand-off is always expressed as the skill invocation
+`ycc:visual-plan <absolute-plan-path>`, with `<absolute-plan-path>` resolved by
+the calling skill to a real, absolute path on disk.

--- a/ycc/skills/_shared/scripts/visual-egress-guard.sh
+++ b/ycc/skills/_shared/scripts/visual-egress-guard.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+#
+# visual-egress-guard.sh — pre-upload guard for hosted visual-plan egress.
+#
+# Runs BEFORE any MDX/diff payload leaves the machine for a hosted service
+# (e.g. plan.agent-native.com). It enforces three independent gates:
+#   1. Secret/denylist scan of the payload (mirrors clean/validate-safety.sh).
+#   2. Public-remote check — refuses when the repo's resolved remote is the
+#      private Forgejo origin or any non-public host (never hardcodes a host
+#      beyond the public allowlist; the remote URL comes from `git remote
+#      get-url`).
+#   3. Explicit consent — a consent token naming the destination host must be
+#      supplied before egress is permitted.
+#
+# Usage:
+#   visual-egress-guard.sh --payload <path> [--remote <name>] \
+#       [--destination <host>] [--consent <host>]
+#
+# Arguments:
+#   --payload <path>        File or directory to scan before upload (required).
+#   --remote <name>         Remote whose URL gates publicity (default: tracked
+#                           upstream's remote, else "origin").
+#   --destination <host>    Hosted egress destination (default: plan.agent-native.com).
+#   --consent <host>        Explicit consent token; MUST equal --destination.
+#
+# Exit codes:
+#   0 - All gates passed; hosted egress is permitted
+#   1 - Usage / missing required argument
+#   2 - Secret/denylist hit found in the payload (egress aborted)
+#   3 - Resolved remote is non-public (private Forgejo / non-allowlisted host)
+#   4 - Missing or mismatched consent token
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging helpers (stdout = results, stderr = diagnostics)
+# ---------------------------------------------------------------------------
+
+_error() {
+  echo "visual-egress-guard.sh: error: $*" >&2
+}
+
+_info() {
+  echo "visual-egress-guard.sh: $*" >&2
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  visual-egress-guard.sh --payload <path> [--remote <name>] \
+      [--destination <host>] [--consent <host>]
+
+Arguments:
+  --payload <path>      File or directory to scan before upload (required).
+  --remote <name>       Remote whose URL gates publicity (default: upstream's
+                        remote, else "origin").
+  --destination <host>  Hosted egress destination (default: plan.agent-native.com).
+  --consent <host>      Explicit consent token; MUST equal --destination.
+
+Exit codes: 0 ok | 1 usage | 2 secret hit | 3 non-public remote | 4 no consent
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Denylist — mirrors clean/validate-safety.sh PROTECTED/SECURITY patterns.
+# ---------------------------------------------------------------------------
+
+declare -a PROTECTED=(
+  ".env"
+  ".env.*"
+  "*.pem"
+  "*.key"
+  "*.p12"
+  "*.pfx"
+  "*.crt"
+  "id_rsa"
+  "id_ed25519"
+  "credentials.json"
+  "secrets.json"
+)
+
+# Non-public host detection. A host is treated as non-public (egress refused)
+# when it is the known-private Forgejo origin, sits on a private/tailnet TLD, is
+# a loopback/RFC1918 address, or is an unqualified single-label hostname. Any
+# other fully-qualified public host is allowed. This deliberately avoids
+# hardcoding a public vendor host: publicity is inferred, privacy is matched.
+#
+# The known-private host defaults to the Forgejo origin and may be overridden
+# via VISUAL_EGRESS_PRIVATE_HOST for other deployments.
+PRIVATE_HOST="${VISUAL_EGRESS_PRIVATE_HOST:-git.azules-celsius.ts.net}"
+
+declare -a PRIVATE_SUFFIXES=(
+  ".ts.net"
+  ".local"
+  ".internal"
+  ".lan"
+  ".home.arpa"
+  ".localdomain"
+)
+
+DEFAULT_DESTINATION="plan.agent-native.com"
+
+# ---------------------------------------------------------------------------
+# Argument parsing (strict case-based flag handling)
+# ---------------------------------------------------------------------------
+
+PAYLOAD=""
+REMOTE_NAME=""
+DESTINATION="$DEFAULT_DESTINATION"
+CONSENT=""
+
+require_value() {
+  if [[ $# -lt 2 || -z "$2" ]]; then
+    _error "flag $1 requires a value"
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --payload)
+      require_value "$@"
+      PAYLOAD="$2"
+      shift 2
+      ;;
+    --remote)
+      require_value "$@"
+      REMOTE_NAME="$2"
+      shift 2
+      ;;
+    --destination)
+      require_value "$@"
+      DESTINATION="$2"
+      shift 2
+      ;;
+    --consent)
+      require_value "$@"
+      CONSENT="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      _error "unexpected positional argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$PAYLOAD" ]]; then
+  _error "--payload is required"
+  usage
+  exit 1
+fi
+
+if [[ ! -e "$PAYLOAD" ]]; then
+  _error "payload not found: $PAYLOAD"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Gate 1: secret / denylist scan (exit 2 on hit)
+# ---------------------------------------------------------------------------
+
+# Convert a denylist glob into a path-anchored extended regex.
+glob_to_regex() {
+  local g="$1"
+  g="${g//./\\.}"        # escape literal dots
+  g="${g//\*/[^/ ]*}"    # '*' matches a run of non-slash, non-space chars
+  printf '(^|[ /])%s($|[ /])' "$g"
+}
+
+SECRET_HITS=0
+for pattern in "${PROTECTED[@]}"; do
+  regex="$(glob_to_regex "$pattern")"
+
+  # (a) Protected path referenced in payload content (e.g. diff headers).
+  if grep -rInE -- "$regex" "$PAYLOAD" >/dev/null 2>&1; then
+    _error "denylist hit (content): pattern '$pattern' present in payload"
+    SECRET_HITS=$((SECRET_HITS + 1))
+  fi
+
+  # (b) An actual protected file inside the payload tree.
+  if [[ -d "$PAYLOAD" ]]; then
+    if find "$PAYLOAD" -type f -name "$pattern" -print -quit 2>/dev/null | grep -q .; then
+      _error "denylist hit (file): '$pattern' file exists under payload"
+      SECRET_HITS=$((SECRET_HITS + 1))
+    fi
+  else
+    # shellcheck disable=SC2053
+    if [[ "$(basename "$PAYLOAD")" == $pattern ]]; then
+      _error "denylist hit (file): payload basename matches '$pattern'"
+      SECRET_HITS=$((SECRET_HITS + 1))
+    fi
+  fi
+done
+
+if [[ "$SECRET_HITS" -gt 0 ]]; then
+  _error "aborting: ${SECRET_HITS} secret/denylist hit(s) — payload is unsafe to upload"
+  exit 2
+fi
+_info "secret scan clean"
+
+# ---------------------------------------------------------------------------
+# Gate 2: public-remote check (exit 3 when non-public)
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository; cannot verify remote publicity"
+  exit 3
+fi
+
+# Default the remote name to the tracked upstream's remote, else "origin".
+if [[ -z "$REMOTE_NAME" ]]; then
+  UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+  if [[ -n "$UPSTREAM" && "$UPSTREAM" == */* ]]; then
+    REMOTE_NAME="${UPSTREAM%%/*}"
+  else
+    REMOTE_NAME="origin"
+  fi
+fi
+
+REMOTE_URL="$(git remote get-url "$REMOTE_NAME" 2>/dev/null || true)"
+if [[ -z "$REMOTE_URL" ]]; then
+  _error "could not resolve URL for remote '$REMOTE_NAME'"
+  exit 3
+fi
+
+# Extract the host from any common git URL form without hardcoding a host.
+remote_host() {
+  local url="$1"
+  url="${url#*://}"   # drop scheme:// if present
+  url="${url#*@}"     # drop user@ if present
+  url="${url%%[:/]*}" # host is up to the first ':' or '/'
+  printf '%s' "$url"
+}
+
+HOST="$(remote_host "$REMOTE_URL")"
+HOST="$(printf '%s' "$HOST" | tr '[:upper:]' '[:lower:]')"
+
+# Decide whether a host is public. Privacy is matched explicitly; anything not
+# matched as private but shaped like a public FQDN is treated as public.
+is_public_host() {
+  local host="$1"
+
+  # Known-private origin.
+  [[ "$host" == "$PRIVATE_HOST" ]] && return 1
+
+  # Loopback / RFC1918 literals.
+  case "$host" in
+    localhost|127.*|10.*|192.168.*) return 1 ;;
+    172.1[6-9].*|172.2[0-9].*|172.3[01].*) return 1 ;;
+  esac
+
+  # Private / internal / tailnet suffixes.
+  local suffix
+  for suffix in "${PRIVATE_SUFFIXES[@]}"; do
+    [[ "$host" == *"$suffix" ]] && return 1
+  done
+
+  # Unqualified single-label hostnames are not public.
+  [[ "$host" != *.* ]] && return 1
+
+  return 0
+}
+
+if ! is_public_host "$HOST"; then
+  _error "refusing hosted egress: remote '$REMOTE_NAME' host '$HOST' is not public"
+  _error "private/internal remotes (e.g. the Forgejo origin) must not upload to ${DESTINATION}"
+  exit 3
+fi
+_info "remote '$REMOTE_NAME' host '$HOST' is public"
+
+# ---------------------------------------------------------------------------
+# Gate 3: explicit consent (exit 4 when missing/mismatched)
+# ---------------------------------------------------------------------------
+
+if [[ -z "$CONSENT" ]]; then
+  _error "missing consent: pass --consent ${DESTINATION} to authorize hosted egress"
+  exit 4
+fi
+
+if [[ "$CONSENT" != "$DESTINATION" ]]; then
+  _error "consent mismatch: --consent '$CONSENT' does not name destination '${DESTINATION}'"
+  exit 4
+fi
+_info "consent confirmed for destination '${DESTINATION}'"
+
+# ---------------------------------------------------------------------------
+# All gates passed -> result on stdout
+# ---------------------------------------------------------------------------
+
+echo "egress-permitted destination=${DESTINATION} remote=${REMOTE_NAME} host=${HOST}"
+exit 0

--- a/ycc/skills/_shared/scripts/visual-recap-collect.sh
+++ b/ycc/skills/_shared/scripts/visual-recap-collect.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# visual-recap-collect.sh — remote-agnostic local diff collector for visual recap.
+#
+# Collects a diff bundle using ONLY local git refs so it behaves identically on
+# any remote (public GitHub or the private Forgejo). It NEVER calls a vendor PR
+# API and NEVER hardcodes a remote host or branch name.
+#
+# Usage:
+#   visual-recap-collect.sh [<base>..<head> | <branch>]
+#
+# Arguments:
+#   (none)            Collect the working-tree diff (git diff HEAD).
+#   <base>..<head>    Collect git diff <base>...<head> (explicit two endpoints).
+#   <branch>          Treat <branch> as head; compute base via `git merge-base`
+#                     against the tracked upstream (resolved from @{upstream}).
+#
+# Base resolution NEVER hardcodes a trunk branch: the upstream is resolved with
+#   git rev-parse --abbrev-ref --symbolic-full-name @{upstream}
+# and falls back gracefully to merge-base against HEAD when no upstream is set.
+#
+# Output:
+#   - Diff bundle written under docs/prps/reviews/visual/<slug>/
+#       diff.patch     full unified diff (local refs only)
+#       files.txt      changed-file name list
+#       metadata.txt   range/base/head/remote provenance
+#   - Results (bundle path + summary) on stdout.
+#   - All errors and progress notes on stderr.
+#
+# Exit codes:
+#   0 - Bundle collected successfully
+#   1 - Usage / git / I/O failure
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging helpers (stdout = results, stderr = diagnostics)
+# ---------------------------------------------------------------------------
+
+_error() {
+  echo "visual-recap-collect.sh: error: $*" >&2
+}
+
+_info() {
+  echo "visual-recap-collect.sh: $*" >&2
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  visual-recap-collect.sh [<base>..<head> | <branch>]
+
+Arguments:
+  (none)            Collect the working-tree diff (git diff HEAD).
+  <base>..<head>    Collect git diff <base>...<head>.
+  <branch>          Use <branch> as head; base = merge-base(@{upstream}, <branch>).
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing (strict case-based flag handling)
+# ---------------------------------------------------------------------------
+
+RANGE_ARG=""
+
+set_range_arg() {
+  if [[ -z "$RANGE_ARG" ]]; then
+    RANGE_ARG="$1"
+  else
+    _error "unexpected positional argument: $1"
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        set_range_arg "$1"
+        shift
+      done
+      break
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      set_range_arg "$1"
+      shift
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Git context
+# ---------------------------------------------------------------------------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  _error "not inside a git repository"
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+CURRENT_BRANCH="$(git branch --show-current || true)"
+
+# Resolve the tracked upstream without ever hardcoding a trunk branch name.
+resolve_upstream() {
+  git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true
+}
+
+# Resolve the remote URL for the given remote name (never hardcode a host).
+remote_url_for() {
+  local name="$1"
+  git remote get-url "$name" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Range / mode resolution
+# ---------------------------------------------------------------------------
+
+MODE=""
+BASE_REF=""
+HEAD_REF=""
+RANGE_LABEL=""
+
+if [[ -z "$RANGE_ARG" ]]; then
+  # Default: working-tree diff against HEAD.
+  MODE="worktree"
+  HEAD_REF="HEAD"
+  RANGE_LABEL="working-tree"
+elif [[ "$RANGE_ARG" == *".."* ]]; then
+  MODE="range"
+  BASE_REF="${RANGE_ARG%%..*}"
+  HEAD_REF="${RANGE_ARG##*..}"
+  if [[ -z "$BASE_REF" || -z "$HEAD_REF" ]]; then
+    _error "malformed range '$RANGE_ARG'; expected <base>..<head>"
+    exit 1
+  fi
+  RANGE_LABEL="${BASE_REF}...${HEAD_REF}"
+else
+  MODE="branch"
+  HEAD_REF="$RANGE_ARG"
+  if ! git rev-parse --verify --quiet "${HEAD_REF}^{commit}" >/dev/null; then
+    _error "not a valid ref: $HEAD_REF"
+    exit 1
+  fi
+  UPSTREAM="$(resolve_upstream)"
+  if [[ -n "$UPSTREAM" ]]; then
+    _info "tracked upstream: $UPSTREAM"
+    BASE_REF="$(git merge-base "$UPSTREAM" "$HEAD_REF" 2>/dev/null || true)"
+  fi
+  if [[ -z "$BASE_REF" ]]; then
+    _info "no upstream merge-base; falling back to merge-base against HEAD"
+    BASE_REF="$(git merge-base HEAD "$HEAD_REF" 2>/dev/null || true)"
+  fi
+  if [[ -z "$BASE_REF" ]]; then
+    _error "could not compute a merge-base for '$HEAD_REF'"
+    exit 1
+  fi
+  RANGE_LABEL="${BASE_REF}...${HEAD_REF}"
+fi
+
+# ---------------------------------------------------------------------------
+# Slug derivation (filesystem-safe; lowercase alnum + dashes)
+# ---------------------------------------------------------------------------
+
+slugify() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -e 's#[^a-z0-9]\+#-#g' -e 's#^-\+##' -e 's#-\+$##'
+}
+
+case "$MODE" in
+  worktree)
+    SLUG_SOURCE="${CURRENT_BRANCH:-detached-head}"
+    ;;
+  range)
+    SLUG_SOURCE="${BASE_REF}-to-${HEAD_REF}"
+    ;;
+  branch)
+    SLUG_SOURCE="$HEAD_REF"
+    ;;
+esac
+
+SLUG="$(slugify "$SLUG_SOURCE")"
+if [[ -z "$SLUG" ]]; then
+  SLUG="recap"
+fi
+
+# ---------------------------------------------------------------------------
+# Collect the diff (LOCAL refs only — identical on GitHub and Forgejo)
+# ---------------------------------------------------------------------------
+
+OUT_DIR="docs/prps/reviews/visual/${SLUG}"
+mkdir -p "$OUT_DIR"
+
+DIFF_FILE="${OUT_DIR}/diff.patch"
+FILES_FILE="${OUT_DIR}/files.txt"
+META_FILE="${OUT_DIR}/metadata.txt"
+
+if [[ "$MODE" == "worktree" ]]; then
+  git diff HEAD >"$DIFF_FILE" || { _error "git diff failed"; exit 1; }
+  git diff --name-only HEAD >"$FILES_FILE" || { _error "git diff --name-only failed"; exit 1; }
+else
+  # Three-dot diff against the merge-base of base and head.
+  git diff "${BASE_REF}...${HEAD_REF}" >"$DIFF_FILE" || { _error "git diff failed"; exit 1; }
+  git diff --name-only "${BASE_REF}...${HEAD_REF}" >"$FILES_FILE" || { _error "git diff --name-only failed"; exit 1; }
+fi
+
+# Remote provenance: record every remote URL via `git remote get-url` so the
+# bundle is auditable without hardcoding any host.
+{
+  echo "generated-by: visual-recap-collect.sh"
+  echo "mode: ${MODE}"
+  echo "range: ${RANGE_LABEL}"
+  echo "base: ${BASE_REF:-<working-tree>}"
+  echo "head: ${HEAD_REF}"
+  echo "current-branch: ${CURRENT_BRANCH:-<detached>}"
+  echo "slug: ${SLUG}"
+  echo "remotes:"
+  while IFS= read -r _rname; do
+    [[ -z "$_rname" ]] && continue
+    echo "  - ${_rname}: $(remote_url_for "$_rname")"
+  done < <(git remote)
+} >"$META_FILE"
+
+CHANGED_COUNT="$(grep -c . "$FILES_FILE" 2>/dev/null)" || CHANGED_COUNT=0
+
+# ---------------------------------------------------------------------------
+# Results -> stdout
+# ---------------------------------------------------------------------------
+
+echo "$OUT_DIR"
+_info "collected ${CHANGED_COUNT} changed file(s) for range '${RANGE_LABEL}'"
+_info "bundle: ${OUT_DIR}/{diff.patch,files.txt,metadata.txt}"
+
+exit 0

--- a/ycc/skills/parallel-plan/SKILL.md
+++ b/ycc/skills/parallel-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: parallel-plan
 description: Create detailed parallel implementation plans by running analysis and validation stages, then synthesizing dependency-aware tasks into parallel-plan.md. Use after shared-context to prepare implementation-ready planning artifacts. Defaults to standalone parallel sub-agents via the Task tool; pass `--team` (Claude Code only) to orchestrate the analysis and validation stages as teammates under a shared TeamCreate/TaskList with coordinated shutdown.
-argument-hint: '[--team] [--no-worktree] [feature-name] [--dry-run]'
+argument-hint: '[--team] [--no-worktree] [--visual] [feature-name] [--dry-run]'
 allowed-tools:
   - Read
   - Grep
@@ -69,13 +69,14 @@ Parse arguments (flags first, then the feature name):
 - **--team**: Optional. (Claude Code only) Deploy the analysis and validation stages as teammates under a shared `TeamCreate`/`TaskList` with coordinated shutdown. Default is standalone parallel sub-agents via the `Task` tool. Cursor and Codex bundles lack team tools — do not pass `--team` there.
 - **--worktree**: Optional. (legacy — now default; safe to omit) Worktree annotations are emitted by default. Accepted as a silent no-op so existing pipelines continue to work.
 - **--no-worktree**: Optional. Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.
+- **--visual**: Optional. Render the finished plan as an Agent-Native visual artifact (MDX) via `ycc:visual-plan`; local-files by default, hosted link requires `--share`.
 - **--dry-run**: Show what would be created without making changes. With `--team`, also prints the team name and teammate roster.
 - **feature-name**: Required. Matches directory name in `${PLANS_DIR}`.
 
 If no feature name provided, abort with usage instructions:
 
 ```
-Usage: /parallel-plan [--team] [--no-worktree] [feature-name] [--dry-run]
+Usage: /parallel-plan [--team] [--no-worktree] [--visual] [feature-name] [--dry-run]
 
 Examples:
   /parallel-plan user-authentication
@@ -84,7 +85,18 @@ Examples:
   /parallel-plan --team --dry-run user-authentication
   /parallel-plan user-authentication                     # worktree annotations included by default
   /parallel-plan --no-worktree user-authentication       # skip worktree annotations
+  /parallel-plan --visual user-authentication            # also render the plan as a visual artifact
 ```
+
+---
+
+## Visual mode
+
+`--visual` follows the canonical contract at `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md`. It is a **terminal decorator**, not a dispatch mode: it does not change how the plan is researched, dispatched, or written, and composes orthogonally with `--team` and `--no-worktree`.
+
+When `VISUAL_MODE` is set and not `--dry-run`, after the final phase (plan written in Phase 4, validated in Phase 6 Step 21) the skill invokes `ycc:visual-plan <absolute-plan-path>` on the **actual written plan path** — the absolute path of `${feature_dir}/parallel-plan.md`. The bootstrap invocation lives in Step 21.5.
+
+When `--dry-run` is also present, `--visual` is short-circuited (see Step 4): the skill prints `visual generation would run` and generates no artifact, directory, or link.
 
 ---
 
@@ -106,7 +118,8 @@ Extract from `$ARGUMENTS`:
 1. **--team**: Boolean flag. Set `AGENT_TEAM_MODE=true` if present, else `false`.
 2. **--dry-run**: Boolean flag. Set `DRY_RUN=true` if present, else `false`.
 3. **--no-worktree / --worktree**: Default `WORKTREE_MODE=true`. Set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default).
-4. **feature-name**: First non-flag argument (required).
+4. **--visual**: Boolean flag. Set `VISUAL_MODE=true` if present, else `false`.
+5. **feature-name**: First non-flag argument (required).
 
 ```bash
 # Default ON; pass --no-worktree to opt out. --worktree accepted as legacy no-op.
@@ -116,7 +129,15 @@ case " $ARGUMENTS " in
 esac
 ARGUMENTS="${ARGUMENTS//--no-worktree/}"
 ARGUMENTS="${ARGUMENTS//--worktree/}"  # legacy no-op
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
+
+`--visual` is orthogonal — it composes with `--team`/`--no-worktree` and runs after the plan is written and validated. `--dry-run` short-circuits it (prints intent only); see Step 4 and the `## Visual mode` section.
 
 **Compatibility note**: When this skill is invoked from a Cursor or Codex bundle, `--team` must not be used (those bundles ship without team tools).
 
@@ -202,6 +223,14 @@ Teammates:      6 across 2 batches
 ```
 
 Do **not** call `TeamCreate`, `TaskCreate`, `Agent`, `Task`, `SendMessage`, or `TeamDelete` in dry-run mode.
+
+If `VISUAL_MODE=true`, the `--visual` step is **short-circuited** by `--dry-run`: print intent ONLY and generate no visual artifact (`--dry-run` always wins over `--visual`):
+
+```
+visual generation would run
+```
+
+Do **not** invoke `ycc:visual-plan` or create any `visual/` directory or link in dry-run mode.
 
 **STOP HERE** - do not write files or deploy agents.
 
@@ -538,6 +567,21 @@ ${CLAUDE_PLUGIN_ROOT}/skills/parallel-plan/scripts/validate-parallel-plan.sh "${
 ```
 
 Report any structural issues found.
+
+### Step 21.5: Visual Artifact (if `--visual`)
+
+If `VISUAL_MODE=false`, skip this step entirely.
+
+This step runs **only after** the plan has been written (Step 14) and validated (Step 21). Follow the canonical contract at `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md`. `--visual` is a terminal decorator: it never re-runs research, dispatch, or plan generation.
+
+- If `DRY_RUN=true`, this step was already short-circuited in Step 4 (printed `visual generation would run`); do **not** generate anything here.
+- Otherwise, when `VISUAL_MODE=true` and not `--dry-run`, invoke `ycc:visual-plan` on the **actual written plan path** (the absolute path of `${feature_dir}/parallel-plan.md`):
+
+```
+ycc:visual-plan <absolute-path-to-${feature_dir}/parallel-plan.md>
+```
+
+Surface whatever link `ycc:visual-plan` prints (hosted shareable URL with `--share`, localhost preview, or `local files only`). Do not re-derive the output path — `ycc:visual-plan` derives `visual/` relative to the plan path and leaves the plan file byte-for-byte intact.
 
 ### Step 22: Clean Up Team (if `--team`)
 

--- a/ycc/skills/plan-workflow/SKILL.md
+++ b/ycc/skills/plan-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-workflow
 description: Unified planning workflow - research, analyze, and generate parallel implementation plans in one command. Combines shared-context and parallel-plan with checkpoint support. Default is standalone parallel sub-agents via the Task tool. Pass `--team` (Claude Code only) to orchestrate research, analysis, and validation stages as teammates under a shared TeamCreate/TaskList with coordinated shutdown.
-argument-hint: '[--team] [--research-only] [--plan-only] [--no-checkpoint] [--optimized] [--dry-run] [--no-worktree] [feature-name]'
+argument-hint: '[--team] [--research-only] [--plan-only] [--no-checkpoint] [--optimized] [--dry-run] [--no-worktree] [--visual] [feature-name]'
 allowed-tools:
   - Read
   - Grep
@@ -61,12 +61,13 @@ Parse arguments (flags first, then the feature name):
 - **--dry-run**: Show execution plan without running. With `--team`, also prints the team name and teammate roster.
 - **--worktree**: Optional. (legacy — now default; safe to omit) Worktree annotations are emitted in the generated `parallel-plan.md` by default. Accepted as a silent no-op so existing pipelines continue to work.
 - **--no-worktree**: Optional. Opt out of worktree annotations in the generated `parallel-plan.md`. No effect when `--research-only` is passed (no plan file is generated). Honored with `--plan-only`.
+- **--visual**: Render the finished plan as an Agent-Native visual artifact (MDX) via `ycc:visual-plan`; local-files by default, hosted link requires `--share`.
 - **feature-name**: Required. Directory name in `${PLANS_DIR}/`
 
 If no feature name provided, abort with usage instructions:
 
 ```
-Usage: /plan-workflow [--team] [options] [feature-name]
+Usage: /plan-workflow [--team] [options] [--visual] [feature-name]
 
 Options:
   --team            (Claude Code only) Dispatch stages as agent team (default: standalone sub-agents)
@@ -77,6 +78,7 @@ Options:
   --dry-run         Show execution plan without running
   --worktree        (legacy — now default; safe to omit) Worktree annotations emitted by default
   --no-worktree     Opt out of worktree annotations in the generated parallel-plan.md
+  --visual          Render the finished plan as a visual artifact via ycc:visual-plan (local-files by default; hosted link requires --share)
 
 Examples:
   /plan-workflow user-authentication
@@ -87,7 +89,26 @@ Examples:
   /plan-workflow --team --dry-run new-feature
   /plan-workflow add-billing-dashboard                 # worktree annotations included by default
   /plan-workflow --no-worktree add-billing-dashboard   # skip worktree annotations
+  /plan-workflow --visual add-billing-dashboard        # render the finished plan as a visual artifact
 ```
+
+---
+
+## Visual mode
+
+See `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md` for the canonical `--visual` contract shared by all planning skills.
+
+`--visual` is a **terminal decorator step**, not a dispatch mode. It is orthogonal to and composes with `--team`, `--optimized`, and `--no-worktree`, and runs once at the very end.
+
+When `VISUAL_MODE=true` and `--dry-run` is **not** set, after the final phase (the plan has been written and validated) the workflow invokes:
+
+```
+ycc:visual-plan <absolute-plan-path>
+```
+
+where `<absolute-plan-path>` is the **actual written plan path** — the feature-dir plan at `${feature_dir}/parallel-plan.md` resolved in Phase 0 — **not** a hardcoded `docs/prps/plans` path. `ycc:visual-plan` derives its `visual/` output directory relative to that plan path.
+
+When `--dry-run` is set, `--visual` is **short-circuited**: print `visual generation would run` and do not invoke `ycc:visual-plan`. `--research-only` produces no plan file, so `--visual` has nothing to render and does not run.
 
 ---
 
@@ -109,9 +130,16 @@ case " $ARGUMENTS " in
 esac
 ARGUMENTS="${ARGUMENTS//--no-worktree/}"
 ARGUMENTS="${ARGUMENTS//--worktree/}"  # legacy no-op
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
-4. **feature-name**: First non-flag argument (required).
+4. **--visual**: Boolean flag. Set `VISUAL_MODE=true` if present, else `false`. Terminal decorator — see [## Visual mode](#visual-mode).
+5. **feature-name**: First non-flag argument (required).
 
 Validate the feature name:
 
@@ -625,6 +653,26 @@ After validators complete:
 If `AGENT_TEAM_MODE=false`, skip this step — standalone sub-agents return on their own.
 
 Otherwise, send shutdown requests to all validation teammates.
+
+---
+
+## Phase 9.5: Visual Mode (if --visual)
+
+If `VISUAL_MODE=false`, skip this phase entirely.
+
+This step runs only after the plan has been written (Phase 8) and validated (Phases 8–9). It never re-orders, re-runs, or substitutes for any earlier phase. See `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md`.
+
+### Step 32.5: Render Visual Artifact
+
+- If `--dry-run` is set, print `visual generation would run` and **STOP** this phase (the §2.1 short-circuit — no visual artifacts are produced).
+- If `--research-only` was used, no plan file was generated; skip this phase.
+- Otherwise, invoke `ycc:visual-plan` on the **actual written plan path** (the feature-dir plan resolved in Phase 0, not a hardcoded `docs/prps/plans` path):
+
+```
+ycc:visual-plan "${feature_dir}/parallel-plan.md"
+```
+
+`ycc:visual-plan` derives its `visual/` output directory relative to the supplied plan path and prints the resulting link (hosted URL, localhost preview, or `local files only`). Surface that link in the Phase 10 summary; do not re-derive the path yourself, and do not edit the plan file.
 
 ---
 

--- a/ycc/skills/plan/SKILL.md
+++ b/ycc/skills/plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan
 description: Lightweight conversational planner — dispatches ycc:planner (or a multi-perspective fan-out) to produce a phased plan with file paths, dependencies, risks, and tests, then WAITS for confirmation. Lighter than plan-workflow or PRD-driven prp-plan. Use when the user asks to "plan this", "outline an approach", "break this down before I code", "parallel plan", "multi-perspective plan", "enhanced plan", or says "/plan".
-argument-hint: '[--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree] <what you want to plan>'
+argument-hint: '[--parallel] [--team] [--enhanced] [--dry-run] [--no-worktree] [--visual] <what you want to plan>'
 allowed-tools:
   - Read
   - Grep
@@ -48,6 +48,7 @@ Create a comprehensive implementation plan before writing any code. This is the 
 | `--dry-run`     | Valid with `--team` (prints team-coordinated roster) or `--enhanced` (prints standalone or team roster depending on whether `--team` is also present). Prints the roster, then exits without spawning any agents.                                                                                                                                                                                                                                                                                                                                                                                  |
 | `--worktree`    | (legacy — now default; safe to omit) Previously required to emit worktree annotations; the annotations are now emitted by default. Accepted as a silent no-op so existing pipelines continue to work.                                                                                                                                                                                                                                                                                                                                                                                              |
 | `--no-worktree` | Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `--visual`      | Force-write the plan to a file, then render it as an Agent-Native visual artifact (MDX) via `ycc:visual-plan`; local-files by default, hosted link requires `--share`.                                                                                                                                                                                                                                                                                                                                                                                                                             |
 
 **Flag interaction**:
 
@@ -76,7 +77,7 @@ Use this skill when:
 
 ### Step 1 — Parse flags and the user's request
 
-**Flag parsing**: Extract `--parallel`, `--team`, `--enhanced`, `--dry-run`, `--no-worktree`, and `--worktree` from `$ARGUMENTS` before processing. Strip them out. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `ENHANCED_MODE=true|false`, `DRY_RUN=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). The remaining text is the user's request.
+**Flag parsing**: Extract `--parallel`, `--team`, `--enhanced`, `--dry-run`, `--no-worktree`, `--worktree`, and `--visual` from `$ARGUMENTS` before processing. Strip them out. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `ENHANCED_MODE=true|false`, `DRY_RUN=true|false`, `VISUAL_MODE=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). The remaining text is the user's request.
 
 ```bash
 # Default ON; pass --no-worktree to opt out. --worktree accepted as legacy no-op.
@@ -92,6 +93,12 @@ case " $ARGUMENTS " in
   *" --enhanced "*) ENHANCED_MODE=true ;;
 esac
 ARGUMENTS="${ARGUMENTS//--enhanced/}"
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
 **Validation**:
@@ -100,6 +107,7 @@ ARGUMENTS="${ARGUMENTS//--enhanced/}"
 - If `DRY_RUN=true` and both `AGENT_TEAM_MODE=false` and `ENHANCED_MODE=false` → abort with: `--dry-run requires --team or --enhanced (no-op for the single-agent path).`
 - If `--team` is invoked from a Cursor or Codex bundle, abort with the existing compatibility message: `--team requires team tools, which Cursor/Codex bundles do not ship. Use --parallel instead.`
 - `--enhanced` alone is supported in every bundle: Path C uses parallel `Agent` calls without team tools. Only the `--enhanced --team` combination requires Claude Code; in Cursor or Codex, abort with: `--enhanced --team requires team tools, which Cursor/Codex bundles do not ship. Drop --team to use the standalone 5-persona path.`
+- `--visual` is orthogonal and runs after the plan is produced. Because `/ycc:plan` writes no file by default, `--visual` forces a plan-file write first. `--dry-run` short-circuits it (prints intent only).
 
 Read the stripped `$ARGUMENTS`. If it references a file path, read that file for context. If the request is ambiguous, ask a single focused clarifying question **before** dispatching.
 
@@ -533,6 +541,50 @@ Valid user responses:
 **Team-mode re-dispatch note**: Path B's team is `TeamDelete`d in Step B.8 _before_ the user sees the plan. Any re-dispatch from this step creates a **new** team (same name is fine — the old one no longer exists) with a fresh set of teammates. Do not attempt to send messages to teammates from the prior team.
 
 **Path C re-dispatch note**: Path C never created a team, so there is no teardown to worry about. Any re-dispatch from this step simply fires a fresh batch of 5 parallel `Agent` calls (no `team_name=`).
+
+---
+
+### Step 5 — Visual rendering (if `VISUAL_MODE=true`)
+
+This step runs **only after** the user confirms the plan in Step 4 (it is the terminal decorator step). It never re-orders or substitutes for any earlier phase.
+
+- **If `DRY_RUN=true`**: print `visual generation would run` and skip — do not force any write and do not invoke `ycc:visual-plan`. (`--dry-run` already exits earlier at the dispatch gate; this is the no-op contract for the combination.)
+- **Otherwise**:
+  1. **Force-write the plan to a file.** `/ycc:plan` keeps the plan in-chat and writes no artifact by default, so there is nothing on disk to visualize. Write the confirmed plan verbatim to a concrete path. Default location: `docs/prps/plans/<slug>.plan.md`, where `<slug>` is the user's request sanitized to kebab-case (same scheme as Path B §B.1: lowercase, non-`[a-z0-9-]` → `-`, collapse runs, trim, truncate to 20 chars, fallback `untitled`). Create the directory first (`mkdir -p docs/prps/plans`). Resolve the path to an **absolute** path.
+  2. **Invoke** `ycc:visual-plan <absolute-plan-path>` with the absolute path written in the previous step.
+  3. **Surface the link** that `ycc:visual-plan` prints (hosted URL, localhost preview, or `local files only`). Do not re-derive the output directory yourself.
+
+See the canonical contract for the full force-write-first rule and `--dry-run` short-circuit:
+
+```
+${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md
+```
+
+---
+
+## Visual mode
+
+`--visual` is the single, shared visual decorator described in
+`${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md`. It is a
+**terminal decorator step** — it does not change how the plan is researched,
+dispatched, or relayed. It runs once, last, on the confirmed plan.
+
+**FORCE-WRITE-FIRST (mandatory for `/ycc:plan`)**: unlike the other planning
+skills, `/ycc:plan` writes **no** plan artifact by default — the plan stays
+in-chat. There is therefore nothing on disk to visualize. When `VISUAL_MODE` is
+set (and **not** `--dry-run`), the skill MUST:
+
+1. **Write the otherwise-inline plan to a concrete file path first.** Default:
+   `docs/prps/plans/<slug>.plan.md` (absolute path; directory created if
+   missing). This forced write happens even though it would normally be skipped.
+2. **Then invoke** `ycc:visual-plan <absolute-plan-path>` with that absolute
+   path.
+
+Without the forced write there is no input for `ycc:visual-plan`, so the
+force-write is required, not optional. Under `--dry-run` this is moot: the
+skill prints `visual generation would run` and forces no write (see §2.1 and §4
+of the canonical reference). `ycc:visual-plan` derives its `visual/` output
+directory relative to the plan path it is handed and never edits the plan file.
 
 ---
 

--- a/ycc/skills/prp-plan/SKILL.md
+++ b/ycc/skills/prp-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prp-plan
 description: Create a self-contained feature implementation plan with codebase pattern extraction and optional external research. Detects PRD vs free-form input, runs codebase discovery via ycc:prp-researcher, and writes docs/prps/plans/{name}.plan.md ready for /ycc:prp-implement. Use when the user asks for a "PRP plan", "implementation plan from PRD", "feature plan with patterns to mirror", "parallel PRP plan", "team PRP plan", or says "/prp-plan".
-argument-hint: '[--parallel | --team] [--enhanced] [--no-worktree] [--dry-run] <feature description | path/to/prd.md>'
+argument-hint: '[--parallel | --team] [--enhanced] [--no-worktree] [--visual] [--dry-run] <feature description | path/to/prd.md>'
 allowed-tools:
   - Read
   - Grep
@@ -55,6 +55,7 @@ Extract flags from `$ARGUMENTS`:
 | `--no-worktree` | Opt out of worktree annotations. The plan will not contain a `## Worktree Setup` section or per-task `**Worktree**:` annotations.                                                                                                                                                                                            |
 | `--dry-run`     | Only valid with `--team`. Prints the team name and teammate roster, then exits without spawning any teammates.                                                                                                                                                                                                               |
 | `--enhanced`    | Enhanced research mode: grow the research fan-out from 3 to 7 specialized researchers (api/business/tech/ux/security/practices/recommendations — same coverage as ycc:feature-research). Output is still a single PRP-compliant plan file. Composes with --parallel (default), --team (Claude Code only), and --no-worktree. |
+| `--visual`      | Render the finished plan as an Agent-Native visual artifact (MDX) via `ycc:visual-plan`; local-files by default, hosted shareable link requires `--share`.                                                                                                                                                                   |
 
 Strip the flags. Set `PARALLEL_MODE=true|false`, `AGENT_TEAM_MODE=true|false`, `DRY_RUN=true|false`. Default `WORKTREE_MODE=true`; set `WORKTREE_MODE=false` if `--no-worktree` is present. `--worktree` is accepted as a legacy no-op (matches the default). Remaining text is the feature description or PRD path.
 
@@ -72,6 +73,12 @@ case " $ARGUMENTS " in
   *" --enhanced "*) ENHANCED_MODE=true ;;
 esac
 ARGUMENTS="${ARGUMENTS//--enhanced/}"
+
+VISUAL_MODE=false
+case " $ARGUMENTS " in
+  *" --visual "*) VISUAL_MODE=true ;;
+esac
+ARGUMENTS="${ARGUMENTS//--visual/}"
 ```
 
 **Validation**:
@@ -80,6 +87,7 @@ ARGUMENTS="${ARGUMENTS//--enhanced/}"
 - `--dry-run` requires `--team`. If `DRY_RUN=true` and `AGENT_TEAM_MODE=false` → abort with: `--dry-run requires --team.`
 - `--no-worktree` is **orthogonal** to `--parallel` and `--team` — it may be combined freely with either flag or used alone to suppress annotations.
 - If `--enhanced` is passed without `--parallel` or `--team`, default to standalone sub-agent dispatch (Path B equivalent at width 7). If `--enhanced --team` is invoked from a Cursor or Codex bundle, abort with the same compatibility message used today for plain `--team`. If `--dry-run` is passed, it requires `--team` (same constraint as today); `--enhanced --dry-run` alone is invalid.
+- `--visual` is orthogonal — it composes with `--parallel`/`--team`/`--enhanced`/`--no-worktree` and runs after the plan is written and validated. `--dry-run` short-circuits it (prints intent only).
 
 **Compatibility note**: When this skill is invoked from a Cursor or Codex bundle, `--team` must not be used (those bundles ship without team tools). Use `--parallel` instead.
 
@@ -406,6 +414,23 @@ Include a brief note in the report: "Plan validated with N warning(s) — see va
 
 ---
 
+## Phase 7 — VISUALIZE (optional)
+
+This step runs after the plan is written (Phase 6) and validated (Phase 6.5), regardless of the dispatch path taken (`--parallel`, `--team`, or sequential):
+
+- If `VISUAL_MODE=true` and `--dry-run` is NOT set, invoke `ycc:visual-plan <plan-path>` — passing the absolute path of the just-written `docs/prps/plans/{name}.plan.md` — and capture its printed link.
+- If `--dry-run` is set, print `visual generation would run` and skip the invocation.
+
+---
+
+## Visual mode
+
+This skill exposes the shared `--visual` decorator. The canonical contract lives at `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md` — follow it for composition, timing, and hand-off rules.
+
+When `VISUAL_MODE` is set and `--dry-run` is NOT, the skill invokes `ycc:visual-plan <absolute-plan-path>` AFTER Phase 6, passing the just-written `.plan.md` path (the file written in Phase 6 and validated in Phase 6.5). `ycc:visual-plan` derives its own `visual/` output directory from that path and prints the resulting link; the skill surfaces that link in the Report block. When `--dry-run` is set, print `visual generation would run` and skip — no visual artifacts, directories, or links are produced.
+
+---
+
 ## Output
 
 ### Update PRD (if input was a PRD)
@@ -429,6 +454,8 @@ Update the phase status from `pending` to `in-progress` and add the plan file pa
 - **Research Dispatch**: [Sequential | Parallel sub-agents | Agent team | Enhanced (7 researchers)]
 - **Execution Mode**: [Sequential | Parallel (N batches, max width X)]
 - **Worktree Mode**: [Enabled (default) — plan includes ## Worktree Setup (single feature worktree — **Parent**: line only) | Disabled via --no-worktree]
+- **Visual Artifact**: [Generated via ycc:visual-plan | n/a (--visual not set)]
+- **Visual Link**: [hosted URL | http://127.0.0.1:PORT/... | local files only | n/a (--visual not set)]
 
 > Next step: Run `/ycc:prp-implement docs/prps/plans/{name}.plan.md` to execute this plan.
 ```

--- a/ycc/skills/visual-plan/SKILL.md
+++ b/ycc/skills/visual-plan/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: visual-plan
+description: Turn an existing text plan into a rich, interactive visual plan — diagrams, file maps, annotated code, open questions, and an optional UI/prototype review surface. Read-only with respect to the plan file. Use when the user asks to "make this plan visual", "render a visual plan", "create a wireframe/canvas for this plan", "visualize the implementation plan", says "/visual-plan", or when a planning skill hands off via the shared `--visual` decorator.
+argument-hint: '[--share] <path/to/plan.md>'
+allowed-tools:
+  - Read
+  - Write
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - Bash(test:*)
+  - Bash(mkdir:*)
+  - Bash(dirname:*)
+  - Bash(npx:*)
+  - Bash(plan:*)
+  - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/scripts/*.sh:*)'
+  - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/*.sh:*)'
+---
+
+# Visual Plan (Agent-Native Plans)
+
+Turn an ordinary text plan into a structured, reviewable visual plan. Build the
+plan a reader would normally skim in Markdown, but as a scannable document with
+editable blocks mixed in: inline diagrams, annotated code, open questions, and
+an optional top visual review surface (wireframe canvas, live prototype, or both
+in tabs). Architecture and backend plans stay document-only; UI and product
+plans start with the top canvas/prototype.
+
+`ycc:visual-plan` is the packaged entry point (slash command `/visual-plan`). It
+**consumes an existing plan** handed to it — it does not research, dispatch, or
+re-plan. The runtime is the Agent-Native Plans CLI/MCP connector; its install
+pin, auth/reconnect flow, connector names, localhost bridge, block-catalog
+lookup, and egress policy are defined ONCE in
+`${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/agent-native-setup.md`. Read
+that file for any setup/auth/serve/egress detail rather than memorizing it here.
+
+## Contract (read first)
+
+This skill is the hand-off target of the shared `--visual` decorator. The full
+contract lives in `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/visual-mode.md`.
+The non-negotiable invariants:
+
+- **Accept ANY plan path.** Never assume `docs/prps/plans` or any fixed
+  location. The plan path is supplied by the caller and may live anywhere.
+- **Derive `visual/` relative to the given plan path.** Output goes into a
+  `visual/` sibling of the plan file — `<dirname of plan>/visual/` — computed
+  from the path handed in, never hardcoded.
+- **NEVER edit the plan file.** Read it; write only into the derived `visual/`
+  directory. The plan artifact stays byte-for-byte intact.
+- **NEVER re-run research or dispatch.** Only consume the existing plan.
+- **Print exactly one resulting link to stdout** — a hosted shareable URL, a
+  localhost preview `http://127.0.0.1:PORT/...`, or `local files only`.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- **`<path/to/plan.md>`** (required positional) — absolute or repo-relative path
+  to the source plan. Read it; derive `visual/` from its directory.
+- **`--share`** (optional, **consent flag**) — the explicit, named opt-in to
+  hosted egress (destination `plan.agent-native.com`). Without it, the skill
+  runs in **local-files** mode and nothing leaves the machine. See **Egress &
+  consent** below.
+
+## Mode selection (auto)
+
+Choose the review surface from the source plan's content — do not add visual
+chrome by default:
+
+- **UI-first** — work is primarily product UI; review should start with screens.
+  Top canvas is the primary surface (`create-ui-plan`).
+- **prototype-first** — review should start with a functional live prototype;
+  interaction is the main question (`create-prototype-plan`).
+- **design-first** — review needs full-fidelity branded screens
+  (`create-plan-design`).
+- **visual-intake** — only when the user explicitly asks for a questionnaire
+  before planning (`create-visual-questions`). Never run it as `/visual-plan`
+  preflight.
+- **document-only** — architecture, backend, data, refactor, or API plans get NO
+  top canvas; inline `diagram` blocks sit next to the relevant prose
+  (`create-visual-plan`).
+
+When the source plan is already a Codex / Claude Code / Markdown / pasted plan,
+use it as `planText` and build the review surface from it instead of starting
+over. Preserve its useful intent and codebase facts; publish a clean standalone
+proposal (no "this revision changes…" framing).
+
+## Block vocabulary — resolve at USE TIME
+
+> The MDX block vocabulary drifts upstream between releases. Do NOT author from a
+> memorized tag list — not from this skill, not from the references.
+
+At author time (use time), fetch the live block catalog FIRST:
+
+- Hosted / connected: call the **`get-plan-blocks`** MCP tool.
+- Offline / `local-files`: run `plan blocks --out <path>` (per
+  `agent-native-setup.md`) and read that file.
+
+Render plan MDX against the freshly-fetched list. The references in this skill
+describe block _families_ and quality bars; the catalog is the authority on
+exact tag names, required fields, and prop shapes.
+
+## Core workflow
+
+1. **Read the source plan.** Read the file at the given path (read-only). Derive
+   the output dir with the thin helper (it computes the `visual/` sibling per the
+   contract and never hardcodes a location):
+
+   ```
+   OUT="$(${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/scripts/derive-visual-dir.sh <plan> --mkdir)"
+   ```
+
+   Gather the plan's exact text — do not invent source content.
+
+2. **Resolve blocks.** Call `get-plan-blocks` (or the offline `plan blocks`
+   fallback) for the authoritative catalog before authoring any MDX.
+3. **Create the plan** with the mode-matched create tool (see Mode selection),
+   passing the source as `planText`. For UI/product plans, compose the top canvas
+   first with the primary wireframes and annotated states, then write the
+   document body with native blocks. For non-visual plans, skip the top surface
+   and place `diagram` / `code` / `annotated-code` / `table` blocks next to the
+   relevant prose.
+4. **Emit files** into the derived `visual/` dir: `plan.mdx` plus, when a canvas
+   is used, `canvas.mdx` (and `prototype.mdx` for prototype plans). These are the
+   portable source artifacts (per `visual-mode.md`).
+5. **Surface the link.** Print exactly one link to stdout (see Contract). In
+   local-files mode this is the localhost bridge URL from `plan local serve`
+   (127.0.0.1, ephemeral port) or `local files only` if no server is available.
+   With `--share`, it is the hosted shareable URL returned by the create tool.
+6. **Read feedback** with `get-plan-feedback` before editing, after review, and
+   before the final response. Treat anchor details and resolver intent as the
+   source of truth for what each comment points at.
+7. **Apply changes** with `update-visual-plan`, preferring targeted
+   `contentPatches`: `patch-wireframe-html`, `patch-diagram-html`, `update-block`,
+   `replace-blocks`, `update-rich-text`, plus `read-visual-plan-source` /
+   `patch-visual-plan-source` for source-control-friendly MDX edits. Treat the
+   top-level `content` payload as a full replacement, never a partial merge — if a
+   full replacement is unavoidable, read the complete source first and carry
+   forward every existing block and surface.
+
+## Quality references — read before authoring
+
+These are provider-neutral quality bars. Read the relevant one IN FULL before
+authoring; do not paraphrase from memory:
+
+- `${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/references/document-quality.md` — the
+  plan-document quality bar and block families.
+- `${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/references/canvas.md` — canvas /
+  artboard / annotation mechanics and patch ops.
+- `${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/references/wireframe.md` — the HTML
+  wireframe quality bar (`.wf-*` tokens, surfaces, icons, skeletons).
+- `${CLAUDE_PLUGIN_ROOT}/skills/visual-plan/references/exemplar.md` — a worked
+  example plus the anti-patterns to avoid.
+
+## Planning is read-only
+
+Make NO source edits while building or reviewing the visual plan, and never edit
+the input plan file. Begin editing code only after the user approves the
+direction. The plan is the approval gate: surface it, name which files/areas the
+work touches, and request sign-off.
+
+## Egress & consent (default OFF)
+
+Hosted upload is **OFF by default** and **consent-gated**. The full policy lives
+in `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/agent-native-setup.md`;
+the operational rules for this skill:
+
+- **Default = `local-files`.** Set `AGENT_NATIVE_PLANS_MODE=local-files`. In this
+  mode the runtime reads/writes plan files locally and never contacts
+  `plan.agent-native.com`. Preview via the localhost bridge
+  (`plan local serve --dir <OUT> --open`), which binds 127.0.0.1 on an ephemeral
+  port, performs no DB writes, and sends nothing remote — this is **not** egress.
+- **`--share` is the only opt-in.** It names the destination host
+  `plan.agent-native.com`. Only when the operator passes `--share` may any plan
+  content leave the machine.
+- **Route all hosted egress through the guard.** Before any MDX/diff payload is
+  uploaded, run:
+
+  ```
+  ${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/visual-egress-guard.sh \
+    --payload <OUT> --destination plan.agent-native.com \
+    --consent plan.agent-native.com
+  ```
+
+  The guard scans the payload for secrets, refuses non-public/private remotes,
+  and requires a consent token matching the destination. If it exits non-zero,
+  STOP — do not upload; report the gate that failed.
+
+## Setup, auth, and the localhost bridge
+
+Do not duplicate install/reconnect/serve commands here. For the pinned install
+version, the one-time per-client reconnect, the `plan` MCP connector (legacy
+alias `agent-native-plans`), local-files mode, and the localhost bridge
+(`plan local check` / `plan local serve`), read
+`${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/agent-native-setup.md`. If a
+Plans tool returns `needs auth` / `Unauthorized` / `Session terminated`, stop and
+give the user the reconnect step from that reference — never reinstall from
+scratch to fix auth, and never fall back to inline chat-only plan output.
+
+## Output
+
+Exactly one of the following is printed to stdout, per the `visual-mode.md`
+contract:
+
+- a hosted shareable URL under `https://plan.agent-native.com` (only with
+  `--share`, after the egress guard passes), or
+- a localhost preview `http://127.0.0.1:PORT/...` (default local-files mode), or
+- `local files only` when no server/host is available.
+
+The calling planning skill surfaces whatever link this skill prints.

--- a/ycc/skills/visual-plan/references/canvas.md
+++ b/ycc/skills/visual-plan/references/canvas.md
@@ -1,0 +1,121 @@
+# Canvas & artboard placement — single source of truth
+
+The canonical guide for how the visual-plan canvas works: artboard placement,
+lane layout, annotations, patching, and emitted files. Read it in full before
+authoring or editing any canvas/artboard content; do not author canvas layouts
+from memory. Resolve exact block/component tag names against the live catalog
+(`get-plan-blocks` or the offline `plan blocks` dump).
+
+---
+
+## Canvas block families
+
+A plan canvas is composed from these block families (resolve exact tag names and
+props via the catalog):
+
+- **`<DesignBoard>`** — the canvas root that holds the artboards and annotations.
+- **`<Section>`** — groups related artboards into a labeled region/lane.
+- **`<Artboard>`** — a single fixed-footprint frame; its size/aspect is locked by
+  `surface` (see `wireframe.md`). Carries an `html` wireframe or references a
+  wireframe block via `blockId`.
+- **`<Screen>`** — a product screen surface inside the board (a UI state under
+  review).
+- **`<Annotation>`** — a plain-text designer note anchored to a frame by
+  `targetId` + `placement`.
+- **`<Connector>`** — an arrow between neighboring steps of a real sequence.
+
+## Emitted files
+
+- `plan.mdx` — frontmatter plus markdown/document blocks (the plan body).
+- `canvas.mdx` — the `<DesignBoard>` / `<Section>` / `<Artboard>` / `<Screen>` /
+  `<Annotation>` / `<Connector>` tree.
+- `prototype.mdx` — present only for prototype plans (the functional flow).
+
+JSON is the canonical runtime shape; MDX is the repo-friendly authoring/export
+surface. Both live under the derived `visual/` directory.
+
+## The coordinate rule
+
+The `surface` locks each artboard's footprint and aspect — **never** set artboard
+width/height and **never** use coordinates inside the wireframe HTML. Board-level
+artboard `x`/`y` IS allowed when it creates clear lanes. Let canvas
+auto-placement handle simple one-row boards. Sizing is always via `surface`, not
+explicit pixels.
+
+## Lay out mixed canvases in lanes
+
+When a canvas contains broad `browser` / `desktop` frames plus compact `mobile`,
+`popover`, or `panel` surfaces, do not put everything in one horizontal strip.
+Use board-level artboard `x`/`y` to reserve lanes with generous empty space: main
+flow on one row, compact surfaces in their own column or row, loading/error
+states in a lower row. Keep at least **96px** between rendered artboard rectangles
+plus room for annotation gutters. Connect only neighboring steps; never draw a
+long connector that skips across unrelated frames. Before handoff, inspect the
+top canvas at default zoom and move any frame whose label, connector, or
+annotation crosses another frame.
+
+## Annotations are designer notes on the artboard
+
+When a top canvas is present, sprinkle Figma-style notes near the frames they
+explain: a short heading, supporting text, and bullets — plain text layers, never
+bordered or shadowed cards, and never a box around a frame. The renderer spaces
+notes away from frames, so place each note by the frame it describes. Use an
+arrow (`<Connector>`) only to point at one specific control or transition; for a
+broad frame-level note, write text beside the frame with no connector.
+
+**Do not create overlapping annotations.** Anchor each ordinary note to the frame
+it explains with `targetId` + `placement` (top/right/bottom/left), and omit
+`type` or use `type: "note"`. The renderer parks notes in a gutter beside the
+frame and lays them out automatically. Do not use `type: "callout"`,
+`type: "text"`, `type: "arrow"`, x/y, or points for ordinary notes; those are
+freeform review-markup layers reserved for intentional markup in open canvas
+space. Connectors are for real sequences only — never fake "Step 1 → Step 2"
+lines between independent states.
+
+## Patching
+
+Edit one wireframe, canvas annotation, diagram, or block with targeted
+`contentPatches` rather than regenerating the whole plan:
+
+- `patch-wireframe-html` — edit the HTML of one artboard's wireframe.
+- `patch-diagram-html` — edit the HTML/SVG of one diagram.
+- `update-block` / `replace-blocks` — replace a block by stable id.
+- `update-canvas-annotation` — edit one annotation.
+- `read-visual-plan-source` / `patch-visual-plan-source` — granular MDX AST
+  patches by stable block, artboard, annotation, component, or wireframe-node id
+  when working from exported source files.
+- `update-rich-text` — prose edits (agents use this or source patches; humans
+  edit prose inline in the browser).
+
+`contentPatches` are part of the public MCP action schema, so every host can make
+surgical edits. **Never** send a partial top-level `content` object as a shortcut
+to add a canvas, frame, or block: `content` is a full structured replacement, so
+omitted blocks or surfaces disappear. If a full replacement is truly unavoidable,
+read the complete source/JSON first, include every existing block and surface in
+the new payload, and verify the source/export immediately after the update.
+
+## Never emit a titled artboard with no interior wireframe content
+
+Every artboard must carry an `html` wireframe or reference a wireframe block via
+`blockId`; when using `blockId`, the referenced wireframe block must remain in the
+plan. If you remove a duplicate wireframe from the document body, first move its
+`data` inline onto the corresponding canvas frame. A label-only frame or a frame
+pointing at a deleted block renders empty and is rejected at parse time. If you
+only have a title, write it as a section header or annotation, not an empty
+artboard.
+
+## UI mockups belong in the top visual review area
+
+Static UI/product visuals live on the canvas; multi-step UI flows get both canvas
+wireframes and a `prototype`. When the user asks for a mockup, UI state, loading
+state, layout, screen, or visual comparison, make the canvas the primary home for
+that static visual. Architecture/code diagrams stay inline in the document
+(`document-quality.md` owns that rule) unless the user explicitly asks for a
+spatial board. A skeleton/loading mockup also lives in a canvas artboard — never
+move a mockup out of the canvas into a `custom-html` document block.
+
+For abstract product concepts, use the canvas to create the first "I get it"
+moment: one real app state near the top showing how the concept appears to a
+user, followed by separate annotations or diagrams for mechanics. Do not make the
+first artboard a hybrid of app UI and architecture notes; the app screen should be
+inspectable as product UI on its own.

--- a/ycc/skills/visual-plan/references/document-quality.md
+++ b/ycc/skills/visual-plan/references/document-quality.md
@@ -1,0 +1,169 @@
+# Plan document quality — single source of truth
+
+The canonical quality bar for the plan document below the canvas: how it reads,
+which block families to use, how open questions are surfaced, and the pre-handoff
+check. Read it in full before authoring the plan document. Resolve exact tag
+names and field shapes against the live catalog (`get-plan-blocks`, or the
+offline `plan blocks` dump) — the families below are the bar, the catalog is the
+authority.
+
+---
+
+**The document is a serious technical plan, not marketing.** Write it the way a
+strong implementation plan reads: outcome-first, prose-first, self-contained, and
+specific. State the objective and what "done" means, the scope and non-goals, the
+proposed approach with key decisions and their rationale, ordered steps that name
+real files / symbols / actions / data shapes, the risks, and a closing
+verification step (tests, build, or a checkable behavior). Replace vague prose
+with specifics; never ship a step like "make it work." No hero art, gradients,
+logos, nav bars, slogans, value props, giant landing-page headings, or marketing
+cards unless the user explicitly asks.
+
+**Every published plan must stand alone.** Even when revising an existing plan,
+the output is a plan to do the work, not a changelog of the conversation. Do not
+write phrases like "preserve the previous plan", "do not drop the old idea", "as
+discussed above", "this revision", "unlike the prior version", or "correction
+from the earlier plan". Fold the right decisions into the plan as normal
+objective, architecture, scope, and roadmap prose. A reviewer who opens the plan
+from a link with no chat history should understand it. Avoid negative framing
+that only makes sense against absent context ("not the old mode", "not just X")
+unless the contrast is defined in the plan and genuinely helps; state the
+positive model directly.
+
+**Make abstract plans instantly legible.** If the idea is broad, strategic, or
+intended for a third-party reviewer, put one concrete product snapshot near the
+top before dense architecture, mode tables, manifests, or roadmaps. For
+UI-capable concepts, that snapshot is usually a top-canvas app state plus a short
+paragraph that says what the user sees and what changes under the hood. Then put
+mechanics, data flow, sync boundaries, and implementation detail in separate
+diagrams or document sections.
+
+**Preserve the user's level of abstraction.** A motivating use case is not
+automatically the architecture. When the prompt describes a broader framework,
+product mode, or reusable primitive, separate the reusable core from specific
+apps, providers, customers, scripts, or launch examples. Use the concrete example
+to make the plan understandable, then make clear which parts are core, which are
+app-specific adapters, and which are future examples.
+
+**When top visuals exist, they and the document never duplicate each other.** For
+UI work, the UI story lives in the top visual surface: canvas artboards for static
+inspection, plus prototype tabs when the flow should be functional. The document
+carries the technical depth the visuals cannot show — concrete file/symbol maps,
+API and data contracts, code snippets, migration or implementation phases, risks,
+and validation. For architecture/code reviews, invert that: the document is the
+visual surface, and each recommendation carries its own nearby inline `diagram`
+block plus file evidence. Repeat a wireframe in the document only for a genuinely
+new detail view or comparison. Skip the visual surface entirely for non-visual
+work and write a clean rich document.
+
+## Block families (resolve exact tags via `get-plan-blocks`)
+
+Use the right block, and make it carry substance:
+
+- **`rich-text`** — plan prose with real bold/italic/code/links and nested lists.
+- **`annotated-code`** — the file map: for a load-bearing file, prefer the
+  annotated walkthrough over a bare `code` block. Carry the real,
+  syntax-highlighted code AND anchor short margin notes to the lines that
+  actually change (the new action, the changed schema, the wiring point). Each
+  annotation is `{ lines: "12" | "12-18"; label?; note }`; keep a few high-signal
+  notes per file, not one per line. Highlight only files worth reading.
+- **`code`** — a throwaway snippet with nothing to call out. When more than one
+  file matters, group blocks in a vertical `tabs` block rather than a bespoke
+  container.
+- **`tabs`** — multiple states, directions, or comparisons. A tab that reveals
+  only prose usually means the plan is under-specified — include a relevant visual
+  unless the tab is intentionally document-only.
+- **`columns`** — side-by-side before/after or current/target comparisons where
+  each side needs real nested blocks; label the columns clearly.
+- **`diagram`** — two-dimensional architecture, dependency, data-flow, or state
+  relationships, only when it clarifies something real. See **Diagram primitives**
+  below.
+- **`table`** — scannable structured data.
+- **`checklist`** — copy the catalog example verbatim: items need `id` and
+  `label`.
+- **`callout`** — for a decision you have committed to, use `tone="decision"`
+  (optionally with a `columns` block weighing the options). Use other tones for
+  concise assumptions or risks in the relevant section.
+- **`question-form`** — the bottom-only Open Questions block (see below).
+- **`custom-html`** — a bounded escape hatch only (see below).
+
+## Decisions
+
+- If the reviewer must still pick between a genuinely-open either/or, put it in
+  the bottom Open Questions `question-form` as a `single` question — one option
+  per real alternative, each with a short detail and `recommended: true` on the
+  one you would choose. Do not also restate the same choice elsewhere.
+- If you have already committed to an approach, state it as settled prose or a
+  `callout` with `tone="decision"` — never as a confusing mid-document form for a
+  question you have already answered.
+
+## Diagram primitives
+
+For architecture/code diagrams, prefer `data.html` / `data.css` with semantic
+HTML and inline SVG so the diagram can use panels, layers, matrices, arrows,
+annotations, and responsive layout directly. Author with renderer-owned
+primitives: `.diagram-panel`, `.diagram-card`, `.diagram-node`, `.diagram-box`,
+`.diagram-pill`, `.diagram-muted`, and `[data-rough]` for sketchy mode. They map
+to the theme variables `--wf-ink`, `--wf-muted`, `--wf-line`, `--wf-paper`,
+`--wf-card`, `--wf-accent`, `--wf-accent-soft`, `--wf-warn`, and `--wf-ok`, and
+switch to the sketch font plus rough.js outlines in sketchy mode.
+
+- Do NOT set `font-family` and do NOT hard-code hex, rgb, or hsl colors in
+  diagram HTML or CSS.
+- Prefer standard two-dimensional layouts — paired before/after panels, layered
+  diagrams, swimlanes, dependency maps, matrices, or grouped regions; do not
+  default to left-to-right chains, and use a line only when the relationship is
+  truly a sequence.
+- Leave room for the sketch font: keep labels short, give nodes generous width,
+  and place boundary/annotation labels in unused space — labels must not overlap
+  nodes, connectors, or each other.
+- For small text/SVG changes to an existing HTML diagram, use **`patch-diagram-html`**
+  with a unique `find`/`replace` snippet instead of resending the whole
+  `data.html` string. Use legacy `nodes` / `edges` only for small previews or
+  truly sequential flows.
+
+## Open questions live at the bottom as a form
+
+Surface answerable unresolved decisions in a final `question-form` block titled
+"Open Questions" so the renderer presents it as a distinct section. That bottom
+form is the ONLY place that enumerates the open questions: never add a second
+"Open Questions" heading, list, or recap of the same questions earlier in the
+document. A one-line pointer in the overview prose ("a few decisions are still
+open — see Open Questions below") is fine.
+
+- Use `single` or `multi` for clear choices, `freeform` for constraints,
+  `recommended: true` for the default you would pick. `single`/`multi` questions
+  always render a write-in field, so never add an explicit "Other" option
+  yourself; set `allowOther: false` only when a free-text answer makes no sense.
+- Copy the catalog example verbatim for required fields: each question needs
+  `id`, `title`, and `mode`; each option needs `id` and `label`.
+- Keep non-answerable assumptions or risks as concise `callout` blocks in the
+  relevant section. Never bury a questions/decisions wall inside the plan
+  narrative, and never ask the same question twice.
+
+For complex plans, do not end without an open-question audit. If architecture,
+scope, UX, data shape, rollout, provider mapping, or ownership still depends on a
+choice, either commit to a recommendation with rationale or add it to the bottom
+form with a recommended default.
+
+## `custom-html` is a bounded escape hatch only
+
+A single complete fragment inside a block, never `html`/`head`/`body`/`script`
+tags, never a generic placeholder, density demo, or proof that custom HTML works.
+Prefer native blocks for normal plans. For architecture/code reviews, use
+`diagram` `data.html` / `data.css` for rich local HTML/SVG diagrams instead of
+`custom-html`. For UI/product work, `custom-html` is never the primary home for a
+requested mockup, UI state, or visual comparison.
+
+## Verification must exercise the real workflow
+
+The final verification section should go beyond typecheck/unit tests when the
+plan changes UI, local files, sync, providers, browser behavior, or multi-app
+flows. Include at least one end-to-end smoke that matches the user journey — a
+fresh repo/folder, real manifest or data fixture, browser interaction, save/sync
+action, and an on-disk or database assertion. Name the command or manual browser
+path when it is known.
+
+**Before handoff, open the plan and check it.** Fix overlap, excessive
+whitespace, clipped fragments, misleading inactive controls, poor contrast, and
+unreadable diagrams before asking for approval.

--- a/ycc/skills/visual-plan/references/exemplar.md
+++ b/ycc/skills/visual-plan/references/exemplar.md
@@ -1,0 +1,113 @@
+# Good vs. bad exemplar — single source of truth
+
+The canonical worked example of a great plan (and the anti-patterns to avoid).
+Read it alongside `document-quality.md` and `canvas.md` before authoring a plan;
+it is the bar these plans must clear. Resolve exact block tags against the live
+catalog (`get-plan-blocks` / offline `plan blocks` dump) before emitting MDX.
+
+---
+
+## A worked example — UI-first plan MDX
+
+The following sketch shows the _shape_ of a strong UI-first plan: a top canvas
+with one real `desktop` artboard, plain-text designer notes off the frame, then a
+serious document below it. Treat the tags as families — confirm exact names/props
+against the catalog.
+
+```mdx
+---
+title: Inbox triage redesign
+mode: ui-first
+---
+
+{/* canvas.mdx — the top review surface */}
+
+<DesignBoard>
+  <Section label="Triage view">
+    <Artboard id="inbox-default" surface="desktop" label="Inbox — default">
+      {/* data.html is a real flex layout: a sidebar of links
+          (Inbox 12, Today 4, Done), a main column headed "Today",
+          accent .wf-pill filters, a muted "OVERDUE" section label,
+          and .wf-card task rows with real titles, due dates, and a
+          button.primary — styled only via bare elements, helper
+          classes, and --wf-* tokens. */}
+    </Artboard>
+    <Annotation targetId="inbox-default" placement="right">
+      Overdue items float to the top; the primary action stays in the header so triage never scrolls.
+    </Annotation>
+  </Section>
+</DesignBoard>
+
+{/* plan.mdx — the document body */}
+<rich-text>
+
+## Objective
+
+Cut inbox triage from many clicks to one. "Done" means an overdue item
+can be deferred or completed from the row without opening it.
+</rich-text>
+
+<tabs>
+  {/* one `code` / `annotated-code` block per load-bearing file:
+      the new defer action, the changed query, the row component */}
+</tabs>
+
+<callout tone="decision">
+  Defer writes a `snoozedUntil` timestamp rather than moving the row to a separate table — see the columns block for the
+  two options weighed.
+</callout>
+
+<question-form title="Open Questions">
+  {/* single/multi questions for genuinely-open decisions, each option
+      with id + label, recommended: true on the default */}
+</question-form>
+```
+
+If the task also changes a multi-step completion flow, the same top area gains a
+Prototype tab whose screens reuse the canvas labels and states.
+
+## GOOD — the bar
+
+- **UI-first todo/inbox plan.** A canvas `desktop` artboard whose `data.html` is a
+  real flex layout (sidebar links, a "Today" heading, accent `.wf-pill` filters, a
+  muted `OVERDUE` label, `.wf-card` task rows with real titles/dates and a
+  `button.primary`), styled only through bare elements, helper classes, and
+  `--wf-*` tokens. Plain-text designer notes sit spaced off the frame, pointing
+  only at controls that need explanation. Below it, a strong document: objective
+  and done-criteria, a few `code` blocks (grouped in a vertical `tabs` block when
+  more than one) showing the real shape of load-bearing files, a `callout` with
+  `tone="decision"` stating the chosen approach with a `columns` block weighing the
+  two real options, and a validation step — none of it repeating the canvas.
+- **Broad product-architecture plan.** Opens with a plain recommendation and one
+  concrete app state before the abstraction. The first canvas artboard is pure
+  product UI that matches the current app shell; nearby notes explain the
+  user-visible delta. A separate `diagram` below shows the mechanics. The document
+  separates the reusable core from app/provider adapters and examples, covers
+  contracts and schema shape, roadmap, non-goals, a bottom Open Questions form, and
+  a verification section with at least one realistic end-to-end smoke.
+- **Backend architecture review.** No top canvas. The document opens with context
+  and a legend, then repeats recommendation cards: title, confidence/category
+  badges, a monospace grid of real file paths, one inline two-dimensional
+  before/after or layered architecture `diagram` (using space to show boundaries
+  and ownership, not a default left-to-right chain), and terse
+  Problem/Solution/Why bullets in the codebase's vocabulary. Ends with a top
+  recommendation and a bottom `question-form` only if the next direction is
+  genuinely open.
+
+## BAD — never produce this
+
+- A `data.html` with hard-coded hex colors, a `font-family`, or fixed pixel
+  width/height.
+- Gray placeholder bars "insinuating" text on a non-skeleton frame.
+- A forced `desktop` + `mobile` pair for a popover.
+- Floating bordered annotation cards hugging the frames.
+- A multi-step UI flow with only static frames and no prototype tab.
+- A mockup escaped into a document `custom-html` block.
+- A marketing-style document with a hero heading and value props that just
+  restates what the canvas already shows.
+- An architecture-only plan forced into a top canvas of labeled boxes with
+  overlapping text, where the real code evidence lives elsewhere.
+- A product wireframe that mixes a real screen with repo names, file-contract
+  arrows, architecture explanations, or a made-up permanent inspector.
+- A plan that describes itself as a revision of a prior conversation instead of a
+  standalone proposal.

--- a/ycc/skills/visual-plan/references/wireframe.md
+++ b/ycc/skills/visual-plan/references/wireframe.md
@@ -1,0 +1,210 @@
+# HTML wireframe quality — single source of truth
+
+The canonical quality bar for HTML wireframe content. Read it in full before
+authoring ANY wireframe; do not author wireframes from memory or paraphrase these
+rules per mode.
+
+---
+
+**A wireframe is an HTML mockup. The renderer owns the look; you write the
+content.** Set `data.html` to a self-contained, semantic HTML fragment of the
+screen and set `data.surface`. The renderer owns the surface footprint/aspect, the
+dark/light theme, the hand-drawn font, and the sketch overlay — you never write
+`<style>` / `<link>` / `<font>` tags or any width/height/coordinates. You write
+real HTML layout and real product content; the renderer styles and roughens it.
+
+**A wireframe block's data is an HTML screen plus a surface:**
+
+```json
+{
+  "surface": "browser",
+  "html": "<div style=\"display:flex;flex-direction:column;gap:10px;padding:16px;height:100%\"><h1>Sign in</h1><p class=\"wf-muted\">Use your work email to continue.</p><div class=\"wf-card\" style=\"display:flex;flex-direction:column;gap:10px\"><label>Email<input value=\"jane@acme.co\" /></label><label>Password<input value=\"********\" /></label><label style=\"display:flex;align-items:center;gap:8px\"><input type=\"checkbox\" checked /> Remember me</label><button class=\"primary\">Sign in</button></div><a href=\"#\">Forgot password?</a></div>"
+}
+```
+
+**Write PLAIN semantic HTML and let the renderer style it.** Bare elements
+(`h1`/`h2`/`h3`, `p`, `button`, `input`, `label`, `a`, `hr`) are auto-themed — no
+classes needed. Helper classes carry the rest:
+
+- `.wf-card` / `.wf-box` — a bordered, padded container (a panel, a list item).
+- `.wf-pill` / `.wf-chip` — a rounded tag or filter; add `.accent` for the
+  accent-filled variant.
+- `.wf-muted` — secondary/muted text.
+- `button.primary` or any element with `[data-primary]` — the accent-filled
+  primary button.
+
+**No decorative shadows around mockups.** Do not put `box-shadow`,
+`filter: drop-shadow(...)`, Tailwind `shadow-*` classes, or other fake depth on a
+wireframe frame, root container, `.wf-card` / `.wf-box`, or canvas artboard.
+Mockups should read as flat, bordered surfaces; use spacing, borders, labels, and
+annotations for separation. Only show a shadow when the real product UI already
+has it and it is essential to the change being reviewed.
+
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading
+icons inside fields, chips, menu items, and toolbars, write an empty marker with
+`[data-icon]` (e.g. `<span data-icon="search"></span>`). The renderer replaces it
+with a Tabler-style SVG and the `.wf-icon` class sizes it to the surrounding text.
+Supported names and aliases include: `mail`/`email`, `lock`/`password`, `search`,
+`plus`/`add`, `x`/`close`, `check`, `chevronDown`, `chevronUp`, `chevronLeft`,
+`chevronRight`, `dots`/`more`, `chevron`/`caret`/`dropdown` (down chevron), `user`,
+`settings`, `calendar`, `bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do
+not put visible words like "email", "lock", "search", "chevron", or "more" where
+the product UI would show an icon; use text only when it is a real label a user
+would read.
+
+**Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips
+these on light/dark, so referencing tokens is what keeps a mockup correct in both
+themes. For any inline border, background, or text color, reference a token:
+`style="border:1.4px solid var(--wf-line)"`. The tokens are `--wf-ink` (text),
+`--wf-muted` (secondary text), `--wf-line` (borders/dividers), `--wf-paper` (page
+background), `--wf-card` (container surface), `--wf-accent` / `--wf-accent-fg` /
+`--wf-accent-soft` (brand action), `--wf-warn`, `--wf-ok`, and `--wf-radius`.
+**Never hard-code a hex (or rgb/hsl) color and never set `font-family`** — the
+renderer owns the sketch/clean font.
+
+**Lay out with inline `style` flex/grid.** You write the real layout —
+`display:flex; flex-direction:column; gap:10px; padding:16px` — and the renderer
+never repositions anything. Compose the actual product: reproduce the current
+screen, then show the modification. Real labels, real counts, real dates, real
+button text grounded in the screen you read; not lorem or gray bars.
+
+**Surface presets — match the real footprint, never default to desktop+mobile.**
+Pick the `surface` that matches what the user will actually see:
+
+- `browser`: a web page that needs a browser chrome frame around it.
+- `desktop`: a full desktop app page or app shell.
+- `mobile`: a phone screen, only when the work is genuinely mobile.
+- `popover`: a small floating menu, dropdown, or inline popover.
+- `panel`: a side panel, inspector, or sidebar widget.
+
+A sidebar popover renders as a small surface, not a desktop page and a phone
+frame. Do not emit `desktop` + `mobile` variants unless responsive behavior
+actually changes the layout.
+
+**Model the actual component shell for small surfaces.** A rendered UI change
+belongs in a wireframe; reserve `diagram` for architecture, dependency, state, or
+data-flow relationships. Popovers, dropdown menus, command palettes, and context
+menus use `surface: "popover"` unless the surrounding page placement is the point
+of the change. Dialogs, sheets, inspectors, sidebars, and long property panels use
+the matching `panel` / `desktop` surface. Show the real chrome: trigger/anchor
+when it matters, title/header row, top-right actions, separators, fields, options,
+selected states, body content, and visible footer actions.
+
+**Modify, don't redesign.** When the task changes an existing screen, reproduce
+the current screen's real layout and footprint FIRST, then change only the delta
+and call it out with a single annotation. Do not restack the page into a new
+layout. For net-new surfaces, compose from the real app shell.
+
+**Keep product screens pure.** A product wireframe shows the app state a user
+would actually see. Do not embed file contracts, architecture arrows, repo pills,
+mode explanations, or implementation callouts inside the screen just to explain
+the plan. Put those in canvas annotations, a separate diagram, or the document
+body.
+
+**Zoom in on sub-surfaces, don't redraw the page.** For a small sub-surface (a
+popover, menu, dialog, toast), show the full screen once, then add a small
+separate artboard whose `html` contains ONLY that sub-surface — do not re-draw the
+whole page around it, and do not scale a duplicate up. Pick the matching `surface`
+(e.g. `popover`) so the footprint is right; never widen a popover to page width.
+
+**Loading / skeleton states.** Set `data.skeleton: true` on the wireframe and fill
+the `html` with neutral, textless placeholder geometry — boxes and bars built as
+`<div>`s with `background:var(--wf-line)` and explicit heights/widths, no labels
+or copy. The renderer drops borders, sketch, and color into the skeleton register
+automatically. Never escape to a `custom-html` document block to fake a loader.
+
+**Editing an existing mockup.** To change one element, text, or color, call
+`update-visual-plan` with
+`contentPatches: [{ op: "patch-wireframe-html", blockId, edits: [{ find, replace }] }]`.
+Each `find` is a unique snippet of the current html (read it first); set
+`all: true` on an edit to replace every occurrence. The result is re-sanitized.
+
+**Treat the wireframe border as part of the visible design.** Always wrap HTML
+wireframe content in a root container with real inner padding before drawing
+cards, fields, pills, labels, or controls. Use at least 14-16px of padding,
+`box-sizing: border-box`, `height: 100%`, and `gap` between child rows so the
+first row never sits flush against the screen border.
+
+**Lay out children safely so they never collide.** Use HTML flex/grid with `gap`,
+`min-width: 0`, and sensible overflow. Avoid negative margins, absolute
+positioning, or fixed child widths that can collide across light/dark, sketch/clean,
+or zoom levels.
+
+**Do not wrap intentionally single-line labels.** For toolbars, tab rails,
+breadcrumbs, chip/filter rows, branch and file names, and code filenames — any
+deliberately single-line row — put `white-space: nowrap` on the row (and
+`overflow: hidden; text-overflow: ellipsis` on labels that can grow). Use
+horizontally scrollable or clipped rails for overflow.
+
+**Fill the frame; keep labels short.** Each artboard is a fixed-size surface —
+compose enough realistic HTML to fill it top to bottom with even vertical rhythm;
+never leave a large empty band. On desktop/app-shell sidebars, let the nav stack
+flex to fill (`flex:1`) and add any persistent bottom action/status after it. On
+mobile, flow real rows down the whole screen rather than a header floating above a
+gap. Keep every label short enough to sit on one line within its column.
+
+**Persistent chrome bars span the full frame width.** Top bars, app headers,
+toolbars, and bottom tab/nav bars are full-width chrome, not centered content. Lay
+each one out as a single flex row that fills the frame
+(`style="display:flex;align-items:center;width:100%"`) and push trailing actions to
+the right edge with a flex spacer (`<div style="flex:1"></div>`) between the
+leading and trailing groups — never center a bar inside a narrow block, and never
+let it collapse to the width of its contents.
+
+**Pin bottom bars to the bottom of the frame.** For mobile tab bars, footers, and
+any persistent bottom action row, make the frame itself a flex column at
+`height:100%` (`style="display:flex;flex-direction:column;height:100%"`), give the
+scrolling body `flex:1`, and place the bar as the LAST child (or set
+`margin-top:auto`). The bar then sits flush at the bottom instead of floating with
+an empty band beneath it.
+
+**Before / after must be comparable.** When showing a state change, preserve the
+unchanged controls in both states so the reviewer can see exactly what moved or
+appeared; do not show an added control as a generic box floating elsewhere. Place
+the new/changed affordance where the implementation puts it. Use the same frame
+size, scale, outer padding, border radius, and visual density on both sides unless
+the change itself alters those properties.
+
+**Name the states with the column header, never inside the frame.** For
+document-body wireframes, put the two states in a `columns` block and set each
+column's `label` to `Before` and `After` — the renderer draws that label as a
+heading above each frame. Do NOT bake a `Before`/`After` pill, title, or heading
+into the wireframe `html`. On a canvas, place the two state artboards as neighbors
+with frame labels — never encode Before/After inside the html.
+
+**Let the surface choose side-by-side vs. stacked.** For document-body wireframes,
+the `columns` renderer lays narrow surfaces (`mobile`, `popover`, `panel`) out
+side by side, and automatically stacks wide surfaces (`desktop`, `browser`)
+vertically at full document width so a large frame is never crushed into a
+half-width column. Author both wireframes with the real `surface` and matching
+`Before`/`After` column labels.
+
+**Good example — a contacts list, surface `browser`.** A small, real screen
+composed from the helper classes and tokens, layout in inline flex, no fonts or
+hex colors:
+
+```html
+<div style="display:flex;flex-direction:column;gap:12px;padding:16px;height:100%">
+  <div style="display:flex;align-items:center;justify-content:space-between">
+    <h1>Contacts</h1>
+    <button class="primary">New contact</button>
+  </div>
+  <div style="display:flex;gap:6px">
+    <span class="wf-pill accent">All 128</span>
+    <span class="wf-pill">Favorites</span>
+    <span class="wf-pill">Archived</span>
+  </div>
+  <div class="wf-card" style="display:flex;flex-direction:column;gap:0;padding:0">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-bottom:1.4px solid var(--wf-line)">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Jane Cooper</strong><br /><small>jane@acme.co</small></div>
+      <span class="wf-pill">Lead</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Marcus Lee</strong><br /><small>marcus@globex.io</small></div>
+      <span class="wf-pill">Customer</span>
+    </div>
+  </div>
+</div>
+```

--- a/ycc/skills/visual-plan/scripts/derive-visual-dir.sh
+++ b/ycc/skills/visual-plan/scripts/derive-visual-dir.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# derive-visual-dir.sh — compute the visual/ output directory for a plan path.
+#
+# The visual-plan contract (skills/_shared/references/visual-mode.md) requires
+# the output to live in a `visual/` sibling of the input plan file, derived from
+# the path handed in — never hardcoded. This thin wrapper performs that single
+# derivation so the skill never improvises the path.
+#
+# Usage:
+#   derive-visual-dir.sh <path/to/plan.md> [--mkdir]
+#
+# Arguments:
+#   <path/to/plan.md>   Source plan path (absolute or relative). Must exist.
+#   --mkdir             Create the derived directory if it does not exist.
+#
+# Output:
+#   The derived visual/ directory path on stdout.
+#
+# Exit codes:
+#   0 - Derived (and created, if --mkdir) successfully
+#   1 - Usage error or plan path missing
+#
+set -euo pipefail
+
+_error() {
+  echo "derive-visual-dir.sh: error: $*" >&2
+}
+
+PLAN_PATH=""
+DO_MKDIR=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mkdir)
+      DO_MKDIR=1
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: derive-visual-dir.sh <path/to/plan.md> [--mkdir]" >&2
+      exit 0
+      ;;
+    -*)
+      _error "unknown flag: $1"
+      exit 1
+      ;;
+    *)
+      if [[ -n "$PLAN_PATH" ]]; then
+        _error "unexpected extra argument: $1"
+        exit 1
+      fi
+      PLAN_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$PLAN_PATH" ]]; then
+  _error "a plan path is required"
+  echo "Usage: derive-visual-dir.sh <path/to/plan.md> [--mkdir]" >&2
+  exit 1
+fi
+
+if [[ ! -f "$PLAN_PATH" ]]; then
+  _error "plan file not found: $PLAN_PATH"
+  exit 1
+fi
+
+PLAN_DIR="$(cd "$(dirname "$PLAN_PATH")" && pwd)"
+OUT_DIR="${PLAN_DIR}/visual"
+
+if [[ "$DO_MKDIR" -eq 1 ]]; then
+  mkdir -p "$OUT_DIR"
+fi
+
+echo "$OUT_DIR"
+exit 0

--- a/ycc/skills/visual-recap/SKILL.md
+++ b/ycc/skills/visual-recap/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: visual-recap
+description: Turn a finished change — a git range, branch, or working-tree diff — into a LOCAL-ONLY interactive visual recap (annotated diffs, file map, schema/API deltas, diagrams, wireframes) under docs/prps/reviews/visual/, previewed in the browser via the localhost bridge. Use when the user asks to "recap this branch", "show what changed visually", "visual recap", "review the diff visually", or says "/visual-recap". Never uploads code to a hosted service; remote-agnostic (identical on the public GitHub remote and the private Forgejo origin).
+argument-hint: '[base..head | branch]'
+allowed-tools:
+  - Read
+  - Write
+  - Bash(npx:*)
+  - Bash(plan:*)
+  - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/visual-recap-collect.sh:*)'
+  - 'Bash(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/visual-egress-guard.sh:*)'
+---
+
+# Visual Recap (LOCAL-ONLY)
+
+`/visual-recap` builds a visual plan **from** a diff, not toward one. It is the
+reverse of forward planning: instead of describing the change you are about to
+make, you describe the change that was just made, at a higher altitude than
+line-by-line review. Schema, API, file, and architecture changes become the same
+`data-model`, `api-endpoint`, `file-tree`, and `diagram` blocks a forward plan
+would use, only now they summarize work that exists. A reviewer scans the shape
+of the change before spending attention on the literal lines.
+
+## LOCAL-ONLY mandate — read this first
+
+> This ycc port **inverts** the upstream BuilderIO `visual-recap` skill. Upstream
+> ALWAYS publishes the recap to the hosted Agent-Native Plan database and FORBIDS
+> inline output ("a recap's entire value is the hosted plan"). **This skill does the
+> opposite.** It is permanently pinned to local-files mode and MUST NOT regress to
+> any hosted Plan create tool.
+
+Hard rules for this skill:
+
+- **`AGENT_NATIVE_PLANS_MODE=local-files` is always set.** Export it before running
+  any runtime command. The recap never writes to the hosted Plan database.
+- **NEVER call a hosted Plan create/publish tool.** The hosted recap-create tool,
+  `create-visual-plan`, `import-visual-plan-source`, `update-visual-plan`,
+  `patch-visual-plan-source`, `get-plan-feedback`, `export-visual-plan`, and
+  `set-resource-visibility` are all **disabled** in this skill. They are listed only
+  to be explicitly excluded — do not invoke them.
+- **The ONLY permitted network call is `get-plan-blocks`** (schema-only block catalog;
+  offline fallback `plan blocks --out`). It carries no recap content. Everything else
+  stays on this machine.
+- **The deliverable is local MDX** under `docs/prps/reviews/visual/<slug>/`, served via
+  the localhost bridge (`plan local serve --open`, 127.0.0.1, ephemeral port). There is
+  no hosted link and no shareable URL.
+- **Diffs are sourced through the shared collector**
+  `${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/visual-recap-collect.sh`, which uses
+  local git refs only — so it behaves identically against the public `github` remote and
+  the private Forgejo `origin` (no vendor PR API, no hardcoded host or trunk branch).
+
+For the pinned `@agent-native/*` install, the `plan` MCP connector (legacy alias
+`agent-native-plans`), the localhost-bridge command surface, and the hosted-egress
+policy, read — do not duplicate —
+`${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/agent-native-setup.md`.
+
+## When to use
+
+Build a recap when a change is large, multi-file, or touches schema, API contracts,
+or architecture, and a reviewer would benefit from seeing the change mapped to
+structured blocks before reading the raw diff. Skip it for small, single-file, or
+obvious diffs — a recap is review overhead, and a tiny change reviews faster as plain
+diff.
+
+## Phase 0 — Collect the diff (remote-agnostic, local refs only)
+
+Set local-files mode, then drive the shared collector with `$ARGUMENTS`:
+
+```bash
+export AGENT_NATIVE_PLANS_MODE=local-files
+
+# (none)         → working-tree diff vs HEAD
+# <base>..<head> → explicit range
+# <branch>       → branch as head; base = merge-base against tracked upstream
+BUNDLE_DIR="$(${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/visual-recap-collect.sh $ARGUMENTS)"
+```
+
+The collector writes a bundle under `docs/prps/reviews/visual/<slug>/`:
+
+- `diff.patch` — full unified diff (local refs only)
+- `files.txt` — changed-file name list
+- `metadata.txt` — range / base / head / remote provenance (every remote URL via
+  `git remote get-url`, never a hardcoded host)
+
+`$BUNDLE_DIR` (printed on stdout) is the slug directory the recap MDX is written into.
+Read `diff.patch` and `files.txt` to ground every block. **Print the resolved
+range and remote provenance from `metadata.txt` before authoring** so it is obvious
+which refs the recap covers.
+
+## Phase 1 — Scope the work unit
+
+Default scope is the whole change in the collected range, not only the most recent
+edit. Separate the changes that belong to this work unit from unrelated pre-existing
+dirty work. If the scope is genuinely ambiguous, state the assumption or ask a concise
+question before authoring.
+
+Make a short surface/state inventory from the diff before writing any block: changed
+routes, components, popovers/dialogs, role/access states, empty/error/loading states,
+and shared abstractions. The final recap must either represent each meaningful item
+with a block or intentionally omit it as tiny/redundant/not-user-visible.
+
+## Phase 2 — Fetch the block catalog (the one permitted network call)
+
+> GOTCHA: The MDX block vocabulary drifts upstream between releases. Do NOT author
+> from memorized JSX tags — they silently produce wrong tags that error on import.
+
+Before writing any structured MDX, fetch the live block catalog:
+
+- Connected: call `get-plan-blocks` on the `plan` MCP connector (schema-only; no recap
+  content leaves the machine).
+- Offline / `local-files` fallback: run `plan blocks --out plan-blocks.md` and read it
+  first (calls the public no-auth `get-plan-blocks` route; sends no recap content).
+
+Author every block against the tags and schemas that call returns. The scratch
+`plan-blocks.md` is git-ignored — do not commit it.
+
+## Phase 3 — Map the diff to blocks
+
+Derive every structured block mechanically from the real diff (real paths, real fields,
+real method/path, real before/after text). The names below are CONCEPTUAL block types;
+resolve each to its exact tag + props via `get-plan-blocks`.
+
+- **Schema / migration change** → `data-model` for the resulting entities, fields, and
+  relations. Flag each field/entity with `change: "added" | "modified" | "removed" |
+"renamed"`; for a changed type set `was` to the prior value. The diff-aware
+  `data-model` is the headline; add a split `diff` of literal SQL only when the exact
+  statement still matters.
+- **API / action / route change** → `api-endpoint` with the post-change method, path,
+  params, request, and responses. Flag each changed param/response with `change` (and
+  `was` when a type/shape changed); set `change` on the endpoint root for a wholly added
+  or removed route; mark removed routes `deprecated: true`. Author each request/response
+  example as a single valid JSON value.
+- **Files added / removed / renamed** → `file-tree` with each entry's `change` flag
+  (`added`, `removed`, `modified`, `renamed`) and a short `note`.
+- **Any meaningful code hunk** → `diff` with **split view as the default** (`mode:
+"split"`), carrying the real `before`/`after` text plus `filename`/`language`. Give
+  every `diff` a one-line `summary`; attach a few high-signal `annotations` to the key
+  files. Reserve `mode: "unified"` for a genuinely narrow standalone hunk. Group the key
+  files under a `## Key changes` heading in a single horizontal `tabs` block (one file
+  per tab) so the selected split diff gets full document width.
+- **Brand-new file with no meaningful "before"** → `annotated-code` rather than a
+  one-sided split `diff`.
+- **Rendered UI / interaction change** → `wireframe` blocks (see below) showing the
+  visible delta before any code.
+- **Architecture or data-flow shift** → `diagram` (`data.html`/`data.css` two-panel
+  before/after, layered, or swimlane; or `mermaid` for a quick graph). Use `--wf-*`
+  theme tokens and `.diagram-*` primitives — never hex, rgb/hsl, or `font-family`. Do
+  not use `diagram` as a stand-in for rendered UI; UI changes need `wireframe`.
+- **Outcome-first narrative** → `rich-text` for the "what changed and why": the
+  objective, key decisions visible in the diff, and risks. This is the only place the
+  model writes freely.
+
+### Canonical shape
+
+A strong recap follows one skeleton, top to bottom:
+
+1. UI-impact headline — wireframes first, when the diff changed rendered UI.
+2. Short outcome narrative (`rich-text`): what changed and why, 1–3 paragraphs.
+3. `data-model` / `api-endpoint` blocks for schema and contract changes.
+4. `file-tree` of the changed files with `change` flags.
+5. `## Key changes` — one horizontal `tabs` block of `diff` / `annotated-code`
+   (3–8 focused tabs; prefer under ~150 lines per tab).
+
+Keep the body lean: no boilerplate intro/disclaimer/provenance prose. Add prose only
+when it tells the reviewer something the structured blocks do not.
+
+## UI impact requires wireframes (MANDATORY)
+
+When the diff changes rendered UI, layout, density, visual state, interaction
+affordances, navigation, controls, menus, dialogs, or design tokens, the recap **MUST**
+include one or more `wireframe` blocks. Prose and file diffs are not a substitute for
+showing what changed visually.
+
+Before authoring ANY wireframe, **read
+`${CLAUDE_PLUGIN_ROOT}/skills/visual-recap/references/wireframe.md` in full** — it is the
+single source of truth for HTML wireframe quality (`.wf-*` classes, `[data-icon]` Tabler
+set, `surface` presets, `--wf-*` tokens, before/after comparability, skeleton states).
+Do not author wireframes from memory. Show the changed entry point, the main changed
+interaction surface, and the resulting/destination state; for UI-heavy changes a single
+before/after of the entry surface is not enough.
+
+## Phase 4 — Write and serve the local recap
+
+Write the recap as a local MDX folder inside the collected bundle directory:
+
+- `docs/prps/reviews/visual/<slug>/plan.mdx` (required), optional `canvas.mdx`, and
+  optional `.plan-state.json`. Set `kind: "recap"` and `localOnly: true` in the source
+  frontmatter/state.
+
+Validate, then serve via the localhost bridge:
+
+```bash
+plan local check --dir docs/prps/reviews/visual/<slug>
+plan local serve --dir docs/prps/reviews/visual/<slug> --kind recap --open
+```
+
+`serve` binds **127.0.0.1** on an ephemeral CLI-chosen port and opens the preview. It
+performs **no DB writes and sends nothing to any server** — it is a purely local render
+of the on-disk MDX. Report the local bridge URL from stdout (or `<slug>/.plan-url`, a
+local token file — do not commit it). The URL is not shareable across machines.
+
+Treat review feedback as file/chat feedback: edit the MDX directly, rerun
+`plan local serve`, and report the new local bridge URL. Hosted comments, sharing,
+screenshots, and PR sticky-comment publishing are intentionally unavailable.
+
+## Grounding & security
+
+- **Grounding rule.** `diff`, `data-model`, `api-endpoint`, and `file-tree` blocks must
+  be built mechanically from the real changed lines — never inferred, rounded, or
+  invented. Mark anything the model inferred (not extracted) as inferred in prose. When
+  the diff does not contain a fact, leave it out.
+- **Never transcribe secrets.** A diff can contain API keys, tokens, webhook URLs,
+  signing secrets, or `.env` values. Never copy these into any block, snippet, caption,
+  or note — redact them (`sk-•••`). This mirrors the repo's hardcoded-secret rule.
+- **No egress.** This skill performs no hosted upload. The shared
+  `${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/visual-egress-guard.sh` exists for the
+  consent-gated hosted path used by `ycc:visual-plan`; it is NOT invoked here because
+  this recap never leaves the machine.
+
+## Output
+
+- Local MDX recap under `docs/prps/reviews/visual/<slug>/` (`plan.mdx` + bundle).
+- A `127.0.0.1` localhost-bridge preview URL printed to stdout.
+- **No hosted link, no shareable URL, no PR comment, no GitHub/Forgejo Action.**
+
+## Related
+
+- `ycc:visual-plan` — forward planning; faithful hosted+local MDX workflow with
+  consent-gated egress. Shares the wireframe quality bar word-for-word.
+- `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/agent-native-setup.md` — runtime
+  contract (install pin, connector, bridge, egress policy).

--- a/ycc/skills/visual-recap/references/wireframe.md
+++ b/ycc/skills/visual-recap/references/wireframe.md
@@ -1,0 +1,234 @@
+# HTML wireframe quality — single source of truth
+
+This file is the canonical quality bar for HTML wireframes / `WireframeBlock`
+content, shared word for word by `ycc:visual-plan` and `ycc:visual-recap`. Read it in
+full before authoring ANY wireframe; do not author wireframes from memory or paraphrase
+these rules per command.
+
+**A wireframe is an HTML mockup. The renderer owns the look; you write the content.**
+Set `data.html` to a self-contained, semantic HTML fragment of the screen and set
+`data.surface`. The renderer owns the surface footprint/aspect, the dark/light theme,
+the hand-drawn font, and the sketch overlay — you never write `<html>`/`<body>`/`<svg>`
+tags or any width/height/coordinates. You write real HTML layout and real product
+content; the renderer styles and roughens it.
+
+**A wireframe block's data is an HTML screen plus a surface:**
+
+```json
+{
+  "surface": "browser",
+  "html": "<div style=\"display:flex;flex-direction:column;gap:10px;padding:16px;height:100%\"><h1>Sign in</h1><p class=\"wf-muted\">Use your work email to continue.</p><div class=\"wf-card\" style=\"display:flex;flex-direction:column;gap:10px\"><label>Email<input value=\"jane@acme.co\" /></label><label>Password<input value=\"••••••••\" /></label><label style=\"display:flex;align-items:center;gap:8px\"><input type=\"checkbox\" checked /> Remember me</label><button class=\"primary\">Sign in</button></div><a href=\"#\">Forgot password?</a></div>"
+}
+```
+
+**Write PLAIN semantic HTML and let the renderer style it.** Bare elements
+(`h1`/`h2`/`h3`, `p`, `button`, `input`, `label`, `a`, `hr`) are auto-themed — no
+classes needed. Helper classes carry the rest:
+
+- `.wf-card` / `.wf-box` — a bordered, padded container (a panel, a list item).
+- `.wf-pill` / `.wf-chip` — a rounded tag or filter; add `.accent` for the
+  accent-filled variant.
+- `.wf-muted` — secondary/muted text.
+- `button.primary` or any element with `[data-primary]` — the accent-filled primary
+  button.
+
+**No decorative shadows around mockups.** Do not put `box-shadow`,
+`filter: drop-shadow(...)`, Tailwind `shadow-*` classes, or other fake depth effects on
+a wireframe frame, root container, `.wf-card` / `.wf-box`, or canvas artboard. Mockups
+should read as flat, bordered surfaces; use spacing, borders, labels, and annotations
+for separation. Only show a shadow when the real product UI already has that shadow and
+it is essential to the change being reviewed.
+
+**Use renderer icons, not visible icon words.** For icon-only buttons or leading icons
+inside fields, chips, menu items, and toolbars, write an empty marker such as
+`<i data-icon="mail"></i>` or `<span data-icon="search"></span>`. The renderer replaces
+it with a Tabler-style SVG and the `.wf-icon` class sizes it to the surrounding text.
+Supported names and aliases: `mail`/`email`, `lock`/`password`, `search`, `plus`/`add`,
+`x`/`close`, `check`, `chevronDown`, `chevronUp`, `chevronLeft`, `chevronRight`,
+`dots`/`more`, `chevron`/`caret`/`dropdown` (down chevron), `user`, `settings`,
+`calendar`, `bell`, `send`, `edit`, `arrowLeft`, and `arrowRight`. Do not put visible
+words like "email", "lock", "search", "chevron", or "more" where the product UI would
+show an icon; use text only when it is a real label a user would read.
+
+**Use the `--wf-*` tokens for any custom color, never hex.** The renderer flips these on
+light/dark, so reading them is what keeps a mockup correct in both themes. For any
+inline border, background, or text color, reference a token:
+`style="border:1.4px solid var(--wf-line)"`. The tokens are `--wf-ink` (text),
+`--wf-muted` (secondary text), `--wf-line` (borders/dividers), `--wf-paper` (page
+background), `--wf-card` (container surface), `--wf-accent` / `--wf-accent-fg` /
+`--wf-accent-soft` (brand action), `--wf-warn`, `--wf-ok`, and `--wf-radius`. Never
+hard-code a hex color and never set `font-family` — the renderer owns the sketch/clean
+font.
+
+**Lay out with inline `style` flex/grid.** You write the real layout —
+`display:flex; flex-direction:column; gap:10px; padding:16px` and so on — and the
+renderer never repositions anything. Compose the actual product: reproduce the current
+screen, then show the modification. Real labels, real counts, real dates, real button
+text grounded in the screen you read; not lorem or gray bars.
+
+**Surface presets — match the real footprint, never default to desktop+mobile.** Pick
+the `surface` that matches what the user will actually see:
+
+- `browser`: a web page that needs a browser chrome frame around it.
+- `desktop`: a full desktop app page or app shell.
+- `mobile`: a phone screen, only when the work is genuinely mobile.
+- `popover`: a small floating menu, dropdown, or inline popover.
+- `panel`: a side panel, inspector, or sidebar widget.
+
+A sidebar popover renders as a small surface, not a desktop page and a phone frame. Do
+not emit `desktop` + `mobile` variants unless responsive behavior actually changes the
+layout. For a component or widget, show one broader app-context frame only when
+placement affects understanding, then the focused component states.
+
+**Model the actual component shell for small surfaces.** A rendered UI change belongs in
+a wireframe; reserve `diagram` for architecture, dependency, state, or data-flow
+relationships. Popovers, dropdown menus, command palettes, and context menus use
+`surface: "popover"` unless the surrounding page placement is the point of the change.
+Dialogs, sheets, inspectors, sidebars, and long property panels use the matching
+`panel` / `desktop` surface as appropriate. Show the real chrome: trigger or anchor when
+it matters, title/header row, top-right actions, separators, fields, options, selected
+states, body content, and footer actions that are visible in the workflow.
+
+**Modify, don't redesign.** When the task changes an existing screen, reproduce the
+current screen's real layout and footprint FIRST, then change only the delta and call it
+out with a single annotation. Do not restack the page into a new layout. For net-new
+surfaces, compose from the real app shell. Inspect the actual app components before
+drawing an existing product: sidebar density, toolbar actions, overflow menus, property
+panels, and framework chrome should match the product unless the plan intentionally
+changes them.
+
+**Keep product screens pure.** A product wireframe shows the app state a user would
+actually see. Do not embed file contracts, architecture arrows, repo pills, mode
+explanations, or implementation callouts inside the screen just to explain the plan. Put
+those in canvas annotations, a separate diagram, or the document body. Secondary UI such
+as properties, history, sync, export, or agent controls should appear where the real
+product would put them: an overflow popover, sheet, panel, or separate framework sidebar
+state, not a generic permanent right inspector unless that inspector is the actual
+design.
+
+**Classify mockup scope before implementation.** Before turning a plan mockup into
+source code, decide whether each artboard represents the whole page/app shell, a route
+body inside an existing shell, or a component/sub-surface. If an artboard includes
+navigation, sidebars, auth banners, or a signup/login form, map those pieces to the real
+shared shell/auth components instead of nesting the entire mockup inside the current
+page. When a mockup references the product's standard signup/login page, find and reuse
+that existing implementation; do not approximate it from the wireframe.
+
+**Zoom in on sub-surfaces, don't redraw the page.** For a small sub-surface (a popover,
+menu, dialog, toast), show the full screen once, then add a small separate artboard
+whose `html` contains ONLY that sub-surface — do not re-draw the whole page around it,
+and do not scale a duplicate up. Pick the matching `surface` (e.g. `popover`) so the
+footprint is right; never widen a popover to page width.
+
+**Loading / skeleton states.** Set `data.skeleton: true` on the wireframe and fill the
+`html` with neutral, textless placeholder geometry — boxes and bars built as `<div>`s
+with `background:var(--wf-line)` and explicit heights/widths, no labels or copy. The
+renderer drops borders, sketch, and color into the skeleton register automatically.
+Never escape to a `custom-html` document block to fake a loader.
+
+**Editing an existing mockup.** Because this skill is LOCAL-ONLY, edit the MDX source
+file directly (no hosted patch tool), then rerun `plan local serve` to re-render. Read
+the current `html` first so each replacement targets a unique snippet; the result is
+re-sanitized on reload.
+
+**Treat the wireframe border as part of the visible design.** Always wrap HTML wireframe
+content in a root container with real inner padding before drawing cards, fields, pills,
+labels, or controls. Use at least 14–16px of padding, `box-sizing: border-box`,
+`height: 100%`, and `gap` between child rows so the first row never sits flush against
+the screen border. Keep text away from borders: every container, field, button, menu
+item, and annotation needs enough padding and line-height to read cleanly in the
+rendered Plan view.
+
+**Lay out children safely so they never collide.** Use HTML flex/grid with `gap`,
+`min-width: 0`, and sensible overflow. Avoid negative margins, absolute positioning, or
+fixed child widths that can collide when the renderer switches between light/dark,
+sketch/clean, or different zoom levels.
+
+**Do not wrap intentionally single-line labels.** For toolbars, tab rails, breadcrumbs,
+chip/filter rows, branch and file names, file chips, and code filenames — any
+deliberately single-line row — do not let long text wrap. Put `white-space: nowrap` on
+the row (and `overflow: hidden; text-overflow: ellipsis` on the individual labels that
+can grow), so the wireframe demonstrates the actual layout behavior instead of producing
+ugly stacked or vertical text. Use horizontally scrollable or clipped rails for
+overflow.
+
+**Fill the frame; keep labels short.** Each artboard is a fixed-size surface — compose
+enough realistic HTML to fill it top to bottom with even vertical rhythm; never leave a
+large empty band. On desktop/app-shell sidebars, let the nav stack flex to fill
+(`flex:1`) and add any persistent bottom action/status after it so the rail reads
+complete in taller frames. On mobile especially, flow real rows down the whole screen
+(status bar, header, then list/detail content) rather than a header floating above a
+gap. Keep every label short enough to sit on one line within its column — shorten the
+copy rather than relying on the frame to absorb it.
+
+**Persistent chrome bars span the full frame width.** Top bars, app headers, toolbars,
+and bottom tab/nav bars are full-width chrome, not centered content. Lay each one out as
+a single flex row that fills the frame (`style="display:flex;align-items:center;width:100%"`)
+and push trailing actions to the right edge with a flex spacer
+(`<div style="flex:1"></div>`) between the leading group and the trailing group — never
+center a bar inside a narrow, centered block, and never let it collapse to the width of
+its contents. In a Before/After pair the bar stays full-width in BOTH states even when
+one state has fewer controls; the spacer absorbs the difference so the remaining controls
+hold their edge alignment.
+
+**Pin bottom bars to the bottom of the frame.** For mobile tab bars, footers, and any
+persistent bottom action row, make the frame itself a flex column at `height:100%`
+(`style="display:flex;flex-direction:column;height:100%"`), give the scrolling body
+`flex:1` so it absorbs the slack, and place the bar as the LAST child of the frame (or
+set `margin-top:auto` on it). The bar then sits flush at the bottom of the surface
+instead of floating directly under the content with an empty band beneath it.
+
+**Before / after must be comparable.** When showing a state change, preserve the
+unchanged controls in both states so the reviewer can see exactly what moved or
+appeared; do not show an added control as a generic box floating elsewhere in the
+surface. Place the new/changed affordance where the implementation puts it — for
+example, a new `Edit with AI` action in a popover header belongs in the top-right header
+slot, aligned with the title, not in the body or footer. Use the same frame size, scale,
+outer padding, border radius, and visual density on both sides unless the change itself
+alters those properties, and let the frame height fit the content rather than leaving a
+tall empty lower half.
+
+**Name the states with the column header, never inside the frame.** For document-body
+wireframes (recaps), put the two states in a `columns` block and set each column's
+`label` to `Before` and `After` — the renderer draws that label as an `h4` heading above
+each frame. Do NOT bake a `Before`/`After` pill, title, or heading into the wireframe
+`html`: a label placed inside reads as part of the product UI, lands in a random corner,
+and clutters the comparison. The column header is the one and only place the state name
+belongs.
+
+**Let the surface choose side-by-side vs. stacked.** For document-body wireframes
+(recaps), the `columns` renderer lays narrow surfaces (`mobile`, `popover`, `panel`) out
+side by side, and automatically stacks wide surfaces (`desktop`, `browser`) vertically
+at full document width so a large frame is never crushed into a half-width column and
+cropped. Author both wireframes with the real `surface` and the matching `Before`/`After`
+column labels; do not hand-stack the pair into separate top-level wireframes or duplicate
+the state name as body content.
+
+**Good example — a contacts list, surface `browser`.** A small, real screen composed
+from the helper classes and tokens, layout in inline flex, no fonts or hex colors:
+
+```html
+<div style="display:flex;flex-direction:column;gap:12px;padding:16px;height:100%">
+  <div style="display:flex;align-items:center;justify-content:space-between">
+    <h1>Contacts</h1>
+    <button class="primary">New contact</button>
+  </div>
+  <div style="display:flex;gap:6px">
+    <span class="wf-pill accent">All 128</span>
+    <span class="wf-pill">Favorites</span>
+    <span class="wf-pill">Archived</span>
+  </div>
+  <div class="wf-card" style="display:flex;flex-direction:column;gap:0;padding:0">
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px;border-bottom:1.4px solid var(--wf-line)">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Jane Cooper</strong><br /><small>jane@acme.co</small></div>
+      <span class="wf-pill">Lead</span>
+    </div>
+    <div style="display:flex;align-items:center;gap:10px;padding:10px 12px">
+      <div style="width:32px;height:32px;border-radius:999px;background:var(--wf-accent-soft)"></div>
+      <div style="flex:1"><strong>Marcus Lee</strong><br /><small>marcus@globex.io</small></div>
+      <span class="wf-pill">Customer</span>
+    </div>
+  </div>
+</div>
+```


### PR DESCRIPTION
## Summary

Adds `visual-plan` and `visual-recap` skills to the ycc plugin, wires a `--visual` flag into four planning skills, registers the MCP plan connector, and syncs regenerated Cursor/Codex/OpenCode bundles.

## Changes

- **New skills**: `visual-plan` (canvas/wireframe planning) and `visual-recap` (post-implementation visual summary)
- **Planning integration**: `--visual` support on `plan`, `parallel-plan`, `plan-workflow`, and `prp-plan`
- **Shared assets**: `visual-mode` reference, agent-native setup, egress guard and recap collection scripts
- **Commands & MCP**: New ycc/opencode commands; plan connector entries in `mcp-configs/mcp.json` and Codex `.mcp.json`
- **Docs**: README and inventory updates; PRP plan archived and implementation report added

## Files Changed

- **Added**: `ycc/skills/visual-plan/**`, `ycc/skills/visual-recap/**`, shared scripts/references, commands, mirrored generated bundles (85 files total)
- **Modified**: Four planning skills/commands across ycc and generated targets; `.gitignore`; `docs/inventory.json`
- **Docs**: `docs/prps/plans/completed/visual-planning-skills.plan.md`, `docs/prps/reports/visual-planning-skills-report.md`

## Testing

- `./scripts/validate.sh` passed locally (inventory, sync checks, content policy across cursor/codex/opencode)
- Pre-push lefthook validate hook passed on push to `origin`

## PRP Artifacts

- Implementation report: [docs/prps/reports/visual-planning-skills-report.md](docs/prps/reports/visual-planning-skills-report.md)
- Completed plan: [docs/prps/plans/completed/visual-planning-skills.plan.md](docs/prps/plans/completed/visual-planning-skills.plan.md)

## Related Issues

None