### PR TITLE
feat(git): autodetect forge provider (GitHub + Forgejo/Gitea) across git skills

### DIFF
--- a/.codex-plugin/ycc/shared/references/ci-monitoring.md
+++ b/.codex-plugin/ycc/shared/references/ci-monitoring.md
@@ -22,6 +22,27 @@ must not diverge from either.
 
 ---
 
+## Provider Support
+
+The CI-autofix loop is **GitHub-only**. Both `ci-monitor.sh` and
+`release-ci-monitor.sh` depend on `gh` run controls (`gh run view
+--log-failed`, `gh run rerun`, `gh run list`) that have no Forgejo/Gitea (`tea`)
+or GitLab (`glab`) equivalent. Before entering the loop the scripts detect the
+forge provider on the watched remote; on any non-GitHub remote they emit
+`RESULT=unsupported-provider` (exit 2) and do nothing else.
+
+The detection contract — provider values `github` / `forgejo` / `gitea` /
+`gitlab` / `unknown`, the `forge_detect_provider` / `forge_cli` law — lives in
+[`forge-detection.md`](forge-detection.md) (capability matrix: "CI-autofix loop
+(`--ci`)" is GitHub-only).
+
+**Skill loop handling:** treat `RESULT=unsupported-provider` exactly like
+`pr-not-found` / `refused-default-branch` — surface it directly and do **not**
+loop. State that the loop is GitHub-only, skip it cleanly, and never re-invoke
+the monitor. It is a terminal non-loop result, not an error to retry.
+
+---
+
 ## Trust Boundary
 
 `--ci` grants the following standing authorization for the duration of one skill
@@ -109,6 +130,7 @@ corresponding code.
 | `bail-timeout`           | 13        | Wall-clock ≥ `--ci-timeout-min`, or checks never registered              |
 | `pr-not-found`           | 2         | PR does not exist or is unreachable                                      |
 | `refused-default-branch` | 2         | Will not operate when head branch equals the default branch              |
+| `unsupported-provider`   | 2         | Remote is not GitHub; the CI-autofix loop is GitHub-only                 |
 
 Exit code 1 is reserved for argument/usage errors and never appears in the loop.
 
@@ -174,8 +196,10 @@ the skill.
      - The cap or constraint that fired
        Exit phase; do not push further.
 
-   - **`pr-not-found`** / **`refused-default-branch`** — surface the error
-     directly; do not enter the loop.
+   - **`pr-not-found`** / **`refused-default-branch`** / **`unsupported-provider`**
+     — surface the error directly; do not enter the loop. For
+     `unsupported-provider`, state that the CI-autofix loop is GitHub-only (see
+     the Provider Support section above) and skip it cleanly.
 
 ---
 

--- a/.codex-plugin/ycc/shared/references/forge-detection.md
+++ b/.codex-plugin/ycc/shared/references/forge-detection.md
@@ -1,0 +1,155 @@
+# Forge Provider Detection & Tooling Selection
+
+Single source of truth for how every git skill in the `ycc` bundle decides
+**which forge it is talking to** and **which CLI to drive**. Any skill that
+creates PRs, files issues, cuts releases, posts review comments, or watches CI
+must run this detection first and route accordingly.
+
+The programmatic counterpart is
+[`_shared/scripts/lib/forge.sh`](../scripts/lib/forge.sh) — a sourceable bash
+library that implements the detection law described here. Scripts source it;
+SKILL prose references this document. The two must never diverge.
+
+> **Why this exists.** The bundle was historically GitHub-only (`gh`
+> everywhere). Self-hosted **Forgejo** and **Gitea** repositories need the same
+> workflows driven through the `tea` CLI. Detection lets one skill serve both
+> without the user passing a `--provider` flag.
+
+---
+
+## Provider values
+
+| Provider  | Hosts                          | CLI    | Notes                                  |
+| --------- | ------------------------------ | ------ | -------------------------------------- |
+| `github`  | github.com, GitHub Enterprise  | `gh`   | Full feature support                   |
+| `forgejo` | self-hosted Forgejo            | `tea`  | Gitea fork; same tooling as `gitea`    |
+| `gitea`   | self-hosted Gitea              | `tea`  | Generic Gitea-family label             |
+| `gitlab`  | gitlab.com, self-hosted GitLab | `glab` | Pre-existing partial support           |
+| `unknown` | anything else                  | (none) | Skip host-API steps with a loud notice |
+
+`forgejo` and `gitea` are the **same tooling family** — both driven by `tea`.
+They are distinguished only for accurate user-facing messages. For command
+selection, treat them identically (`forge_cli` maps both to `tea`).
+
+---
+
+## Detection algorithm
+
+`forge_detect_provider [remote] [--probe]` (default remote: `origin`):
+
+1. Read `git remote get-url <remote>`. No remote → `unknown`.
+2. Extract the bare host from the URL (handles `git@host:owner/repo.git`,
+   `ssh://git@host:port/...`, `https://host/...`, `git://host/...`; strips a
+   trailing `.git`).
+3. **GitHub** if the host is `github.com` / `*.github.com`, equals `$GH_HOST`
+   or `$GITHUB_HOST`, or appears in `~/.config/gh/hosts.yml`.
+4. **GitLab** if the host is `gitlab.com` / `*.gitlab.com`, or appears in
+   `~/.config/glab-cli/config.yml`.
+5. **Gitea family** if the host matches a configured `tea login list` entry.
+   With `--probe`, a best-effort `GET https://<host>/api/v1/version` (plus the
+   Server header) distinguishes `forgejo` from `gitea`; offline, default to
+   `gitea`.
+6. With `--probe` and no local match, the `/api/v1/version` probe can still
+   classify an unconfigured Gitea/Forgejo host.
+7. Otherwise → `unknown`.
+
+Steps 3–4 and the `tea login list` read in step 5 are **local only** — no
+network, no rate-limit cost. The `/api/v1/version` probe in steps 5–6 is
+opt-in via `--probe` so default detection stays fast and offline-friendly.
+
+---
+
+## Auth probes (run once, cache the result)
+
+Never call the host API to check auth — use the local status commands:
+
+```bash
+# github
+command -v gh   >/dev/null && gh   auth status >/dev/null 2>&1   # → authed
+
+# forgejo / gitea  (tea has no `auth status`; a configured login is the signal)
+command -v tea  >/dev/null && tea login list 2>/dev/null | grep -q '://'
+
+# gitlab
+command -v glab >/dev/null && glab auth status >/dev/null 2>&1
+```
+
+The lib exposes these as `forge_auth_ok <provider>`. If the matched provider's
+CLI is missing or unauthenticated, surface a precise remediation (`gh auth
+login`, `tea login add`, `glab auth login`) and fall back to local-only mode
+rather than guessing.
+
+---
+
+## Operation equivalence map
+
+Core operations are supported on **both** families. Drive them through the CLI
+that `forge_cli <provider>` returns.
+
+| Operation             | GitHub (`gh`)                            | Forgejo / Gitea (`tea`)                          |
+| --------------------- | ---------------------------------------- | ------------------------------------------------ |
+| Default branch        | `gh repo view --json defaultBranchRef`   | `git symbolic-ref refs/remotes/origin/HEAD`      |
+| Create PR             | `gh pr create --title --body [--draft]`  | `tea pull create --title --description [--head]` |
+| PR for current branch | `gh pr list --head <branch>`             | `tea pull list` (filter by head branch)          |
+| View PR state         | `gh pr view <n> --json state`            | `tea pull <n>`                                   |
+| List open issues      | `gh issue list`                          | `tea issues list`                                |
+| Create issue          | `gh issue create --title --body`         | `tea issues create --title --description`        |
+| Close issue           | `gh issue close <n>`                     | `tea issues close <n>`                           |
+| Create release        | `gh release create <tag> [--notes-file]` | `tea release create --tag <tag> [--note-file]`   |
+| Delete remote branch  | `git push <remote> --delete <branch>`    | `git push <remote> --delete <branch>` (same)     |
+
+`tea` operates on the repo bound to the current directory's `origin` remote (it
+reads `.git/config`); pass `--repo owner/name` only when overriding.
+
+---
+
+## Capability matrix — GitHub-only features
+
+Some advanced features depend on APIs that **do not exist** on Forgejo/Gitea.
+These degrade gracefully: detect the provider, and on a non-GitHub remote emit
+`forge_unsupported_notice` and exit cleanly rather than faking parity.
+
+| Feature                              | GitHub | Forgejo / Gitea | Why                                                         |
+| ------------------------------------ | ------ | --------------- | ----------------------------------------------------------- |
+| PR / issue / release create + list   | ✅     | ✅              | Covered by `gh` and `tea`                                   |
+| Review-thread resolution (`resolve`) | ✅     | ❌              | Requires GraphQL `resolveReviewThread`; no GraphQL on Gitea |
+| Per-comment PR autofix harvesting    | ✅     | ❌              | `fetch-pr-comments.sh` uses the GitHub GraphQL API          |
+| CI-autofix loop (`--ci`)             | ✅     | ❌              | Depends on `gh run view --log-failed` / `gh run rerun`      |
+| Emoji reactions on comments          | ✅     | ❌              | GraphQL `addReaction`                                       |
+
+For ❌ features on a non-GitHub remote, the skill must:
+
+1. Detect the provider in its Phase 0.
+2. Tell the user the feature is GitHub-only and **why** (one line).
+3. Offer the manual alternative (e.g. "resolve the thread in the Forgejo UI").
+4. Continue with whatever **is** supported (e.g. still create the PR via `tea`),
+   skipping only the unsupported step.
+
+Never silently no-op and never pretend an unsupported step succeeded.
+
+---
+
+## Skill integration pattern (Phase 0)
+
+Every git-operation skill adds a detection step before any host call:
+
+```bash
+# shellcheck source=/dev/null
+source "~/.codex/plugins/ycc/shared/scripts/lib/forge.sh"
+provider="$(forge_detect_provider origin)"
+cli="$(forge_cli "$provider")"
+forge_auth_ok "$provider" || { echo "Auth needed for $provider"; exit 2; }
+```
+
+Then branch on `$provider` for the operation, or call a script that does the
+branching internally. Log the resolved provider + CLI so the user sees which
+forge the workflow targeted.
+
+---
+
+## References
+
+- [`_shared/scripts/lib/forge.sh`](../scripts/lib/forge.sh) — the detection lib
+- [`git-cleanup/references/host-detection.md`](../../git-cleanup/references/host-detection.md)
+  — the older GitHub/GitLab host-detection notes this generalizes
+- [`ci-monitoring.md`](ci-monitoring.md) — CI-autofix loop (GitHub-only; gated here)

--- a/.codex-plugin/ycc/shared/scripts/ci-monitor.sh
+++ b/.codex-plugin/ycc/shared/scripts/ci-monitor.sh
@@ -38,6 +38,16 @@ VERSION="1.0.0"
 . "$(dirname "$0")/lib/ci-classify.sh"
 
 # ---------------------------------------------------------------------------
+# Forge provider detection (sourced)
+# ---------------------------------------------------------------------------
+# The CI-autofix loop depends on `gh run view --log-failed` / `gh run rerun`,
+# which have no Forgejo/Gitea equivalent. The loop is GitHub-only; on any other
+# provider this script exits early with RESULT=unsupported-provider.
+
+# shellcheck source=lib/forge.sh
+. "$(dirname "$0")/lib/forge.sh"
+
+# ---------------------------------------------------------------------------
 # Usage
 # ---------------------------------------------------------------------------
 
@@ -383,6 +393,18 @@ main() {
     log_jsonl "$log_file" "$ts" "$iteration" "$pr" "0" "" "success" "" "green" "$push_count" "" '"dry_run":true'
     printf 'RESULT=green\n'
     exit 0
+  fi
+
+  # -------------------------------------------------------------------------
+  # Step 0: Forge provider gate (GitHub-only feature)
+  # -------------------------------------------------------------------------
+
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "the --ci auto-fix loop"
+    printf 'RESULT=unsupported-provider\n'
+    exit 2
   fi
 
   # -------------------------------------------------------------------------

--- a/.codex-plugin/ycc/shared/scripts/lib/forge.sh
+++ b/.codex-plugin/ycc/shared/scripts/lib/forge.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# forge.sh — Git forge provider detection and tooling selection.
+#
+# Sourceable library. Sourcing it has NO side effects (no network, no writes,
+# no `set` changes that leak to the caller). Every consumer that talks to a
+# remote git host (GitHub / Forgejo / Gitea / GitLab) routes through these
+# helpers so a single detection law governs the whole bundle.
+#
+# Provider values returned by forge_detect_provider:
+#   github   — GitHub.com or GitHub Enterprise        → CLI: gh
+#   forgejo  — Forgejo instance (Gitea fork)          → CLI: tea
+#   gitea    — Gitea instance                          → CLI: tea
+#   gitlab   — GitLab.com or self-hosted GitLab        → CLI: glab
+#   unknown  — could not be determined                 → CLI: (none)
+#
+# `forgejo` and `gitea` are the same tooling family (both driven by `tea`);
+# they are distinguished only for accurate messaging. Treat them identically
+# for command selection — forge_cli maps both to `tea`.
+#
+# Contract: see _shared/references/forge-detection.md (single source of truth).
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+# forge_strip_git_suffix <url> — strip a trailing ".git".
+forge_strip_git_suffix() {
+  printf '%s' "${1%.git}"
+}
+
+# forge_remote_url [remote] — print the fetch URL for a remote (default origin).
+# Prints nothing and returns 1 if the remote does not exist.
+forge_remote_url() {
+  local remote="${1:-origin}"
+  git remote get-url "$remote" 2>/dev/null
+}
+
+# forge_host_from_url <url> — extract the bare hostname from an ssh, https, or
+# git:// remote URL. Handles:
+#   git@host:owner/repo.git
+#   ssh://git@host:22/owner/repo.git
+#   https://host/owner/repo.git
+#   git://host/owner/repo.git
+forge_host_from_url() {
+  local url="$1"
+  url="$(forge_strip_git_suffix "$url")"
+
+  case "$url" in
+    *://*)
+      # scheme://[user@]host[:port]/path
+      local rest="${url#*://}"
+      rest="${rest#*@}"      # drop optional user@
+      rest="${rest%%/*}"     # keep host[:port]
+      printf '%s' "${rest%%:*}"  # drop :port
+      ;;
+    *@*:*)
+      # scp-like: [user@]host:path
+      local rest="${url#*@}"
+      printf '%s' "${rest%%:*}"
+      ;;
+    *:*)
+      # host:path with no user
+      printf '%s' "${url%%:*}"
+      ;;
+    *)
+      printf '%s' "$url"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Configured-host probes (local only — no network)
+# ---------------------------------------------------------------------------
+
+# forge_host_is_github <host> — true if the host is GitHub.com, a configured
+# GH_HOST/GITHUB_HOST enterprise host, or listed in ~/.config/gh/hosts.yml.
+forge_host_is_github() {
+  local host="$1"
+  case "$host" in
+    github.com|*.github.com) return 0 ;;
+  esac
+  if [[ -n "${GH_HOST:-}" && "$host" == "${GH_HOST}" ]]; then return 0; fi
+  if [[ -n "${GITHUB_HOST:-}" && "$host" == "${GITHUB_HOST}" ]]; then return 0; fi
+  local hosts_yml="${HOME}/.config/gh/hosts.yml"
+  if [[ -f "$hosts_yml" ]] && grep -qE "^${host}:" "$hosts_yml" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# forge_host_is_gitlab <host> — true if GitLab.com or a configured glab host.
+forge_host_is_gitlab() {
+  local host="$1"
+  case "$host" in
+    gitlab.com|*.gitlab.com) return 0 ;;
+  esac
+  local glab_cfg="${HOME}/.config/glab-cli/config.yml"
+  if [[ -f "$glab_cfg" ]] && grep -qE "^[[:space:]]*${host}:" "$glab_cfg" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# forge_host_in_tea <host> — true if the host matches a configured `tea` login
+# (Gitea/Forgejo). Reads `tea login list` so no network call is made.
+forge_host_in_tea() {
+  local host="$1"
+  command -v tea >/dev/null 2>&1 || return 1
+  # `tea login list` prints a table containing the URL and SSH host columns.
+  tea login list 2>/dev/null | grep -qiF "$host"
+}
+
+# ---------------------------------------------------------------------------
+# Optional network probe — distinguishes Forgejo from Gitea, and confirms a
+# gitea-family host when no local config exists. Best-effort; never required.
+# ---------------------------------------------------------------------------
+
+# forge_probe_gitea_family <host> — echo "forgejo" or "gitea" if the host serves
+# the Gitea REST API, else echo nothing and return 1. Hits /api/v1/version,
+# which is public on virtually all instances.
+forge_probe_gitea_family() {
+  local host="$1"
+  command -v curl >/dev/null 2>&1 || return 1
+  local body
+  body="$(curl -fsSL --max-time 5 "https://${host}/api/v1/version" 2>/dev/null)" || return 1
+  # The version endpoint returns {"version":"..."}. Forgejo advertises itself in
+  # the Server header; fall back to assuming gitea for the bare version payload.
+  case "$body" in
+    *version*)
+      local server
+      server="$(curl -fsSLI --max-time 5 "https://${host}/api/v1/version" 2>/dev/null | tr -d '\r')"
+      if printf '%s' "$server" | grep -qi 'forgejo'; then
+        printf 'forgejo'
+      else
+        printf 'gitea'
+      fi
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Provider detection
+# ---------------------------------------------------------------------------
+
+# forge_detect_provider [remote] [--probe]
+#   Detect the forge provider for a remote (default origin).
+#   Pass --probe to allow the network /api/v1/version fallback (off by default
+#   so detection stays fast and offline-friendly).
+#   Echoes one of: github | forgejo | gitea | gitlab | unknown
+forge_detect_provider() {
+  local remote="origin" probe="false"
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --probe) probe="true" ;;
+      *) remote="$arg" ;;
+    esac
+  done
+
+  local url host
+  url="$(forge_remote_url "$remote")" || { printf 'unknown'; return 0; }
+  [[ -z "$url" ]] && { printf 'unknown'; return 0; }
+  host="$(forge_host_from_url "$url")"
+  [[ -z "$host" ]] && { printf 'unknown'; return 0; }
+
+  if forge_host_is_github "$host"; then printf 'github'; return 0; fi
+  if forge_host_is_gitlab "$host"; then printf 'gitlab'; return 0; fi
+  if forge_host_in_tea "$host"; then
+    if [[ "$probe" == "true" ]]; then
+      local fam
+      fam="$(forge_probe_gitea_family "$host")" && { printf '%s' "$fam"; return 0; }
+    fi
+    # tea is configured for this host but we can't tell Forgejo from Gitea
+    # offline — default to the generic family label.
+    printf 'gitea'
+    return 0
+  fi
+  if [[ "$probe" == "true" ]]; then
+    local fam
+    fam="$(forge_probe_gitea_family "$host")" && { printf '%s' "$fam"; return 0; }
+  fi
+  printf 'unknown'
+}
+
+# ---------------------------------------------------------------------------
+# Tooling selection
+# ---------------------------------------------------------------------------
+
+# forge_cli <provider> — echo the CLI binary name for a provider.
+#   github → gh, forgejo|gitea → tea, gitlab → glab, unknown → (empty)
+forge_cli() {
+  case "$1" in
+    github) printf 'gh' ;;
+    forgejo|gitea) printf 'tea' ;;
+    gitlab) printf 'glab' ;;
+    *) printf '' ;;
+  esac
+}
+
+# forge_is_gitea_family <provider> — true for forgejo or gitea.
+forge_is_gitea_family() {
+  case "$1" in
+    forgejo|gitea) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# forge_cli_available <provider> — true if the provider's CLI is installed.
+forge_cli_available() {
+  local cli
+  cli="$(forge_cli "$1")"
+  [[ -n "$cli" ]] && command -v "$cli" >/dev/null 2>&1
+}
+
+# forge_auth_ok <provider> — true if the provider's CLI is authenticated.
+# Uses only local auth-status checks (no API/rate-limit cost).
+forge_auth_ok() {
+  case "$1" in
+    github) command -v gh   >/dev/null 2>&1 && gh   auth status >/dev/null 2>&1 ;;
+    forgejo|gitea)
+      # `tea` has no `auth status`; a configured login list is the local signal.
+      command -v tea  >/dev/null 2>&1 && tea login list 2>/dev/null | grep -q '://'
+      ;;
+    gitlab) command -v glab >/dev/null 2>&1 && glab auth status >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# forge_default_branch <provider> — echo the repository default branch, or
+# fall back to "main". Provider-neutral.
+forge_default_branch() {
+  local provider="$1" b=""
+  case "$provider" in
+    github)
+      b="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null)"
+      ;;
+    forgejo|gitea)
+      # `tea repos search`/`tea` lacks a stable default-branch field across
+      # versions; infer from the remote HEAD instead.
+      b="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+      ;;
+    gitlab)
+      b="$(glab repo view --output json 2>/dev/null | grep -o '"default_branch":"[^"]*"' | head -n1 | sed 's/.*:"//;s/"//')"
+      ;;
+  esac
+  if [[ -z "$b" ]]; then
+    b="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+  fi
+  printf '%s' "${b:-main}"
+}
+
+# forge_unsupported_notice <provider> <feature> — print a uniform, honest
+# message to stderr when an advanced feature is GitHub-only. Returns 0 so the
+# caller controls the exit code.
+forge_unsupported_notice() {
+  local provider="$1" feature="$2"
+  printf '%s: %s is a GitHub-only feature; provider "%s" is not supported.\n' \
+    "${0##*/}" "$feature" "$provider" >&2
+  printf '  Reason: Forgejo/Gitea expose only the REST v1 API (no GraphQL) and\n' >&2
+  printf '  the tea CLI does not surface CI-run logs/rerun controls. Run this\n' >&2
+  printf '  feature on a GitHub remote, or do the action manually on %s.\n' "$provider" >&2
+}

--- a/.codex-plugin/ycc/shared/scripts/release-ci-monitor.sh
+++ b/.codex-plugin/ycc/shared/scripts/release-ci-monitor.sh
@@ -35,6 +35,11 @@ VERSION="1.0.0"
 # shellcheck source=lib/ci-classify.sh
 . "$(dirname "$0")/lib/ci-classify.sh"
 
+# Forge provider detection. The release CI-autofix loop depends on
+# `gh run` controls with no Forgejo/Gitea equivalent — GitHub-only.
+# shellcheck source=lib/forge.sh
+. "$(dirname "$0")/lib/forge.sh"
+
 # ---------------------------------------------------------------------------
 # Usage
 # ---------------------------------------------------------------------------
@@ -417,6 +422,15 @@ main() {
     log_jsonl "$log_file" "$ts" "$iteration" "$tag" "0" "" "success" "" "green" "$push_count" "" '"dry_run":true'
     printf 'RESULT=green\n'
     exit 0
+  fi
+
+  # Forge provider gate (GitHub-only feature).
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "the release --ci auto-fix loop"
+    printf 'RESULT=unsupported-provider\n'
+    exit 2
   fi
 
   # Workflow file must be resolvable in non-dry-run mode.

--- a/.codex-plugin/ycc/skills/code-review/SKILL.md
+++ b/.codex-plugin/ycc/skills/code-review/SKILL.md
@@ -321,6 +321,15 @@ write an artifact here — quick-review owns the artifact lifecycle.
 
 Comprehensive GitHub PR review — fetches diff, reads full files, runs validation, posts review.
 
+**GitHub-only.** PR mode is GitHub-only: it reads and posts on PRs through the
+`gh` PR/review plumbing (`gh pr view`/`gh pr diff`/`gh pr review` + the GitHub
+review-comments API), which has no `tea` equivalent. Detect the forge provider
+on `origin` first (`forge_detect_provider origin`); if it is **not** `github`,
+state that PR mode is GitHub-only and offer **Local Review Mode** instead
+(local-diff review works on any provider). Do not attempt the `gh` PR calls on a
+non-GitHub remote. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
+
 Detect whether GitHub MCP tools are available (look for `mcp__github__*`). If they are, prefer those for PR fetch/view/review operations. Otherwise fall back to the `gh` CLI examples shown below.
 
 ### Phase 1 — FETCH

--- a/.codex-plugin/ycc/skills/git-cleanup/SKILL.md
+++ b/.codex-plugin/ycc/skills/git-cleanup/SKILL.md
@@ -39,13 +39,21 @@ Parse `$ARGUMENTS`:
 1. **Verify working tree is a git repo**: `git rev-parse --git-dir`. Abort if not.
 2. **Determine default branch**: `git symbolic-ref refs/remotes/origin/HEAD` →
    fall back to `main` / `master` if unset.
-3. **Detect host CLIs and MCP tools**. See
-   `~/.codex/plugins/ycc/skills/git-cleanup/references/host-detection.md` for
-   the full decision table. Summary:
+3. **Detect host CLIs and MCP tools**. Detection follows the bundle-wide
+   contract in
+   `~/.codex/plugins/ycc/shared/references/forge-detection.md`
+   (`forge_detect_provider origin` → `github` / `forgejo` / `gitea` / `gitlab` /
+   `unknown`; `forge_cli` → `gh` / `tea` / `glab`); the git-cleanup-specific
+   operation map lives in
+   `~/.codex/plugins/ycc/skills/git-cleanup/references/host-detection.md`.
+   Summary:
    - Prefer `mcp__github__*` tools if available for GitHub operations.
-   - Else `gh auth status` for GitHub, `glab auth status` for GitLab.
-   - If `--host=auto`, parse `git remote get-url origin`. Unknown hosts skip
-     the remote-domain audits with a loud notice.
+   - Else `gh auth status` for GitHub, `tea login list` for the Forgejo/Gitea
+     family, `glab auth status` for GitLab.
+   - If `--host=auto`, parse `git remote get-url origin` via the shared lib.
+     A Forgejo/Gitea remote (matched against `tea login list`) routes PR/issue
+     cleanup through `tea` (`tea pull list/close`, `tea issues list/close`).
+     Unknown hosts skip the remote-domain audits with a loud notice.
 4. **Check working-tree state**: Capture `git status --porcelain` and
    `git stash list`. Record whether the current branch has unpushed commits.
 5. **Initialize progress tracking** with the task tracker (one entry per phase).

--- a/.codex-plugin/ycc/skills/git-cleanup/references/host-detection.md
+++ b/.codex-plugin/ycc/skills/git-cleanup/references/host-detection.md
@@ -1,5 +1,14 @@
 # Host Detection and Client Selection
 
+> **Canonical source of truth:** the bundle-wide forge-detection contract lives at
+> [`../../_shared/references/forge-detection.md`](../../_shared/references/forge-detection.md)
+> (provider values `github` / `forgejo` / `gitea` / `gitlab` / `unknown`; CLIs
+> `gh` / `tea` / `glab`; the `forge_detect_provider`, `forge_cli`, `forge_auth_ok`
+> detection law implemented in `_shared/scripts/lib/forge.sh`). Prefer that document
+> and library for detection. This file is the **git-cleanup-specific supplement**:
+> it maps the resolved provider to the concrete read/write cleanup operations this
+> skill performs. When the two disagree on detection, the canonical reference wins.
+
 Reference for Phase 0 of `ycc/skills/git-cleanup/SKILL.md`. Given a repository,
 determine (1) which remote host the audit should query and (2) which client
 library / CLI / MCP server to use for each operation.
@@ -17,6 +26,12 @@ For GitLab repositories, pick the first available:
 1. **`glab` CLI** — authenticated (`glab auth status` returns 0).
 2. **Local-only mode** — skip `--prs` and `--issues` with a loud notice.
 
+For Forgejo / Gitea repositories (provider `forgejo` or `gitea` — same tooling
+family, both driven by `tea`), pick the first available:
+
+1. **`tea` CLI** — a configured login (`tea login list` shows a `://` entry).
+2. **Local-only mode** — skip `--prs` and `--issues` with a loud notice.
+
 Never mix clients within a single audit. Decide once in Phase 0 and log the
 decision in `.git-cleanup/report.md` under "Host-API notes".
 
@@ -24,13 +39,14 @@ decision in `.git-cleanup/report.md` under "Host-API notes".
 
 When `--host=auto` (default), parse `git remote get-url origin`:
 
-| Pattern match                                 | Inferred host |
-| --------------------------------------------- | ------------- |
-| `github.com:`, `github.com/`, `*.github.com/` | GitHub        |
-| `gitlab.com:`, `gitlab.com/`, `/api/v4/`      | GitLab        |
-| Self-hosted GitHub Enterprise (`GHE_HOST`)    | GitHub        |
-| Self-hosted GitLab                            | GitLab        |
-| Anything else                                 | Unknown       |
+| Pattern match                                 | Inferred host   |
+| --------------------------------------------- | --------------- |
+| `github.com:`, `github.com/`, `*.github.com/` | GitHub          |
+| `gitlab.com:`, `gitlab.com/`, `/api/v4/`      | GitLab          |
+| Self-hosted GitHub Enterprise (`GHE_HOST`)    | GitHub          |
+| Self-hosted GitLab                            | GitLab          |
+| Self-hosted Forgejo / Gitea                   | Forgejo / Gitea |
+| Anything else                                 | Unknown         |
 
 Accept SSH, HTTPS, and `git://` URLs. Strip any `.git` suffix before matching.
 
@@ -40,6 +56,12 @@ as GitHub and route `gh` calls to that host.
 
 **Self-hosted GitLab:** `glab` reads its host list from `~/.config/glab-cli/`.
 If the `origin` host matches one of its configured hosts, treat as GitLab.
+
+**Self-hosted Forgejo / Gitea:** `tea` reads its login list from
+`~/.config/tea/`. If the `origin` host matches a configured `tea login list`
+entry, treat as the Gitea family and route `tea` calls to that host. The two are
+the same tooling family (`forge_cli` maps both to `tea`); the canonical reference
+distinguishes `forgejo` from `gitea` only for messaging.
 
 ## Detecting MCP availability
 
@@ -101,6 +123,25 @@ GitLab's "Merge Request" maps to GitHub's "Pull Request" one-for-one for this
 skill's purposes. Both concepts share the same R-rules (see
 `active-code-rules.md`).
 
+### Forgejo / Gitea (`tea` fallbacks)
+
+```bash
+# Open PRs ("pulls") for the current repo
+tea pull list --state open
+
+# Merged/closed PRs (filter the list output for merged state)
+tea pull list --state closed
+
+# Open issues
+tea issues list --state open
+```
+
+`tea` operates on the repo bound to the current directory's `origin` remote (it
+reads `.git/config`); pass `--repo owner/name` only when overriding. Forgejo's
+"Pull Request" maps to GitHub's one-for-one and shares the same R-rules (see
+`active-code-rules.md`). `tea` paginates with `--limit` (alias for page size);
+bound large lists the same way `--limit` bounds `gh` output.
+
 ## Write operations (only with `--apply` + user approval)
 
 ### GitHub
@@ -119,6 +160,15 @@ skill's purposes. Both concepts share the same R-rules (see
 | Close an MR    | `glab mr close <iid>`                 |
 | Close an issue | `glab issue close <iid>`              |
 | Add a label    | `glab issue update <iid> --label ...` |
+
+### Forgejo / Gitea
+
+| Action                 | `tea` command                                     |
+| ---------------------- | ------------------------------------------------- |
+| Close a PR             | `tea pull close <n>`                              |
+| Close an issue         | `tea issues close <n>`                            |
+| Add a label            | `tea issues edit <n> --add-labels ...`            |
+| Delete a remote branch | (n/a — use git) `git push origin --delete <name>` |
 
 ## Rate-limit awareness
 

--- a/.codex-plugin/ycc/skills/git-workflow/SKILL.md
+++ b/.codex-plugin/ycc/skills/git-workflow/SKILL.md
@@ -654,6 +654,15 @@ This provides:
 - Documentation changes
 - Suggested PR title and scope
 
+**Forge provider detection**: `create-pr.sh` runs forge detection on `origin`
+first and routes PR creation through the matching CLI — `gh` for `github`,
+`tea` for `forgejo`/`gitea` (`gh pr create` ↔ `tea pull create`). The MCP-first
+path above applies only to `github`; on a `forgejo`/`gitea` remote the script
+drives `tea` directly. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the detection algorithm and operation-equivalence map. Log the resolved
+provider + CLI so the user sees which forge the PR targeted.
+
 ### Step 25: Generate PR Title
 
 PR titles **MUST** follow the conventional commit format: `<type>(<scope>): <description>`
@@ -905,6 +914,15 @@ If repository has `.github/PULL_REQUEST_TEMPLATE.md`:
 
 **Trigger:** This phase runs ONLY when `--ci ∈ flags`. Skip silently otherwise. Phase 6 does not require Phase 5 to have run — bare `--ci` and `--push --ci` both reach this phase by design.
 
+**GitHub-only:** The CI auto-fix loop is GitHub-only — it depends on `gh run`
+controls (`gh run view --log-failed`, `gh run rerun`). On a non-GitHub remote
+`ci-monitor.sh` returns `RESULT=unsupported-provider` (exit 2). Treat this like
+`pr-not-found`/`refused-default-branch`: report it directly and **skip the loop
+without erroring**. State that the loop is GitHub-only and why, then end Phase 6
+cleanly. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+and [`../_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md).
+
 ### Step 32: Discover PR for the current branch
 
 If a `PR_NUMBER` was captured in Phase 5 (either newly created in Steps 23-30 or detected as existing in Step 22a), use it directly and skip ahead to Step 33.
@@ -975,6 +993,7 @@ Branch on stdout `RESULT=...` per the **Loop Protocol** section of `ci-monitorin
 - `rerun-pending` → Flake-suspected; the script already triggered `gh run rerun --failed`. Do NOT apply any fix. Sleep 30 seconds (`sleep 30`), then goto Step 36.
 - `bail-recurrence` / `bail-nonfixable` / `bail-pushes` / `bail-timeout` → Render a diagnosis block citing the audit log path, the `RESULT=` value, the `REASON=` line if present, and the cap that fired. End Phase 6 (do NOT push further).
 - `pr-not-found` / `refused-default-branch` → Surface the error directly; do not retry.
+- `unsupported-provider` → Remote is not GitHub; the CI auto-fix loop is GitHub-only. Report that the loop is GitHub-only and skip it cleanly; do not retry and do not treat as an error.
 
 ### Step 37: Final report
 

--- a/.codex-plugin/ycc/skills/git-workflow/scripts/create-pr.sh
+++ b/.codex-plugin/ycc/skills/git-workflow/scripts/create-pr.sh
@@ -44,24 +44,54 @@ if ! git rev-parse --git-dir > /dev/null 2>&1; then
     exit 1
 fi
 
-# Check if gh CLI is available
-if ! command -v gh &> /dev/null; then
-    echo -e "${RED}Error: GitHub CLI (gh) is not installed${NC}" >&2
+# Detect the forge provider and select the matching CLI (gh / tea / glab).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.codex/plugins/ycc/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
+PROVIDER="$(forge_detect_provider origin)"
+FORGE_CLI="$(forge_cli "$PROVIDER")"
+
+case "$PROVIDER" in
+    github|forgejo|gitea) ;;  # supported for PR creation
+    gitlab)
+        echo -e "${RED}Error: GitLab PR creation is not yet supported by this script${NC}" >&2
+        echo "Create the merge request with: glab mr create" >&2
+        exit 1
+        ;;
+    *)
+        echo -e "${RED}Error: Could not determine the forge provider for 'origin'${NC}" >&2
+        echo "origin = $(forge_remote_url origin)" >&2
+        echo "Supported: GitHub (gh), Forgejo/Gitea (tea)." >&2
+        exit 1
+        ;;
+esac
+
+# Check the matching CLI is installed
+if ! command -v "$FORGE_CLI" &> /dev/null; then
+    echo -e "${RED}Error: ${FORGE_CLI} CLI (for ${PROVIDER}) is not installed${NC}" >&2
     echo "" >&2
-    echo "Install with:" >&2
-    echo "  macOS:   brew install gh" >&2
-    echo "  Linux:   See https://github.com/cli/cli/blob/trunk/docs/install_linux.md" >&2
+    case "$PROVIDER" in
+        github) echo "Install gh:  https://github.com/cli/cli#installation" >&2 ;;
+        *)      echo "Install tea: https://gitea.com/gitea/tea#installation" >&2 ;;
+    esac
     exit 1
 fi
 
-# Check if authenticated with gh
-if ! gh auth status &> /dev/null; then
-    echo -e "${RED}Error: Not authenticated with GitHub CLI${NC}" >&2
+# Check authentication for the detected provider
+if ! forge_auth_ok "$PROVIDER"; then
+    echo -e "${RED}Error: Not authenticated with ${FORGE_CLI} (${PROVIDER})${NC}" >&2
     echo "" >&2
-    echo "Authenticate with:" >&2
-    echo "  gh auth login" >&2
+    case "$PROVIDER" in
+        github) echo "Authenticate with: gh auth login" >&2 ;;
+        *)      echo "Authenticate with: tea login add" >&2 ;;
+    esac
     exit 1
 fi
+
+echo -e "${BLUE}Forge provider:${NC} ${PROVIDER} (using ${FORGE_CLI})" >&2
 
 # Get current branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -71,8 +101,8 @@ if [ "$CURRENT_BRANCH" = "HEAD" ]; then
     exit 1
 fi
 
-# Get default branch (usually main or master)
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+# Get default branch (usually main or master) — provider-neutral
+DEFAULT_BRANCH=$(forge_default_branch "$PROVIDER")
 
 # Check if branch exists on remote
 if ! git ls-remote --exit-code --heads origin "$CURRENT_BRANCH" &> /dev/null; then
@@ -219,8 +249,13 @@ echo ""
 if [ "$MODE" = "analyze" ]; then
     echo -e "${BLUE}=== Analysis Complete ===${NC}\n"
     echo "To create PR:"
-    echo "  Regular: gh pr create --web"
-    echo "  Draft:   gh pr create --draft --web"
+    if [ "$PROVIDER" = "github" ]; then
+        echo "  Regular: gh pr create --web"
+        echo "  Draft:   gh pr create --draft --web"
+    else
+        echo "  Regular: tea pull create --head $CURRENT_BRANCH --base $DEFAULT_BRANCH"
+        echo "  (Forgejo/Gitea: 'tea' has no --draft or --web; open the PR in the web UI to mark it draft)"
+    fi
     exit 0
 fi
 
@@ -228,13 +263,22 @@ fi
 echo -e "${BLUE}=== Creating Pull Request ===${NC}\n"
 
 # Check if PR already exists
-EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+if [ "$PROVIDER" = "github" ]; then
+    EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+else
+    # tea pull list — match the head branch column; best-effort across tea versions
+    EXISTING_PR=$(tea pull list --output simple 2>/dev/null | grep -F "$CURRENT_BRANCH" | grep -oE '^#?[0-9]+' | head -n1 | tr -d '#' || echo "")
+fi
 
 if [ -n "$EXISTING_PR" ]; then
     echo -e "${YELLOW}⚠ PR already exists for this branch: #$EXISTING_PR${NC}"
     echo ""
-    echo "View PR: gh pr view $EXISTING_PR"
-    echo "Edit PR: gh pr edit $EXISTING_PR"
+    if [ "$PROVIDER" = "github" ]; then
+        echo "View PR: gh pr view $EXISTING_PR"
+        echo "Edit PR: gh pr edit $EXISTING_PR"
+    else
+        echo "View PR: tea pull $EXISTING_PR"
+    fi
     exit 1
 fi
 
@@ -309,32 +353,58 @@ Closes #
 echo "Creating PR..."
 echo ""
 
-if [ "$DRAFT" = true ]; then
-    set +e
-    gh pr create \
-        --title "$PR_TITLE" \
-        --body "$PR_DESCRIPTION" \
-        --draft \
-        --web
-    rc=$?
-    set -e
+if [ "$PROVIDER" = "github" ]; then
+    if [ "$DRAFT" = true ]; then
+        set +e
+        gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_DESCRIPTION" \
+            --draft \
+            --web
+        rc=$?
+        set -e
 
-    if [ $rc -eq 0 ]; then
-        echo ""
-        echo -e "${GREEN}✓ Draft PR created successfully${NC}"
-        echo ""
-        echo "Mark ready when complete: gh pr ready"
+        if [ $rc -eq 0 ]; then
+            echo ""
+            echo -e "${GREEN}✓ Draft PR created successfully${NC}"
+            echo ""
+            echo "Mark ready when complete: gh pr ready"
+        else
+            echo ""
+            echo -e "${RED}✗ Failed to create PR${NC}"
+            exit 1
+        fi
     else
-        echo ""
-        echo -e "${RED}✗ Failed to create PR${NC}"
-        exit 1
+        set +e
+        gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_DESCRIPTION" \
+            --web
+        rc=$?
+        set -e
+
+        if [ $rc -eq 0 ]; then
+            echo ""
+            echo -e "${GREEN}✓ PR created successfully${NC}"
+        else
+            echo ""
+            echo -e "${RED}✗ Failed to create PR${NC}"
+            exit 1
+        fi
     fi
 else
+    # Forgejo / Gitea via tea. No --draft or --web support; create directly.
+    if [ "$DRAFT" = true ]; then
+        echo -e "${YELLOW}⚠ 'tea' does not support draft PRs; creating a normal PR.${NC}" >&2
+        echo "  Mark it draft in the ${PROVIDER} web UI if needed." >&2
+        echo ""
+    fi
     set +e
-    gh pr create \
+    tea pull create \
         --title "$PR_TITLE" \
-        --body "$PR_DESCRIPTION" \
-        --web
+        --description "$PR_DESCRIPTION" \
+        --head "$CURRENT_BRANCH" \
+        --base "$DEFAULT_BRANCH"
     rc=$?
     set -e
 

--- a/.codex-plugin/ycc/skills/pr-autofix/SKILL.md
+++ b/.codex-plugin/ycc/skills/pr-autofix/SKILL.md
@@ -18,6 +18,16 @@ Vendor-neutral counterpart to `coderabbit:autofix`. Pulls **every** comment surf
 **Golden rule**: Never mutate a comment body. Reply with the result, then resolve. The audit trail lives in the PR threads, not in this skill's report file.
 
 > Sister skills: `$review-fix` consumes `$code-review` artifacts (review-finding ID + Status fields). `$pr-autofix` (this) consumes GitHub PR comments directly. The two cover different inputs but share the per-finding agent dispatch model and the CI auto-fix loop.
+>
+> **GitHub-only.** This skill is GitHub-only. Forgejo/Gitea expose only the REST
+> v1 API — no GraphQL `resolveReviewThread`, no review-thread resolution, no
+> per-comment harvesting — and the CI loop depends on `gh run` controls. There
+> is no `tea` equivalent for any of these, so the workflow cannot degrade to a
+> partial mode here. Phase 0 detects the provider; on a non-`github` remote it
+> tells the user the skill is GitHub-only and **why**, then stops gracefully.
+> See [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+> (capability matrix: "Review-thread resolution", "Per-comment PR autofix
+> harvesting", "CI-autofix loop").
 
 ---
 
@@ -74,10 +84,21 @@ gh pr view "$PR_NUMBER" --json number,headRefName,baseRefName,headRepositoryOwne
 
 Record `HEAD_BRANCH`, `BASE_BRANCH`, `STATE`.
 
+### Provider detection
+
+Before the GitHub checks below, detect the forge provider on `origin` per
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+(`forge_detect_provider origin`). If the provider is **not** `github`, stop
+gracefully: "`$pr-autofix` is GitHub-only. Provider `<provider>` lacks the
+GraphQL review-thread resolution and per-comment harvesting this skill requires
+(Forgejo/Gitea expose only the REST v1 API). Resolve threads in the `<provider>`
+UI, or use local review tooling." Do not proceed to FETCH.
+
 ### Preflight refusals
 
 | Check                              | Action on failure                                                                                                  |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Provider is `github`               | Stop: GitHub-only (see Provider detection above).                                                                  |
 | `gh auth status` succeeds          | Stop: "Run `gh auth login` first."                                                                                 |
 | `STATE == "OPEN"`                  | Stop: "PR #<N> is <state>; nothing to autofix."                                                                    |
 | `HEAD_BRANCH != $(default-branch)` | Stop: "Refusing: PR head equals the default branch." (Same constraint as `ci-monitor.sh` — never push to default.) |
@@ -359,6 +380,8 @@ Track closure results in the status map: `closed_ok`, `closed_failed`, `reply_on
 **Trigger**: `--ci` was passed AND at least one fixer returned `Fixed` AND the push in Phase 5 succeeded. Skip silently otherwise.
 
 This phase is a thin wrapper over the same loop used by `$prp-pr` Phase 7 and `$git-workflow` Phase 6. **The policy lives in `~/.codex/plugins/ycc/shared/references/ci-monitoring.md` — do not restate it here.**
+
+The `--ci` loop is GitHub-only (it depends on `gh run` controls); since this entire skill is already gated to `github` in Phase 0, the loop never reaches a non-GitHub remote. If `ci-monitor.sh` ever returns `RESULT=unsupported-provider`, treat it like the other non-loop terminal results below: surface it and exit.
 
 ### Step 1 — Authorization prompt (skip if `--ci-yes`)
 

--- a/.codex-plugin/ycc/skills/pr-autofix/scripts/fetch-pr-comments.sh
+++ b/.codex-plugin/ycc/skills/pr-autofix/scripts/fetch-pr-comments.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # fetch-pr-comments.sh — Fetch all actionable PR comments via GitHub GraphQL
 #
+# GitHub-only. Forgejo/Gitea are unsupported: they expose no GraphQL API, so
+# review-thread harvesting cannot be replicated. On a non-GitHub remote this
+# script emits a uniform unsupported notice and exits 2.
+#
 # Purpose:
 #   Single-source fetcher used by pr-autofix. Pulls every actionable
 #   comment surface on a PR — review threads (file/line anchored) and
@@ -36,12 +40,21 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.codex/plugins/ycc/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
   fetch-pr-comments.sh --pr <number> --out <file> [--owner <owner>] [--repo <repo>]
   fetch-pr-comments.sh --help
   fetch-pr-comments.sh --version
+
+GitHub-only. Forgejo/Gitea are unsupported (no GraphQL API); on a non-GitHub
+remote this script prints an unsupported notice and exits 2.
 
 Options:
   --pr <number>     PR number to fetch comments for (required)
@@ -133,6 +146,18 @@ for dep in gh jq; do
     exit 1
   fi
 done
+
+# ---------------------------------------------------------------------------
+# Forge provider gate (GitHub-only feature)
+# ---------------------------------------------------------------------------
+# Review-thread harvesting uses the GitHub GraphQL API. Forgejo/Gitea have no
+# GraphQL API, so detect the provider before any gh call and degrade gracefully.
+
+PROVIDER="$(forge_detect_provider origin)"
+if [[ "$PROVIDER" != "github" ]]; then
+  forge_unsupported_notice "$PROVIDER" "PR review-comment harvesting"
+  exit 2
+fi
 
 if ! gh auth status >/dev/null 2>&1; then
   printf 'fetch-pr-comments.sh: gh not authenticated. Run `gh auth login`.\n' >&2

--- a/.codex-plugin/ycc/skills/pr-autofix/scripts/post-summary.sh
+++ b/.codex-plugin/ycc/skills/pr-autofix/scripts/post-summary.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # post-summary.sh — Post a single consolidated summary comment on a PR
 #
+# GitHub-only. Forgejo/Gitea are unsupported: this script is part of the
+# GraphQL-driven pr-autofix flow and posts via `gh`. On a non-GitHub remote it
+# emits a uniform unsupported notice and exits 2 (the --dry-run render still
+# works on any provider).
+#
 # Purpose:
 #   At the end of a pr-autofix run, render and post one summary comment to
 #   the PR conversation. Built only from local counters — never echoes raw
@@ -34,12 +39,22 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.codex/plugins/ycc/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
   post-summary.sh --pr <number> --fixed <N> --failed <N> --skipped <N> --deferred <N> \
                   --commit-sha <sha> --branch <name> \
                   [--ci-result <value>] [--ci-iterations <N>] [--ci-pushes <N>] [--dry-run]
+
+GitHub-only. Forgejo/Gitea are unsupported (part of the GraphQL-driven autofix
+flow); on a non-GitHub remote this script prints an unsupported notice and exits
+2. The --dry-run render works on any provider.
 
 Exit codes:
   0  success (or skipped as no-op)
@@ -182,6 +197,19 @@ ${body_footer}"
 if [[ "$DRY_RUN" == "true" ]]; then
   printf '%s\n' "$BODY"
   exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Forge provider gate (GitHub-only feature)
+# ---------------------------------------------------------------------------
+# This script posts via `gh` as part of the GraphQL-driven pr-autofix flow.
+# Detect the provider before the gh-auth check so a non-GitHub remote gets the
+# honest "GitHub-only" message instead of a confusing auth error.
+
+PROVIDER="$(forge_detect_provider origin)"
+if [[ "$PROVIDER" != "github" ]]; then
+  forge_unsupported_notice "$PROVIDER" "PR summary posting"
+  exit 2
 fi
 
 if ! command -v gh >/dev/null 2>&1; then

--- a/.codex-plugin/ycc/skills/pr-autofix/scripts/resolve-thread.sh
+++ b/.codex-plugin/ycc/skills/pr-autofix/scripts/resolve-thread.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # resolve-thread.sh — Mutate PR review threads and conversation comments
 #
+# GitHub-only. Forgejo/Gitea are unsupported: review-thread resolution and emoji
+# reactions require the GitHub GraphQL API (resolveReviewThread, addReaction),
+# which has no Forgejo/Gitea equivalent. On a non-GitHub remote this script emits
+# a uniform unsupported notice and exits 2.
+#
 # Purpose:
 #   Wraps the four mutations pr-autofix needs to close out comments:
 #     resolve      — resolveReviewThread(threadId) via GraphQL
@@ -35,6 +40,12 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.codex/plugins/ycc/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -45,6 +56,10 @@ Usage:
 
   resolve-thread.sh --help
   resolve-thread.sh --version
+
+GitHub-only. Forgejo/Gitea are unsupported (no GraphQL API for review-thread
+resolution or reactions); on a non-GitHub remote this script prints an
+unsupported notice and exits 2.
 
 Reaction values:
   THUMBS_UP THUMBS_DOWN LAUGH HOORAY CONFUSED HEART ROCKET EYES
@@ -177,6 +192,7 @@ main() {
     exit 1
   fi
 
+  # Handle help/version before any forge or auth checks so they work anywhere.
   case "$1" in
     --help|-h)
       usage
@@ -186,6 +202,28 @@ main() {
       printf 'resolve-thread.sh %s\n' "$VERSION"
       exit 0
       ;;
+  esac
+
+  # -------------------------------------------------------------------------
+  # Forge provider gate (GitHub-only feature)
+  # -------------------------------------------------------------------------
+  # resolveReviewThread/addReaction are GraphQL-only. Forgejo/Gitea have no
+  # GraphQL API, so detect the provider and short-circuit before the gh-auth
+  # check so a non-GitHub remote gets the honest "GitHub-only" message.
+
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "PR review-thread resolution"
+    exit 2
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    printf 'resolve-thread.sh: gh not authenticated. Run `gh auth login`.\n' >&2
+    exit 2
+  fi
+
+  case "$1" in
     resolve)
       shift
       cmd_resolve "$@"
@@ -209,10 +247,5 @@ main() {
       ;;
   esac
 }
-
-if ! gh auth status >/dev/null 2>&1; then
-  printf 'resolve-thread.sh: gh not authenticated. Run `gh auth login`.\n' >&2
-  exit 2
-fi
 
 main "$@"

--- a/.codex-plugin/ycc/skills/prp-pr/SKILL.md
+++ b/.codex-plugin/ycc/skills/prp-pr/SKILL.md
@@ -165,12 +165,27 @@ Use this default format:
 
 ### Create the PR
 
+PR creation is provider-aware. Detect the forge provider on `origin` first
+(`forge_detect_provider origin`) and route through the matching CLI: `gh pr
+create` for `github`, `tea pull create --title --description [--head]` for
+`forgejo`/`gitea`. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the operation-equivalence map. Log the resolved provider + CLI so the user
+sees which forge the PR targeted.
+
 ```bash
+# github
 gh pr create \
   --title "<PR title>" \
   --base <base-branch> \
   --body "<PR body>"
   # Add --draft if the --draft flag was parsed from $ARGUMENTS
+
+# forgejo / gitea
+tea pull create \
+  --title "<PR title>" \
+  --base <base-branch> \
+  --description "<PR body>"
 ```
 
 ---
@@ -225,6 +240,13 @@ were printed (otherwise `n/a`).
 **Trigger:** Runs ONLY when `--ci` was passed AND a PR is in scope (created in
 Phase 4, or an existing PR confirmed for monitoring per the Phase 1 modification
 above). Skip silently otherwise.
+
+**GitHub-only:** The CI auto-fix loop is GitHub-only (it depends on `gh run`
+controls). On a non-GitHub remote `ci-monitor.sh` returns
+`RESULT=unsupported-provider` (exit 2). Treat this like
+`pr-not-found`/`refused-default-branch`: report that the loop is GitHub-only and
+skip it cleanly — do not retry, do not error. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 
 **Step 1 — Verify PR is monitorable:** Confirm a PR number is in scope. If not,
 hard-stop: `--ci was passed but no PR is in scope to monitor.`
@@ -286,6 +308,7 @@ Branch on stdout `RESULT=...` per the Loop Protocol in `ci-monitoring.md`:
   goto Step 5 (do NOT apply any fix).
 - `bail-*` → Go to Step 6 (diagnosis). Do not push further.
 - `pr-not-found` / `refused-default-branch` → Surface the error; do not retry.
+- `unsupported-provider` → Remote is not GitHub; the CI auto-fix loop is GitHub-only. Report that the loop is GitHub-only and skip it cleanly; do not retry or treat as an error.
 
 **Step 6 — Final report:**
 

--- a/.codex-plugin/ycc/skills/releaser/SKILL.md
+++ b/.codex-plugin/ycc/skills/releaser/SKILL.md
@@ -269,6 +269,17 @@ If `--ci-config=generate` ran, append:
 # build the matrix and attach artifacts to the GitHub release.
 ```
 
+**Forge provider detection**: release creation is provider-aware.
+`publish-release.sh` detects the forge provider on `origin` first and routes
+through the matching CLI — `gh release create` for `github`, `tea release
+create --tag <tag> [--note-file]` for `forgejo`/`gitea` (per the
+operation-equivalence map). The `gh release create`/`gh release upload` commands
+emitted in the Phase 8 block above are the `github` path; on a `forgejo`/`gitea`
+remote the helper drives `tea release create` instead. Log the resolved provider
+
+- CLI. See
+  [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
+
 When the user passed `--publish[=create|edit|auto]`, after they review the rendered
 notes, run:
 
@@ -306,6 +317,15 @@ The contract (exit codes, `RESULT=` signaling, JSONL audit log, failure classifi
 signature dedup, default-branch refusal) mirrors `ci-monitor.sh` verbatim. See
 [`_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md),
 section "Release mode", for the single source of truth.
+
+**GitHub-only:** the release-CI auto-fix loop is GitHub-only — it depends on
+`gh run list`, `gh workflow run`, and `gh release` controls that have no `tea`
+equivalent. On a non-GitHub remote `release-ci-monitor.sh` returns
+`RESULT=unsupported-provider` (exit 2). Treat it like `not-found`: report that
+the loop is GitHub-only, render an 8.5.4-style diagnosis, and exit Phase 8.5
+cleanly without retrying. (Release _creation_ in Phase 8 remains provider-aware
+via `tea release create`; only this post-publish monitoring loop is gated.) See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 
 ### 8.5.0 Detect re-cut strategy
 
@@ -381,16 +401,17 @@ one human approval the bounded, destructive-capable loop depends on. Therefore:
 
 3. Branch on the exit code (identical contract to `ci-monitor.sh`):
 
-   | Exit | `RESULT=`         | Action                                                |
-   | ---- | ----------------- | ----------------------------------------------------- |
-   | 0    | `green`           | Success. Exit Phase 8.5, continue to Phase 9.         |
-   | 20   | `handoff`         | Step **8.5.3** (fix and re-cut), then loop to step 2. |
-   | 21   | `rerun-pending`   | `sleep 30`, then loop to step 2 (no fix applied).     |
-   | 10   | `bail-recurrence` | Step **8.5.4** (diagnosis), exit Phase 8.5.           |
-   | 11   | `bail-nonfixable` | Step **8.5.4**, exit Phase 8.5.                       |
-   | 12   | `bail-pushes`     | Step **8.5.4**, exit Phase 8.5.                       |
-   | 13   | `bail-timeout`    | Step **8.5.4**, exit Phase 8.5.                       |
-   | 2    | `not-found`       | Step **8.5.4**, exit Phase 8.5.                       |
+   | Exit | `RESULT=`              | Action                                                                     |
+   | ---- | ---------------------- | -------------------------------------------------------------------------- |
+   | 0    | `green`                | Success. Exit Phase 8.5, continue to Phase 9.                              |
+   | 20   | `handoff`              | Step **8.5.3** (fix and re-cut), then loop to step 2.                      |
+   | 21   | `rerun-pending`        | `sleep 30`, then loop to step 2 (no fix applied).                          |
+   | 10   | `bail-recurrence`      | Step **8.5.4** (diagnosis), exit Phase 8.5.                                |
+   | 11   | `bail-nonfixable`      | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 12   | `bail-pushes`          | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 13   | `bail-timeout`         | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 2    | `not-found`            | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 2    | `unsupported-provider` | Remote is not GitHub; loop is GitHub-only. Step **8.5.4**, exit Phase 8.5. |
 
 ### 8.5.3 Fix and re-cut on handoff
 

--- a/.codex-plugin/ycc/skills/releaser/scripts/publish-release.sh
+++ b/.codex-plugin/ycc/skills/releaser/scripts/publish-release.sh
@@ -1,14 +1,29 @@
 #!/usr/bin/env bash
-# publish-release.sh — Publish or update a GitHub release for a given tag.
+# publish-release.sh — Publish or update a release for a given tag.
+#
+# Provider-aware: routes through the CLI that matches the detected forge.
+#   github          → gh release create/edit  (behavior unchanged)
+#   forgejo / gitea → tea release create/edit
+#   gitlab / unknown→ release creation is not supported here; exits 1 with the
+#                     manual command to run.
 #
 # Usage:
 #   publish-release.sh [--mode=create|edit|auto] [--confirm] <tag> <notes-file>
 #
-# By default (no --confirm) prints the resolved gh command and exits 0.
+# By default (no --confirm) prints the resolved command and exits 0.
 # With --confirm the resolved command is executed.
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# --- forge detection -------------------------------------------------------
+# Detect the forge provider and select the matching CLI (gh / tea). Prefer the
+# plugin-root install path; fall back to the source-tree relative path.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.codex/plugins/ycc/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
 
 # --- diagnostic helpers ---
 fail()  { echo "${SCRIPT_NAME}: FAIL: $*" >&2; }
@@ -19,8 +34,9 @@ usage() {
     cat <<EOF
 Usage: ${SCRIPT_NAME} [options] <tag> <notes-file>
 
-Publish (create or update) a GitHub release for <tag> using <notes-file> as
-the release body.
+Publish (create or update) a release for <tag> using <notes-file> as the
+release body. The forge provider is auto-detected from origin (GitHub via gh,
+Forgejo/Gitea via tea).
 
 Arguments:
   <tag>          Git tag (e.g. v1.4.0 or 1.4.0 — normalised to v-prefix if semver)
@@ -30,16 +46,18 @@ Options:
   --mode=create  Create a new release (fails if release already exists)
   --mode=edit    Edit an existing release (fails if release does not exist)
   --mode=auto    Auto-detect: create if missing, edit if present (default)
-  --confirm      Actually run the resolved gh command (default: print only)
+  --confirm      Actually run the resolved command (default: print only)
   -h, --help     Show this help
 
 Print-only mode (no --confirm):
-  Prints the exact gh command that would be run, then exits 0. gh is NOT called.
+  Prints the exact command that would be run, then exits 0. The forge CLI is
+  NOT called.
 
 Authentication:
-  In --mode=auto, gh auth status is checked. If unauthenticated, the script
-  exits 1 with a warning. In --mode=create or --mode=edit, gh itself will
-  surface authentication errors when --confirm is used.
+  In --mode=auto, the detected forge CLI's auth state is checked. If
+  unauthenticated, the script exits 1 with a warning. In --mode=create or
+  --mode=edit, the CLI itself surfaces authentication errors when --confirm
+  is used.
 
 Examples:
   # Preview what would be run for tag v1.4.0:
@@ -144,22 +162,67 @@ if ! git show-ref --verify --quiet "refs/tags/${TAG}"; then
     exit 1
 fi
 
-# --- gh authentication check (auto mode only) ---
+# --- provider routing -------------------------------------------------------
+# Resolve the forge provider for origin and reject providers this script cannot
+# create releases for. github keeps its exact prior semantics; forgejo/gitea
+# route through tea; gitlab/unknown exit with the manual command.
+PROVIDER="$(forge_detect_provider origin)"
+FORGE_CLI="$(forge_cli "${PROVIDER}")"
+
+case "${PROVIDER}" in
+    github|forgejo|gitea)
+        ;;  # supported for release create/edit
+    gitlab)
+        fail "GitLab release creation is not supported by this script"
+        hint "create the release manually: glab release create ${TAG} --notes-file ${NOTES_FILE}"
+        exit 1
+        ;;
+    *)
+        fail "could not determine the forge provider for 'origin'"
+        hint "origin = $(forge_remote_url origin)"
+        hint "supported: GitHub (gh), Forgejo/Gitea (tea)"
+        exit 1
+        ;;
+esac
+
+# --- forge CLI availability check ---
+if ! command -v "${FORGE_CLI}" >/dev/null 2>&1; then
+    fail "${FORGE_CLI} CLI (for ${PROVIDER}) is not installed"
+    case "${PROVIDER}" in
+        github) hint "install gh:  https://github.com/cli/cli#installation" ;;
+        *)      hint "install tea: https://gitea.com/gitea/tea#installation" ;;
+    esac
+    exit 1
+fi
+
+# --- authentication check (auto mode only) ---
 if [[ "${MODE}" == "auto" ]]; then
-    if ! gh auth status >/dev/null 2>&1; then
-        warn "gh not authenticated; cannot determine release state — re-run with explicit --mode=create or --mode=edit"
+    if ! forge_auth_ok "${PROVIDER}"; then
+        warn "${FORGE_CLI} not authenticated (${PROVIDER}); cannot determine release state — re-run with explicit --mode=create or --mode=edit"
+        case "${PROVIDER}" in
+            github) hint "authenticate with: gh auth login" ;;
+            *)      hint "authenticate with: tea login add" ;;
+        esac
         exit 1
     fi
 fi
 
 # --- release existence detection ---
-# Always probe GitHub (including --mode=create) so create-mode can detect an
-# existing release and suggest --mode=edit instead of failing later on gh.
+# Always probe the forge (including --mode=create) so create-mode can detect an
+# existing release and suggest --mode=edit instead of failing later in the CLI.
 RELEASE_JSON=""
 RELEASE_EXISTS=0
-RELEASE_JSON="$(gh release view "${TAG}" --json url,tagName,body 2>/dev/null || true)"
-if [[ -n "${RELEASE_JSON}" ]]; then
-    RELEASE_EXISTS=1
+if [[ "${PROVIDER}" == "github" ]]; then
+    RELEASE_JSON="$(gh release view "${TAG}" --json url,tagName,body 2>/dev/null || true)"
+    if [[ -n "${RELEASE_JSON}" ]]; then
+        RELEASE_EXISTS=1
+    fi
+else
+    # tea has no per-tag "view"; list releases as JSON and match the tag_name.
+    if tea release list --output json 2>/dev/null \
+        | grep -qE "\"tag_name\"[[:space:]]*:[[:space:]]*\"${TAG}\""; then
+        RELEASE_EXISTS=1
+    fi
 fi
 
 # --- mode conflict checks ---
@@ -186,10 +249,22 @@ case "${MODE}" in
 esac
 
 # --- build resolved command ---
-if [[ "${MODE}" == "create" ]]; then
-    RESOLVED_CMD="gh release create $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}") --title $(printf '%q' "${TAG}") --verify-tag"
+# github keeps its prior gh commands verbatim. tea (forgejo/gitea) uses
+# `tea release create --note-file` for create, but `tea release edit` has no
+# --note-file in 0.14.x, so edit passes the notes inline via --note.
+if [[ "${PROVIDER}" == "github" ]]; then
+    if [[ "${MODE}" == "create" ]]; then
+        RESOLVED_CMD="gh release create $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}") --title $(printf '%q' "${TAG}") --verify-tag"
+    else
+        RESOLVED_CMD="gh release edit $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}")"
+    fi
 else
-    RESOLVED_CMD="gh release edit $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}")"
+    if [[ "${MODE}" == "create" ]]; then
+        RESOLVED_CMD="tea release create --tag $(printf '%q' "${TAG}") --title $(printf '%q' "${TAG}") --note-file $(printf '%q' "${NOTES_FILE}")"
+    else
+        # `tea release edit` lacks --note-file; pass the notes file inline.
+        RESOLVED_CMD="tea release edit $(printf '%q' "${TAG}") --note \"\$(cat $(printf '%q' "${NOTES_FILE}"))\""
+    fi
 fi
 
 # --- print-only mode (no --confirm) ---
@@ -200,14 +275,28 @@ fi
 
 # --- confirm mode: warn before destructive edit ---
 if [[ "${MODE}" == "edit" ]]; then
-    existing_body="$(printf '%s' "${RELEASE_JSON}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("body","") or "")' 2>/dev/null || true)"
-    warn "about to overwrite release body for ${TAG}. Current body:"
-    printf '%s\n' "---" "${existing_body}" "---" >&2
+    if [[ "${PROVIDER}" == "github" ]]; then
+        existing_body="$(printf '%s' "${RELEASE_JSON}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("body","") or "")' 2>/dev/null || true)"
+        warn "about to overwrite release body for ${TAG}. Current body:"
+        printf '%s\n' "---" "${existing_body}" "---" >&2
+    else
+        warn "about to overwrite release notes for ${TAG} on ${PROVIDER}."
+    fi
 fi
 
 # --- execute ---
-if [[ "${MODE}" == "create" ]]; then
-    gh release create "${TAG}" --notes-file "${NOTES_FILE}" --title "${TAG}" --verify-tag
+if [[ "${PROVIDER}" == "github" ]]; then
+    if [[ "${MODE}" == "create" ]]; then
+        gh release create "${TAG}" --notes-file "${NOTES_FILE}" --title "${TAG}" --verify-tag
+    else
+        gh release edit "${TAG}" --notes-file "${NOTES_FILE}"
+    fi
 else
-    gh release edit "${TAG}" --notes-file "${NOTES_FILE}"
+    if [[ "${MODE}" == "create" ]]; then
+        tea release create --tag "${TAG}" --title "${TAG}" --note-file "${NOTES_FILE}"
+    else
+        # `tea release edit` lacks --note-file; read the notes file inline.
+        NOTES_BODY="$(cat "${NOTES_FILE}")"
+        tea release edit "${TAG}" --note "${NOTES_BODY}"
+    fi
 fi

--- a/.codex-plugin/ycc/skills/research-to-issues/SKILL.md
+++ b/.codex-plugin/ycc/skills/research-to-issues/SKILL.md
@@ -39,6 +39,22 @@ Parse arguments:
 
 ## Tool Preference Strategy
 
+### Step 0a: Detect forge provider
+
+Issue creation is provider-aware. Detect the forge provider on `origin` first
+(`forge_detect_provider origin`) and route through the matching CLI:
+`gh issue create --title --body` for `github`, `tea issues create --title
+--description` for `forgejo`/`gitea`. `validate-prerequisites.sh` runs the same
+detection and gates the per-provider issue prerequisites. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the operation-equivalence map. Log the resolved provider + CLI.
+
+**Forgejo/Gitea caveats**: repo-slug resolution (`gh repo view`) and some label
+operations (`gh label create`) are `gh`-only and have no `tea` equivalent — skip
+them on `forgejo`/`gitea` (create labels via the Forgejo/Gitea UI, and bind
+`tea` to the `origin`-bound repo rather than resolving an owner/name slug). The
+GitHub MCP path below applies only to `github`.
+
 ### Step 0: Detect GitHub MCP Server
 
 Check if GitHub MCP tools are available by looking for tools matching `mcp__github__*`.

--- a/.codex-plugin/ycc/skills/research-to-issues/scripts/validate-prerequisites.sh
+++ b/.codex-plugin/ycc/skills/research-to-issues/scripts/validate-prerequisites.sh
@@ -14,13 +14,21 @@ set -euo pipefail
 # Auto-detects type from path/content if --type is not specified.
 #
 # Checks:
-#   1. gh CLI is installed and authenticated
-#   2. Current directory is a git repo with a GitHub remote
+#   1. The forge CLI for the detected provider is installed and authenticated
+#      (gh for GitHub, tea for Forgejo/Gitea)
+#   2. Current directory is a git repo on a supported forge
 #   3. Source path exists and matches expected structure
 #
 # Exit codes:
 #   0 = all prerequisites met
 #   1 = missing prerequisite
+
+# Detect the forge provider and select the matching CLI (gh / tea).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.codex/plugins/ycc/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
 
 SOURCE_PATH="${1:-}"
 EXPLICIT_TYPE=""
@@ -41,35 +49,60 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# --- Check gh CLI ---
-if ! command -v gh &>/dev/null; then
-  ERRORS+=("ERROR: GitHub CLI (gh) is not installed. Install: https://cli.github.com/")
-else
-  if ! gh auth status &>/dev/null 2>&1; then
-    ERRORS+=("ERROR: GitHub CLI is not authenticated. Run: gh auth login")
-  else
-    echo "OK: gh CLI installed and authenticated"
-  fi
-fi
-
-# --- Check git repo with GitHub remote ---
+# --- Check git repo and detect forge provider ---
+PROVIDER="unknown"
+FORGE_CLI=""
 if ! git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
   ERRORS+=("ERROR: Not inside a git repository")
 else
   REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
   if [[ -z "$REMOTE_URL" ]]; then
     ERRORS+=("ERROR: No 'origin' remote configured")
-  elif [[ "$REMOTE_URL" != *"github.com"* && "$REMOTE_URL" != *"github:"* ]]; then
-    ERRORS+=("WARNING: Remote may not be GitHub: $REMOTE_URL")
   else
-    REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
-    if [[ -n "$REPO" ]]; then
-      echo "OK: GitHub repo detected: $REPO"
-    else
-      ERRORS+=("ERROR: Could not determine GitHub repo from remote")
-    fi
+    PROVIDER="$(forge_detect_provider origin)"
+    FORGE_CLI="$(forge_cli "$PROVIDER")"
+
+    case "$PROVIDER" in
+      github|forgejo|gitea)
+        echo "OK: Forge provider detected: $PROVIDER (using $FORGE_CLI)"
+        ;;
+      gitlab|unknown)
+        ERRORS+=("ERROR: Issue creation requires GitHub (gh) or Forgejo/Gitea (tea); detected provider '$PROVIDER' (origin: $REMOTE_URL) is not supported")
+        ;;
+    esac
   fi
 fi
+
+# --- Check the matching forge CLI is installed and authenticated ---
+case "$PROVIDER" in
+  github|forgejo|gitea)
+    if ! command -v "$FORGE_CLI" &>/dev/null; then
+      case "$PROVIDER" in
+        github) ERRORS+=("ERROR: GitHub CLI (gh) is not installed. Install: https://cli.github.com/") ;;
+        *)      ERRORS+=("ERROR: tea CLI (for $PROVIDER) is not installed. Install: https://gitea.com/gitea/tea#installation") ;;
+      esac
+    elif ! forge_auth_ok "$PROVIDER"; then
+      case "$PROVIDER" in
+        github) ERRORS+=("ERROR: GitHub CLI is not authenticated. Run: gh auth login") ;;
+        *)      ERRORS+=("ERROR: tea is not authenticated for $PROVIDER. Run: tea login add") ;;
+      esac
+    else
+      echo "OK: $FORGE_CLI CLI installed and authenticated"
+      # GitHub-only: confirm the repo slug resolves via the host API. tea v0.14
+      # has no clean equivalent, so this sub-check is skipped on Forgejo/Gitea.
+      if [[ "$PROVIDER" == "github" ]]; then
+        REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+        if [[ -n "$REPO" ]]; then
+          echo "OK: GitHub repo detected: $REPO"
+        else
+          ERRORS+=("ERROR: Could not determine GitHub repo from remote")
+        fi
+      else
+        echo "NOTICE: Skipping repo-slug resolution check (no clean tea equivalent on $PROVIDER)"
+      fi
+    fi
+    ;;
+esac
 
 # --- Check source path ---
 if [[ -z "$SOURCE_PATH" ]]; then

--- a/.codex-plugin/ycc/skills/review-fix/SKILL.md
+++ b/.codex-plugin/ycc/skills/review-fix/SKILL.md
@@ -841,6 +841,16 @@ The transcript-output contract and shared caveats (worktree cwd, interactive fai
 
 ## Important Notes
 
+- **PR posting is GitHub-only**: The PR-coupled steps here use `gh` (resolving the
+  PR head via `gh pr view`, and the commit+push to the PR branch in worktree mode).
+  Those depend on GitHub plumbing that has no `tea` equivalent. Detect the forge
+  provider on `origin` (`forge_detect_provider origin`) before any `gh pr` call. On a
+  non-`github` provider, apply the fixes **locally** (Path A/B/C all edit files in the
+  working tree regardless of forge) and **skip the PR-posting step** with a notice:
+  "PR posting is GitHub-only on provider `<provider>`; fixes applied locally — commit
+  and push them yourself." Mark `REPORT_COMMITTED: n/a` in that case. The artifact
+  parse, filter, fix, Status updates, and Phase 5 validation are all provider-neutral.
+  See [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 - **In-place Status updates**: The source review file is the source of truth. This skill mutates it in place via `Edit`, updating only the `Status` line of each processed finding. All other content is preserved.
 - **No scope creep**: Each `review-fixer` agent is scope-disciplined — it fixes exactly what the finding specifies. If the fix reveals a larger issue, the agent reports it, but the skill does not chase down related problems.
 - **Resumable**: Re-running on the same review file skips already-processed findings.

--- a/.cursor-plugin/skills/_shared/references/ci-monitoring.md
+++ b/.cursor-plugin/skills/_shared/references/ci-monitoring.md
@@ -22,6 +22,27 @@ must not diverge from either.
 
 ---
 
+## Provider Support
+
+The CI-autofix loop is **GitHub-only**. Both `ci-monitor.sh` and
+`release-ci-monitor.sh` depend on `gh` run controls (`gh run view
+--log-failed`, `gh run rerun`, `gh run list`) that have no Forgejo/Gitea (`tea`)
+or GitLab (`glab`) equivalent. Before entering the loop the scripts detect the
+forge provider on the watched remote; on any non-GitHub remote they emit
+`RESULT=unsupported-provider` (exit 2) and do nothing else.
+
+The detection contract — provider values `github` / `forgejo` / `gitea` /
+`gitlab` / `unknown`, the `forge_detect_provider` / `forge_cli` law — lives in
+[`forge-detection.md`](forge-detection.md) (capability matrix: "CI-autofix loop
+(`--ci`)" is GitHub-only).
+
+**Skill loop handling:** treat `RESULT=unsupported-provider` exactly like
+`pr-not-found` / `refused-default-branch` — surface it directly and do **not**
+loop. State that the loop is GitHub-only, skip it cleanly, and never re-invoke
+the monitor. It is a terminal non-loop result, not an error to retry.
+
+---
+
 ## Trust Boundary
 
 `--ci` grants the following standing authorization for the duration of one skill
@@ -109,6 +130,7 @@ corresponding code.
 | `bail-timeout`           | 13        | Wall-clock ≥ `--ci-timeout-min`, or checks never registered              |
 | `pr-not-found`           | 2         | PR does not exist or is unreachable                                      |
 | `refused-default-branch` | 2         | Will not operate when head branch equals the default branch              |
+| `unsupported-provider`   | 2         | Remote is not GitHub; the CI-autofix loop is GitHub-only                 |
 
 Exit code 1 is reserved for argument/usage errors and never appears in the loop.
 
@@ -174,8 +196,10 @@ the skill.
      - The cap or constraint that fired
        Exit phase; do not push further.
 
-   - **`pr-not-found`** / **`refused-default-branch`** — surface the error
-     directly; do not enter the loop.
+   - **`pr-not-found`** / **`refused-default-branch`** / **`unsupported-provider`**
+     — surface the error directly; do not enter the loop. For
+     `unsupported-provider`, state that the CI-autofix loop is GitHub-only (see
+     the Provider Support section above) and skip it cleanly.
 
 ---
 

--- a/.cursor-plugin/skills/_shared/references/forge-detection.md
+++ b/.cursor-plugin/skills/_shared/references/forge-detection.md
@@ -1,0 +1,155 @@
+# Forge Provider Detection & Tooling Selection
+
+Single source of truth for how every git skill in the `ycc` bundle decides
+**which forge it is talking to** and **which CLI to drive**. Any skill that
+creates PRs, files issues, cuts releases, posts review comments, or watches CI
+must run this detection first and route accordingly.
+
+The programmatic counterpart is
+[`_shared/scripts/lib/forge.sh`](../scripts/lib/forge.sh) — a sourceable bash
+library that implements the detection law described here. Scripts source it;
+SKILL prose references this document. The two must never diverge.
+
+> **Why this exists.** The bundle was historically GitHub-only (`gh`
+> everywhere). Self-hosted **Forgejo** and **Gitea** repositories need the same
+> workflows driven through the `tea` CLI. Detection lets one skill serve both
+> without the user passing a `--provider` flag.
+
+---
+
+## Provider values
+
+| Provider  | Hosts                          | CLI    | Notes                                  |
+| --------- | ------------------------------ | ------ | -------------------------------------- |
+| `github`  | github.com, GitHub Enterprise  | `gh`   | Full feature support                   |
+| `forgejo` | self-hosted Forgejo            | `tea`  | Gitea fork; same tooling as `gitea`    |
+| `gitea`   | self-hosted Gitea              | `tea`  | Generic Gitea-family label             |
+| `gitlab`  | gitlab.com, self-hosted GitLab | `glab` | Pre-existing partial support           |
+| `unknown` | anything else                  | (none) | Skip host-API steps with a loud notice |
+
+`forgejo` and `gitea` are the **same tooling family** — both driven by `tea`.
+They are distinguished only for accurate user-facing messages. For command
+selection, treat them identically (`forge_cli` maps both to `tea`).
+
+---
+
+## Detection algorithm
+
+`forge_detect_provider [remote] [--probe]` (default remote: `origin`):
+
+1. Read `git remote get-url <remote>`. No remote → `unknown`.
+2. Extract the bare host from the URL (handles `git@host:owner/repo.git`,
+   `ssh://git@host:port/...`, `https://host/...`, `git://host/...`; strips a
+   trailing `.git`).
+3. **GitHub** if the host is `github.com` / `*.github.com`, equals `$GH_HOST`
+   or `$GITHUB_HOST`, or appears in `~/.config/gh/hosts.yml`.
+4. **GitLab** if the host is `gitlab.com` / `*.gitlab.com`, or appears in
+   `~/.config/glab-cli/config.yml`.
+5. **Gitea family** if the host matches a configured `tea login list` entry.
+   With `--probe`, a best-effort `GET https://<host>/api/v1/version` (plus the
+   Server header) distinguishes `forgejo` from `gitea`; offline, default to
+   `gitea`.
+6. With `--probe` and no local match, the `/api/v1/version` probe can still
+   classify an unconfigured Gitea/Forgejo host.
+7. Otherwise → `unknown`.
+
+Steps 3–4 and the `tea login list` read in step 5 are **local only** — no
+network, no rate-limit cost. The `/api/v1/version` probe in steps 5–6 is
+opt-in via `--probe` so default detection stays fast and offline-friendly.
+
+---
+
+## Auth probes (run once, cache the result)
+
+Never call the host API to check auth — use the local status commands:
+
+```bash
+# github
+command -v gh   >/dev/null && gh   auth status >/dev/null 2>&1   # → authed
+
+# forgejo / gitea  (tea has no `auth status`; a configured login is the signal)
+command -v tea  >/dev/null && tea login list 2>/dev/null | grep -q '://'
+
+# gitlab
+command -v glab >/dev/null && glab auth status >/dev/null 2>&1
+```
+
+The lib exposes these as `forge_auth_ok <provider>`. If the matched provider's
+CLI is missing or unauthenticated, surface a precise remediation (`gh auth
+login`, `tea login add`, `glab auth login`) and fall back to local-only mode
+rather than guessing.
+
+---
+
+## Operation equivalence map
+
+Core operations are supported on **both** families. Drive them through the CLI
+that `forge_cli <provider>` returns.
+
+| Operation             | GitHub (`gh`)                            | Forgejo / Gitea (`tea`)                          |
+| --------------------- | ---------------------------------------- | ------------------------------------------------ |
+| Default branch        | `gh repo view --json defaultBranchRef`   | `git symbolic-ref refs/remotes/origin/HEAD`      |
+| Create PR             | `gh pr create --title --body [--draft]`  | `tea pull create --title --description [--head]` |
+| PR for current branch | `gh pr list --head <branch>`             | `tea pull list` (filter by head branch)          |
+| View PR state         | `gh pr view <n> --json state`            | `tea pull <n>`                                   |
+| List open issues      | `gh issue list`                          | `tea issues list`                                |
+| Create issue          | `gh issue create --title --body`         | `tea issues create --title --description`        |
+| Close issue           | `gh issue close <n>`                     | `tea issues close <n>`                           |
+| Create release        | `gh release create <tag> [--notes-file]` | `tea release create --tag <tag> [--note-file]`   |
+| Delete remote branch  | `git push <remote> --delete <branch>`    | `git push <remote> --delete <branch>` (same)     |
+
+`tea` operates on the repo bound to the current directory's `origin` remote (it
+reads `.git/config`); pass `--repo owner/name` only when overriding.
+
+---
+
+## Capability matrix — GitHub-only features
+
+Some advanced features depend on APIs that **do not exist** on Forgejo/Gitea.
+These degrade gracefully: detect the provider, and on a non-GitHub remote emit
+`forge_unsupported_notice` and exit cleanly rather than faking parity.
+
+| Feature                              | GitHub | Forgejo / Gitea | Why                                                         |
+| ------------------------------------ | ------ | --------------- | ----------------------------------------------------------- |
+| PR / issue / release create + list   | ✅     | ✅              | Covered by `gh` and `tea`                                   |
+| Review-thread resolution (`resolve`) | ✅     | ❌              | Requires GraphQL `resolveReviewThread`; no GraphQL on Gitea |
+| Per-comment PR autofix harvesting    | ✅     | ❌              | `fetch-pr-comments.sh` uses the GitHub GraphQL API          |
+| CI-autofix loop (`--ci`)             | ✅     | ❌              | Depends on `gh run view --log-failed` / `gh run rerun`      |
+| Emoji reactions on comments          | ✅     | ❌              | GraphQL `addReaction`                                       |
+
+For ❌ features on a non-GitHub remote, the skill must:
+
+1. Detect the provider in its Phase 0.
+2. Tell the user the feature is GitHub-only and **why** (one line).
+3. Offer the manual alternative (e.g. "resolve the thread in the Forgejo UI").
+4. Continue with whatever **is** supported (e.g. still create the PR via `tea`),
+   skipping only the unsupported step.
+
+Never silently no-op and never pretend an unsupported step succeeded.
+
+---
+
+## Skill integration pattern (Phase 0)
+
+Every git-operation skill adds a detection step before any host call:
+
+```bash
+# shellcheck source=/dev/null
+source "${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+provider="$(forge_detect_provider origin)"
+cli="$(forge_cli "$provider")"
+forge_auth_ok "$provider" || { echo "Auth needed for $provider"; exit 2; }
+```
+
+Then branch on `$provider` for the operation, or call a script that does the
+branching internally. Log the resolved provider + CLI so the user sees which
+forge the workflow targeted.
+
+---
+
+## References
+
+- [`_shared/scripts/lib/forge.sh`](../scripts/lib/forge.sh) — the detection lib
+- [`git-cleanup/references/host-detection.md`](../../git-cleanup/references/host-detection.md)
+  — the older GitHub/GitLab host-detection notes this generalizes
+- [`ci-monitoring.md`](ci-monitoring.md) — CI-autofix loop (GitHub-only; gated here)

--- a/.cursor-plugin/skills/_shared/scripts/ci-monitor.sh
+++ b/.cursor-plugin/skills/_shared/scripts/ci-monitor.sh
@@ -38,6 +38,16 @@ VERSION="1.0.0"
 . "$(dirname "$0")/lib/ci-classify.sh"
 
 # ---------------------------------------------------------------------------
+# Forge provider detection (sourced)
+# ---------------------------------------------------------------------------
+# The CI-autofix loop depends on `gh run view --log-failed` / `gh run rerun`,
+# which have no Forgejo/Gitea equivalent. The loop is GitHub-only; on any other
+# provider this script exits early with RESULT=unsupported-provider.
+
+# shellcheck source=lib/forge.sh
+. "$(dirname "$0")/lib/forge.sh"
+
+# ---------------------------------------------------------------------------
 # Usage
 # ---------------------------------------------------------------------------
 
@@ -383,6 +393,18 @@ main() {
     log_jsonl "$log_file" "$ts" "$iteration" "$pr" "0" "" "success" "" "green" "$push_count" "" '"dry_run":true'
     printf 'RESULT=green\n'
     exit 0
+  fi
+
+  # -------------------------------------------------------------------------
+  # Step 0: Forge provider gate (GitHub-only feature)
+  # -------------------------------------------------------------------------
+
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "the --ci auto-fix loop"
+    printf 'RESULT=unsupported-provider\n'
+    exit 2
   fi
 
   # -------------------------------------------------------------------------

--- a/.cursor-plugin/skills/_shared/scripts/lib/forge.sh
+++ b/.cursor-plugin/skills/_shared/scripts/lib/forge.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# forge.sh — Git forge provider detection and tooling selection.
+#
+# Sourceable library. Sourcing it has NO side effects (no network, no writes,
+# no `set` changes that leak to the caller). Every consumer that talks to a
+# remote git host (GitHub / Forgejo / Gitea / GitLab) routes through these
+# helpers so a single detection law governs the whole bundle.
+#
+# Provider values returned by forge_detect_provider:
+#   github   — GitHub.com or GitHub Enterprise        → CLI: gh
+#   forgejo  — Forgejo instance (Gitea fork)          → CLI: tea
+#   gitea    — Gitea instance                          → CLI: tea
+#   gitlab   — GitLab.com or self-hosted GitLab        → CLI: glab
+#   unknown  — could not be determined                 → CLI: (none)
+#
+# `forgejo` and `gitea` are the same tooling family (both driven by `tea`);
+# they are distinguished only for accurate messaging. Treat them identically
+# for command selection — forge_cli maps both to `tea`.
+#
+# Contract: see _shared/references/forge-detection.md (single source of truth).
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+# forge_strip_git_suffix <url> — strip a trailing ".git".
+forge_strip_git_suffix() {
+  printf '%s' "${1%.git}"
+}
+
+# forge_remote_url [remote] — print the fetch URL for a remote (default origin).
+# Prints nothing and returns 1 if the remote does not exist.
+forge_remote_url() {
+  local remote="${1:-origin}"
+  git remote get-url "$remote" 2>/dev/null
+}
+
+# forge_host_from_url <url> — extract the bare hostname from an ssh, https, or
+# git:// remote URL. Handles:
+#   git@host:owner/repo.git
+#   ssh://git@host:22/owner/repo.git
+#   https://host/owner/repo.git
+#   git://host/owner/repo.git
+forge_host_from_url() {
+  local url="$1"
+  url="$(forge_strip_git_suffix "$url")"
+
+  case "$url" in
+    *://*)
+      # scheme://[user@]host[:port]/path
+      local rest="${url#*://}"
+      rest="${rest#*@}"      # drop optional user@
+      rest="${rest%%/*}"     # keep host[:port]
+      printf '%s' "${rest%%:*}"  # drop :port
+      ;;
+    *@*:*)
+      # scp-like: [user@]host:path
+      local rest="${url#*@}"
+      printf '%s' "${rest%%:*}"
+      ;;
+    *:*)
+      # host:path with no user
+      printf '%s' "${url%%:*}"
+      ;;
+    *)
+      printf '%s' "$url"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Configured-host probes (local only — no network)
+# ---------------------------------------------------------------------------
+
+# forge_host_is_github <host> — true if the host is GitHub.com, a configured
+# GH_HOST/GITHUB_HOST enterprise host, or listed in ~/.config/gh/hosts.yml.
+forge_host_is_github() {
+  local host="$1"
+  case "$host" in
+    github.com|*.github.com) return 0 ;;
+  esac
+  if [[ -n "${GH_HOST:-}" && "$host" == "${GH_HOST}" ]]; then return 0; fi
+  if [[ -n "${GITHUB_HOST:-}" && "$host" == "${GITHUB_HOST}" ]]; then return 0; fi
+  local hosts_yml="${HOME}/.config/gh/hosts.yml"
+  if [[ -f "$hosts_yml" ]] && grep -qE "^${host}:" "$hosts_yml" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# forge_host_is_gitlab <host> — true if GitLab.com or a configured glab host.
+forge_host_is_gitlab() {
+  local host="$1"
+  case "$host" in
+    gitlab.com|*.gitlab.com) return 0 ;;
+  esac
+  local glab_cfg="${HOME}/.config/glab-cli/config.yml"
+  if [[ -f "$glab_cfg" ]] && grep -qE "^[[:space:]]*${host}:" "$glab_cfg" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# forge_host_in_tea <host> — true if the host matches a configured `tea` login
+# (Gitea/Forgejo). Reads `tea login list` so no network call is made.
+forge_host_in_tea() {
+  local host="$1"
+  command -v tea >/dev/null 2>&1 || return 1
+  # `tea login list` prints a table containing the URL and SSH host columns.
+  tea login list 2>/dev/null | grep -qiF "$host"
+}
+
+# ---------------------------------------------------------------------------
+# Optional network probe — distinguishes Forgejo from Gitea, and confirms a
+# gitea-family host when no local config exists. Best-effort; never required.
+# ---------------------------------------------------------------------------
+
+# forge_probe_gitea_family <host> — echo "forgejo" or "gitea" if the host serves
+# the Gitea REST API, else echo nothing and return 1. Hits /api/v1/version,
+# which is public on virtually all instances.
+forge_probe_gitea_family() {
+  local host="$1"
+  command -v curl >/dev/null 2>&1 || return 1
+  local body
+  body="$(curl -fsSL --max-time 5 "https://${host}/api/v1/version" 2>/dev/null)" || return 1
+  # The version endpoint returns {"version":"..."}. Forgejo advertises itself in
+  # the Server header; fall back to assuming gitea for the bare version payload.
+  case "$body" in
+    *version*)
+      local server
+      server="$(curl -fsSLI --max-time 5 "https://${host}/api/v1/version" 2>/dev/null | tr -d '\r')"
+      if printf '%s' "$server" | grep -qi 'forgejo'; then
+        printf 'forgejo'
+      else
+        printf 'gitea'
+      fi
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Provider detection
+# ---------------------------------------------------------------------------
+
+# forge_detect_provider [remote] [--probe]
+#   Detect the forge provider for a remote (default origin).
+#   Pass --probe to allow the network /api/v1/version fallback (off by default
+#   so detection stays fast and offline-friendly).
+#   Echoes one of: github | forgejo | gitea | gitlab | unknown
+forge_detect_provider() {
+  local remote="origin" probe="false"
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --probe) probe="true" ;;
+      *) remote="$arg" ;;
+    esac
+  done
+
+  local url host
+  url="$(forge_remote_url "$remote")" || { printf 'unknown'; return 0; }
+  [[ -z "$url" ]] && { printf 'unknown'; return 0; }
+  host="$(forge_host_from_url "$url")"
+  [[ -z "$host" ]] && { printf 'unknown'; return 0; }
+
+  if forge_host_is_github "$host"; then printf 'github'; return 0; fi
+  if forge_host_is_gitlab "$host"; then printf 'gitlab'; return 0; fi
+  if forge_host_in_tea "$host"; then
+    if [[ "$probe" == "true" ]]; then
+      local fam
+      fam="$(forge_probe_gitea_family "$host")" && { printf '%s' "$fam"; return 0; }
+    fi
+    # tea is configured for this host but we can't tell Forgejo from Gitea
+    # offline — default to the generic family label.
+    printf 'gitea'
+    return 0
+  fi
+  if [[ "$probe" == "true" ]]; then
+    local fam
+    fam="$(forge_probe_gitea_family "$host")" && { printf '%s' "$fam"; return 0; }
+  fi
+  printf 'unknown'
+}
+
+# ---------------------------------------------------------------------------
+# Tooling selection
+# ---------------------------------------------------------------------------
+
+# forge_cli <provider> — echo the CLI binary name for a provider.
+#   github → gh, forgejo|gitea → tea, gitlab → glab, unknown → (empty)
+forge_cli() {
+  case "$1" in
+    github) printf 'gh' ;;
+    forgejo|gitea) printf 'tea' ;;
+    gitlab) printf 'glab' ;;
+    *) printf '' ;;
+  esac
+}
+
+# forge_is_gitea_family <provider> — true for forgejo or gitea.
+forge_is_gitea_family() {
+  case "$1" in
+    forgejo|gitea) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# forge_cli_available <provider> — true if the provider's CLI is installed.
+forge_cli_available() {
+  local cli
+  cli="$(forge_cli "$1")"
+  [[ -n "$cli" ]] && command -v "$cli" >/dev/null 2>&1
+}
+
+# forge_auth_ok <provider> — true if the provider's CLI is authenticated.
+# Uses only local auth-status checks (no API/rate-limit cost).
+forge_auth_ok() {
+  case "$1" in
+    github) command -v gh   >/dev/null 2>&1 && gh   auth status >/dev/null 2>&1 ;;
+    forgejo|gitea)
+      # `tea` has no `auth status`; a configured login list is the local signal.
+      command -v tea  >/dev/null 2>&1 && tea login list 2>/dev/null | grep -q '://'
+      ;;
+    gitlab) command -v glab >/dev/null 2>&1 && glab auth status >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# forge_default_branch <provider> — echo the repository default branch, or
+# fall back to "main". Provider-neutral.
+forge_default_branch() {
+  local provider="$1" b=""
+  case "$provider" in
+    github)
+      b="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null)"
+      ;;
+    forgejo|gitea)
+      # `tea repos search`/`tea` lacks a stable default-branch field across
+      # versions; infer from the remote HEAD instead.
+      b="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+      ;;
+    gitlab)
+      b="$(glab repo view --output json 2>/dev/null | grep -o '"default_branch":"[^"]*"' | head -n1 | sed 's/.*:"//;s/"//')"
+      ;;
+  esac
+  if [[ -z "$b" ]]; then
+    b="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+  fi
+  printf '%s' "${b:-main}"
+}
+
+# forge_unsupported_notice <provider> <feature> — print a uniform, honest
+# message to stderr when an advanced feature is GitHub-only. Returns 0 so the
+# caller controls the exit code.
+forge_unsupported_notice() {
+  local provider="$1" feature="$2"
+  printf '%s: %s is a GitHub-only feature; provider "%s" is not supported.\n' \
+    "${0##*/}" "$feature" "$provider" >&2
+  printf '  Reason: Forgejo/Gitea expose only the REST v1 API (no GraphQL) and\n' >&2
+  printf '  the tea CLI does not surface CI-run logs/rerun controls. Run this\n' >&2
+  printf '  feature on a GitHub remote, or do the action manually on %s.\n' "$provider" >&2
+}

--- a/.cursor-plugin/skills/_shared/scripts/release-ci-monitor.sh
+++ b/.cursor-plugin/skills/_shared/scripts/release-ci-monitor.sh
@@ -35,6 +35,11 @@ VERSION="1.0.0"
 # shellcheck source=lib/ci-classify.sh
 . "$(dirname "$0")/lib/ci-classify.sh"
 
+# Forge provider detection. The release CI-autofix loop depends on
+# `gh run` controls with no Forgejo/Gitea equivalent — GitHub-only.
+# shellcheck source=lib/forge.sh
+. "$(dirname "$0")/lib/forge.sh"
+
 # ---------------------------------------------------------------------------
 # Usage
 # ---------------------------------------------------------------------------
@@ -417,6 +422,15 @@ main() {
     log_jsonl "$log_file" "$ts" "$iteration" "$tag" "0" "" "success" "" "green" "$push_count" "" '"dry_run":true'
     printf 'RESULT=green\n'
     exit 0
+  fi
+
+  # Forge provider gate (GitHub-only feature).
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "the release --ci auto-fix loop"
+    printf 'RESULT=unsupported-provider\n'
+    exit 2
   fi
 
   # Workflow file must be resolvable in non-dry-run mode.

--- a/.cursor-plugin/skills/code-review/SKILL.md
+++ b/.cursor-plugin/skills/code-review/SKILL.md
@@ -349,6 +349,15 @@ write an artifact here — quick-review owns the artifact lifecycle.
 
 Comprehensive GitHub PR review — fetches diff, reads full files, runs validation, posts review.
 
+**GitHub-only.** PR mode is GitHub-only: it reads and posts on PRs through the
+`gh` PR/review plumbing (`gh pr view`/`gh pr diff`/`gh pr review` + the GitHub
+review-comments API), which has no `tea` equivalent. Detect the forge provider
+on `origin` first (`forge_detect_provider origin`); if it is **not** `github`,
+state that PR mode is GitHub-only and offer **Local Review Mode** instead
+(local-diff review works on any provider). Do not attempt the `gh` PR calls on a
+non-GitHub remote. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
+
 Detect whether GitHub MCP tools are available (look for `mcp__github__*`). If they are, prefer those for PR fetch/view/review operations. Otherwise fall back to the `gh` CLI examples shown below.
 
 ### Phase 1 — FETCH

--- a/.cursor-plugin/skills/git-cleanup/SKILL.md
+++ b/.cursor-plugin/skills/git-cleanup/SKILL.md
@@ -53,13 +53,21 @@ Parse `$ARGUMENTS`:
 1. **Verify working tree is a git repo**: `git rev-parse --git-dir`. Abort if not.
 2. **Determine default branch**: `git symbolic-ref refs/remotes/origin/HEAD` →
    fall back to `main` / `master` if unset.
-3. **Detect host CLIs and MCP tools**. See
-   `${CURSOR_PLUGIN_ROOT}/skills/git-cleanup/references/host-detection.md` for
-   the full decision table. Summary:
+3. **Detect host CLIs and MCP tools**. Detection follows the bundle-wide
+   contract in
+   `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/forge-detection.md`
+   (`forge_detect_provider origin` → `github` / `forgejo` / `gitea` / `gitlab` /
+   `unknown`; `forge_cli` → `gh` / `tea` / `glab`); the git-cleanup-specific
+   operation map lives in
+   `${CURSOR_PLUGIN_ROOT}/skills/git-cleanup/references/host-detection.md`.
+   Summary:
    - Prefer `mcp__github__*` tools if available for GitHub operations.
-   - Else `gh auth status` for GitHub, `glab auth status` for GitLab.
-   - If `--host=auto`, parse `git remote get-url origin`. Unknown hosts skip
-     the remote-domain audits with a loud notice.
+   - Else `gh auth status` for GitHub, `tea login list` for the Forgejo/Gitea
+     family, `glab auth status` for GitLab.
+   - If `--host=auto`, parse `git remote get-url origin` via the shared lib.
+     A Forgejo/Gitea remote (matched against `tea login list`) routes PR/issue
+     cleanup through `tea` (`tea pull list/close`, `tea issues list/close`).
+     Unknown hosts skip the remote-domain audits with a loud notice.
 4. **Check working-tree state**: Capture `git status --porcelain` and
    `git stash list`. Record whether the current branch has unpushed commits.
 5. **Initialize progress tracking** with TodoWrite (one entry per phase).

--- a/.cursor-plugin/skills/git-cleanup/references/host-detection.md
+++ b/.cursor-plugin/skills/git-cleanup/references/host-detection.md
@@ -1,5 +1,14 @@
 # Host Detection and Client Selection
 
+> **Canonical source of truth:** the bundle-wide forge-detection contract lives at
+> [`../../_shared/references/forge-detection.md`](../../_shared/references/forge-detection.md)
+> (provider values `github` / `forgejo` / `gitea` / `gitlab` / `unknown`; CLIs
+> `gh` / `tea` / `glab`; the `forge_detect_provider`, `forge_cli`, `forge_auth_ok`
+> detection law implemented in `_shared/scripts/lib/forge.sh`). Prefer that document
+> and library for detection. This file is the **git-cleanup-specific supplement**:
+> it maps the resolved provider to the concrete read/write cleanup operations this
+> skill performs. When the two disagree on detection, the canonical reference wins.
+
 Reference for Phase 0 of `ycc/skills/git-cleanup/SKILL.md`. Given a repository,
 determine (1) which remote host the audit should query and (2) which client
 library / CLI / MCP server to use for each operation.
@@ -17,6 +26,12 @@ For GitLab repositories, pick the first available:
 1. **`glab` CLI** — authenticated (`glab auth status` returns 0).
 2. **Local-only mode** — skip `--prs` and `--issues` with a loud notice.
 
+For Forgejo / Gitea repositories (provider `forgejo` or `gitea` — same tooling
+family, both driven by `tea`), pick the first available:
+
+1. **`tea` CLI** — a configured login (`tea login list` shows a `://` entry).
+2. **Local-only mode** — skip `--prs` and `--issues` with a loud notice.
+
 Never mix clients within a single audit. Decide once in Phase 0 and log the
 decision in `.git-cleanup/report.md` under "Host-API notes".
 
@@ -24,13 +39,14 @@ decision in `.git-cleanup/report.md` under "Host-API notes".
 
 When `--host=auto` (default), parse `git remote get-url origin`:
 
-| Pattern match                                 | Inferred host |
-| --------------------------------------------- | ------------- |
-| `github.com:`, `github.com/`, `*.github.com/` | GitHub        |
-| `gitlab.com:`, `gitlab.com/`, `/api/v4/`      | GitLab        |
-| Self-hosted GitHub Enterprise (`GHE_HOST`)    | GitHub        |
-| Self-hosted GitLab                            | GitLab        |
-| Anything else                                 | Unknown       |
+| Pattern match                                 | Inferred host   |
+| --------------------------------------------- | --------------- |
+| `github.com:`, `github.com/`, `*.github.com/` | GitHub          |
+| `gitlab.com:`, `gitlab.com/`, `/api/v4/`      | GitLab          |
+| Self-hosted GitHub Enterprise (`GHE_HOST`)    | GitHub          |
+| Self-hosted GitLab                            | GitLab          |
+| Self-hosted Forgejo / Gitea                   | Forgejo / Gitea |
+| Anything else                                 | Unknown         |
 
 Accept SSH, HTTPS, and `git://` URLs. Strip any `.git` suffix before matching.
 
@@ -40,6 +56,12 @@ as GitHub and route `gh` calls to that host.
 
 **Self-hosted GitLab:** `glab` reads its host list from `~/.config/glab-cli/`.
 If the `origin` host matches one of its configured hosts, treat as GitLab.
+
+**Self-hosted Forgejo / Gitea:** `tea` reads its login list from
+`~/.config/tea/`. If the `origin` host matches a configured `tea login list`
+entry, treat as the Gitea family and route `tea` calls to that host. The two are
+the same tooling family (`forge_cli` maps both to `tea`); the canonical reference
+distinguishes `forgejo` from `gitea` only for messaging.
 
 ## Detecting MCP availability
 
@@ -101,6 +123,25 @@ GitLab's "Merge Request" maps to GitHub's "Pull Request" one-for-one for this
 skill's purposes. Both concepts share the same R-rules (see
 `active-code-rules.md`).
 
+### Forgejo / Gitea (`tea` fallbacks)
+
+```bash
+# Open PRs ("pulls") for the current repo
+tea pull list --state open
+
+# Merged/closed PRs (filter the list output for merged state)
+tea pull list --state closed
+
+# Open issues
+tea issues list --state open
+```
+
+`tea` operates on the repo bound to the current directory's `origin` remote (it
+reads `.git/config`); pass `--repo owner/name` only when overriding. Forgejo's
+"Pull Request" maps to GitHub's one-for-one and shares the same R-rules (see
+`active-code-rules.md`). `tea` paginates with `--limit` (alias for page size);
+bound large lists the same way `--limit` bounds `gh` output.
+
 ## Write operations (only with `--apply` + user approval)
 
 ### GitHub
@@ -119,6 +160,15 @@ skill's purposes. Both concepts share the same R-rules (see
 | Close an MR    | `glab mr close <iid>`                 |
 | Close an issue | `glab issue close <iid>`              |
 | Add a label    | `glab issue update <iid> --label ...` |
+
+### Forgejo / Gitea
+
+| Action                 | `tea` command                                     |
+| ---------------------- | ------------------------------------------------- |
+| Close a PR             | `tea pull close <n>`                              |
+| Close an issue         | `tea issues close <n>`                            |
+| Add a label            | `tea issues edit <n> --add-labels ...`            |
+| Delete a remote branch | (n/a — use git) `git push origin --delete <name>` |
 
 ## Rate-limit awareness
 

--- a/.cursor-plugin/skills/git-workflow/SKILL.md
+++ b/.cursor-plugin/skills/git-workflow/SKILL.md
@@ -650,6 +650,15 @@ This provides:
 - Documentation changes
 - Suggested PR title and scope
 
+**Forge provider detection**: `create-pr.sh` runs forge detection on `origin`
+first and routes PR creation through the matching CLI — `gh` for `github`,
+`tea` for `forgejo`/`gitea` (`gh pr create` ↔ `tea pull create`). The MCP-first
+path above applies only to `github`; on a `forgejo`/`gitea` remote the script
+drives `tea` directly. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the detection algorithm and operation-equivalence map. Log the resolved
+provider + CLI so the user sees which forge the PR targeted.
+
 ### Step 25: Generate PR Title
 
 PR titles **MUST** follow the conventional commit format: `<type>(<scope>): <description>`
@@ -901,6 +910,15 @@ If repository has `.github/PULL_REQUEST_TEMPLATE.md`:
 
 **Trigger:** This phase runs ONLY when `--ci ∈ flags`. Skip silently otherwise. Phase 6 does not require Phase 5 to have run — bare `--ci` and `--push --ci` both reach this phase by design.
 
+**GitHub-only:** The CI auto-fix loop is GitHub-only — it depends on `gh run`
+controls (`gh run view --log-failed`, `gh run rerun`). On a non-GitHub remote
+`ci-monitor.sh` returns `RESULT=unsupported-provider` (exit 2). Treat this like
+`pr-not-found`/`refused-default-branch`: report it directly and **skip the loop
+without erroring**. State that the loop is GitHub-only and why, then end Phase 6
+cleanly. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+and [`../_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md).
+
 ### Step 32: Discover PR for the current branch
 
 If a `PR_NUMBER` was captured in Phase 5 (either newly created in Steps 23-30 or detected as existing in Step 22a), use it directly and skip ahead to Step 33.
@@ -971,6 +989,7 @@ Branch on stdout `RESULT=...` per the **Loop Protocol** section of `ci-monitorin
 - `rerun-pending` → Flake-suspected; the script already triggered `gh run rerun --failed`. Do NOT apply any fix. Sleep 30 seconds (`sleep 30`), then goto Step 36.
 - `bail-recurrence` / `bail-nonfixable` / `bail-pushes` / `bail-timeout` → Render a diagnosis block citing the audit log path, the `RESULT=` value, the `REASON=` line if present, and the cap that fired. End Phase 6 (do NOT push further).
 - `pr-not-found` / `refused-default-branch` → Surface the error directly; do not retry.
+- `unsupported-provider` → Remote is not GitHub; the CI auto-fix loop is GitHub-only. Report that the loop is GitHub-only and skip it cleanly; do not retry and do not treat as an error.
 
 ### Step 37: Final report
 

--- a/.cursor-plugin/skills/git-workflow/scripts/create-pr.sh
+++ b/.cursor-plugin/skills/git-workflow/scripts/create-pr.sh
@@ -44,24 +44,54 @@ if ! git rev-parse --git-dir > /dev/null 2>&1; then
     exit 1
 fi
 
-# Check if gh CLI is available
-if ! command -v gh &> /dev/null; then
-    echo -e "${RED}Error: GitHub CLI (gh) is not installed${NC}" >&2
+# Detect the forge provider and select the matching CLI (gh / tea / glab).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
+PROVIDER="$(forge_detect_provider origin)"
+FORGE_CLI="$(forge_cli "$PROVIDER")"
+
+case "$PROVIDER" in
+    github|forgejo|gitea) ;;  # supported for PR creation
+    gitlab)
+        echo -e "${RED}Error: GitLab PR creation is not yet supported by this script${NC}" >&2
+        echo "Create the merge request with: glab mr create" >&2
+        exit 1
+        ;;
+    *)
+        echo -e "${RED}Error: Could not determine the forge provider for 'origin'${NC}" >&2
+        echo "origin = $(forge_remote_url origin)" >&2
+        echo "Supported: GitHub (gh), Forgejo/Gitea (tea)." >&2
+        exit 1
+        ;;
+esac
+
+# Check the matching CLI is installed
+if ! command -v "$FORGE_CLI" &> /dev/null; then
+    echo -e "${RED}Error: ${FORGE_CLI} CLI (for ${PROVIDER}) is not installed${NC}" >&2
     echo "" >&2
-    echo "Install with:" >&2
-    echo "  macOS:   brew install gh" >&2
-    echo "  Linux:   See https://github.com/cli/cli/blob/trunk/docs/install_linux.md" >&2
+    case "$PROVIDER" in
+        github) echo "Install gh:  https://github.com/cli/cli#installation" >&2 ;;
+        *)      echo "Install tea: https://gitea.com/gitea/tea#installation" >&2 ;;
+    esac
     exit 1
 fi
 
-# Check if authenticated with gh
-if ! gh auth status &> /dev/null; then
-    echo -e "${RED}Error: Not authenticated with GitHub CLI${NC}" >&2
+# Check authentication for the detected provider
+if ! forge_auth_ok "$PROVIDER"; then
+    echo -e "${RED}Error: Not authenticated with ${FORGE_CLI} (${PROVIDER})${NC}" >&2
     echo "" >&2
-    echo "Authenticate with:" >&2
-    echo "  gh auth login" >&2
+    case "$PROVIDER" in
+        github) echo "Authenticate with: gh auth login" >&2 ;;
+        *)      echo "Authenticate with: tea login add" >&2 ;;
+    esac
     exit 1
 fi
+
+echo -e "${BLUE}Forge provider:${NC} ${PROVIDER} (using ${FORGE_CLI})" >&2
 
 # Get current branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -71,8 +101,8 @@ if [ "$CURRENT_BRANCH" = "HEAD" ]; then
     exit 1
 fi
 
-# Get default branch (usually main or master)
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+# Get default branch (usually main or master) — provider-neutral
+DEFAULT_BRANCH=$(forge_default_branch "$PROVIDER")
 
 # Check if branch exists on remote
 if ! git ls-remote --exit-code --heads origin "$CURRENT_BRANCH" &> /dev/null; then
@@ -219,8 +249,13 @@ echo ""
 if [ "$MODE" = "analyze" ]; then
     echo -e "${BLUE}=== Analysis Complete ===${NC}\n"
     echo "To create PR:"
-    echo "  Regular: gh pr create --web"
-    echo "  Draft:   gh pr create --draft --web"
+    if [ "$PROVIDER" = "github" ]; then
+        echo "  Regular: gh pr create --web"
+        echo "  Draft:   gh pr create --draft --web"
+    else
+        echo "  Regular: tea pull create --head $CURRENT_BRANCH --base $DEFAULT_BRANCH"
+        echo "  (Forgejo/Gitea: 'tea' has no --draft or --web; open the PR in the web UI to mark it draft)"
+    fi
     exit 0
 fi
 
@@ -228,13 +263,22 @@ fi
 echo -e "${BLUE}=== Creating Pull Request ===${NC}\n"
 
 # Check if PR already exists
-EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+if [ "$PROVIDER" = "github" ]; then
+    EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+else
+    # tea pull list — match the head branch column; best-effort across tea versions
+    EXISTING_PR=$(tea pull list --output simple 2>/dev/null | grep -F "$CURRENT_BRANCH" | grep -oE '^#?[0-9]+' | head -n1 | tr -d '#' || echo "")
+fi
 
 if [ -n "$EXISTING_PR" ]; then
     echo -e "${YELLOW}⚠ PR already exists for this branch: #$EXISTING_PR${NC}"
     echo ""
-    echo "View PR: gh pr view $EXISTING_PR"
-    echo "Edit PR: gh pr edit $EXISTING_PR"
+    if [ "$PROVIDER" = "github" ]; then
+        echo "View PR: gh pr view $EXISTING_PR"
+        echo "Edit PR: gh pr edit $EXISTING_PR"
+    else
+        echo "View PR: tea pull $EXISTING_PR"
+    fi
     exit 1
 fi
 
@@ -309,32 +353,58 @@ Closes #
 echo "Creating PR..."
 echo ""
 
-if [ "$DRAFT" = true ]; then
-    set +e
-    gh pr create \
-        --title "$PR_TITLE" \
-        --body "$PR_DESCRIPTION" \
-        --draft \
-        --web
-    rc=$?
-    set -e
+if [ "$PROVIDER" = "github" ]; then
+    if [ "$DRAFT" = true ]; then
+        set +e
+        gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_DESCRIPTION" \
+            --draft \
+            --web
+        rc=$?
+        set -e
 
-    if [ $rc -eq 0 ]; then
-        echo ""
-        echo -e "${GREEN}✓ Draft PR created successfully${NC}"
-        echo ""
-        echo "Mark ready when complete: gh pr ready"
+        if [ $rc -eq 0 ]; then
+            echo ""
+            echo -e "${GREEN}✓ Draft PR created successfully${NC}"
+            echo ""
+            echo "Mark ready when complete: gh pr ready"
+        else
+            echo ""
+            echo -e "${RED}✗ Failed to create PR${NC}"
+            exit 1
+        fi
     else
-        echo ""
-        echo -e "${RED}✗ Failed to create PR${NC}"
-        exit 1
+        set +e
+        gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_DESCRIPTION" \
+            --web
+        rc=$?
+        set -e
+
+        if [ $rc -eq 0 ]; then
+            echo ""
+            echo -e "${GREEN}✓ PR created successfully${NC}"
+        else
+            echo ""
+            echo -e "${RED}✗ Failed to create PR${NC}"
+            exit 1
+        fi
     fi
 else
+    # Forgejo / Gitea via tea. No --draft or --web support; create directly.
+    if [ "$DRAFT" = true ]; then
+        echo -e "${YELLOW}⚠ 'tea' does not support draft PRs; creating a normal PR.${NC}" >&2
+        echo "  Mark it draft in the ${PROVIDER} web UI if needed." >&2
+        echo ""
+    fi
     set +e
-    gh pr create \
+    tea pull create \
         --title "$PR_TITLE" \
-        --body "$PR_DESCRIPTION" \
-        --web
+        --description "$PR_DESCRIPTION" \
+        --head "$CURRENT_BRANCH" \
+        --base "$DEFAULT_BRANCH"
     rc=$?
     set -e
 

--- a/.cursor-plugin/skills/pr-autofix/SKILL.md
+++ b/.cursor-plugin/skills/pr-autofix/SKILL.md
@@ -44,6 +44,16 @@ Vendor-neutral counterpart to `coderabbit:autofix`. Pulls **every** comment surf
 **Golden rule**: Never mutate a comment body. Reply with the result, then resolve. The audit trail lives in the PR threads, not in this skill's report file.
 
 > Sister skills: `/review-fix` consumes `/code-review` artifacts (review-finding ID + Status fields). `/pr-autofix` (this) consumes GitHub PR comments directly. The two cover different inputs but share the per-finding agent dispatch model and the CI auto-fix loop.
+>
+> **GitHub-only.** This skill is GitHub-only. Forgejo/Gitea expose only the REST
+> v1 API — no GraphQL `resolveReviewThread`, no review-thread resolution, no
+> per-comment harvesting — and the CI loop depends on `gh run` controls. There
+> is no `tea` equivalent for any of these, so the workflow cannot degrade to a
+> partial mode here. Phase 0 detects the provider; on a non-`github` remote it
+> tells the user the skill is GitHub-only and **why**, then stops gracefully.
+> See [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+> (capability matrix: "Review-thread resolution", "Per-comment PR autofix
+> harvesting", "CI-autofix loop").
 
 ---
 
@@ -100,10 +110,21 @@ gh pr view "$PR_NUMBER" --json number,headRefName,baseRefName,headRepositoryOwne
 
 Record `HEAD_BRANCH`, `BASE_BRANCH`, `STATE`.
 
+### Provider detection
+
+Before the GitHub checks below, detect the forge provider on `origin` per
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+(`forge_detect_provider origin`). If the provider is **not** `github`, stop
+gracefully: "`/pr-autofix` is GitHub-only. Provider `<provider>` lacks the
+GraphQL review-thread resolution and per-comment harvesting this skill requires
+(Forgejo/Gitea expose only the REST v1 API). Resolve threads in the `<provider>`
+UI, or use local review tooling." Do not proceed to FETCH.
+
 ### Preflight refusals
 
 | Check                              | Action on failure                                                                                                  |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Provider is `github`               | Stop: GitHub-only (see Provider detection above).                                                                  |
 | `gh auth status` succeeds          | Stop: "Run `gh auth login` first."                                                                                 |
 | `STATE == "OPEN"`                  | Stop: "PR #<N> is <state>; nothing to autofix."                                                                    |
 | `HEAD_BRANCH != $(default-branch)` | Stop: "Refusing: PR head equals the default branch." (Same constraint as `ci-monitor.sh` — never push to default.) |
@@ -385,6 +406,8 @@ Track closure results in the status map: `closed_ok`, `closed_failed`, `reply_on
 **Trigger**: `--ci` was passed AND at least one fixer returned `Fixed` AND the push in Phase 5 succeeded. Skip silently otherwise.
 
 This phase is a thin wrapper over the same loop used by `/prp-pr` Phase 7 and `/git-workflow` Phase 6. **The policy lives in `${CURSOR_PLUGIN_ROOT}/skills/_shared/references/ci-monitoring.md` — do not restate it here.**
+
+The `--ci` loop is GitHub-only (it depends on `gh run` controls); since this entire skill is already gated to `github` in Phase 0, the loop never reaches a non-GitHub remote. If `ci-monitor.sh` ever returns `RESULT=unsupported-provider`, treat it like the other non-loop terminal results below: surface it and exit.
 
 ### Step 1 — Authorization prompt (skip if `--ci-yes`)
 

--- a/.cursor-plugin/skills/pr-autofix/scripts/fetch-pr-comments.sh
+++ b/.cursor-plugin/skills/pr-autofix/scripts/fetch-pr-comments.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # fetch-pr-comments.sh — Fetch all actionable PR comments via GitHub GraphQL
 #
+# GitHub-only. Forgejo/Gitea are unsupported: they expose no GraphQL API, so
+# review-thread harvesting cannot be replicated. On a non-GitHub remote this
+# script emits a uniform unsupported notice and exits 2.
+#
 # Purpose:
 #   Single-source fetcher used by pr-autofix. Pulls every actionable
 #   comment surface on a PR — review threads (file/line anchored) and
@@ -36,12 +40,21 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
   fetch-pr-comments.sh --pr <number> --out <file> [--owner <owner>] [--repo <repo>]
   fetch-pr-comments.sh --help
   fetch-pr-comments.sh --version
+
+GitHub-only. Forgejo/Gitea are unsupported (no GraphQL API); on a non-GitHub
+remote this script prints an unsupported notice and exits 2.
 
 Options:
   --pr <number>     PR number to fetch comments for (required)
@@ -133,6 +146,18 @@ for dep in gh jq; do
     exit 1
   fi
 done
+
+# ---------------------------------------------------------------------------
+# Forge provider gate (GitHub-only feature)
+# ---------------------------------------------------------------------------
+# Review-thread harvesting uses the GitHub GraphQL API. Forgejo/Gitea have no
+# GraphQL API, so detect the provider before any gh call and degrade gracefully.
+
+PROVIDER="$(forge_detect_provider origin)"
+if [[ "$PROVIDER" != "github" ]]; then
+  forge_unsupported_notice "$PROVIDER" "PR review-comment harvesting"
+  exit 2
+fi
 
 if ! gh auth status >/dev/null 2>&1; then
   printf 'fetch-pr-comments.sh: gh not authenticated. Run `gh auth login`.\n' >&2

--- a/.cursor-plugin/skills/pr-autofix/scripts/post-summary.sh
+++ b/.cursor-plugin/skills/pr-autofix/scripts/post-summary.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # post-summary.sh — Post a single consolidated summary comment on a PR
 #
+# GitHub-only. Forgejo/Gitea are unsupported: this script is part of the
+# GraphQL-driven pr-autofix flow and posts via `gh`. On a non-GitHub remote it
+# emits a uniform unsupported notice and exits 2 (the --dry-run render still
+# works on any provider).
+#
 # Purpose:
 #   At the end of a pr-autofix run, render and post one summary comment to
 #   the PR conversation. Built only from local counters — never echoes raw
@@ -34,12 +39,22 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
   post-summary.sh --pr <number> --fixed <N> --failed <N> --skipped <N> --deferred <N> \
                   --commit-sha <sha> --branch <name> \
                   [--ci-result <value>] [--ci-iterations <N>] [--ci-pushes <N>] [--dry-run]
+
+GitHub-only. Forgejo/Gitea are unsupported (part of the GraphQL-driven autofix
+flow); on a non-GitHub remote this script prints an unsupported notice and exits
+2. The --dry-run render works on any provider.
 
 Exit codes:
   0  success (or skipped as no-op)
@@ -182,6 +197,19 @@ ${body_footer}"
 if [[ "$DRY_RUN" == "true" ]]; then
   printf '%s\n' "$BODY"
   exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Forge provider gate (GitHub-only feature)
+# ---------------------------------------------------------------------------
+# This script posts via `gh` as part of the GraphQL-driven pr-autofix flow.
+# Detect the provider before the gh-auth check so a non-GitHub remote gets the
+# honest "GitHub-only" message instead of a confusing auth error.
+
+PROVIDER="$(forge_detect_provider origin)"
+if [[ "$PROVIDER" != "github" ]]; then
+  forge_unsupported_notice "$PROVIDER" "PR summary posting"
+  exit 2
 fi
 
 if ! command -v gh >/dev/null 2>&1; then

--- a/.cursor-plugin/skills/pr-autofix/scripts/resolve-thread.sh
+++ b/.cursor-plugin/skills/pr-autofix/scripts/resolve-thread.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # resolve-thread.sh — Mutate PR review threads and conversation comments
 #
+# GitHub-only. Forgejo/Gitea are unsupported: review-thread resolution and emoji
+# reactions require the GitHub GraphQL API (resolveReviewThread, addReaction),
+# which has no Forgejo/Gitea equivalent. On a non-GitHub remote this script emits
+# a uniform unsupported notice and exits 2.
+#
 # Purpose:
 #   Wraps the four mutations pr-autofix needs to close out comments:
 #     resolve      — resolveReviewThread(threadId) via GraphQL
@@ -35,6 +40,12 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -45,6 +56,10 @@ Usage:
 
   resolve-thread.sh --help
   resolve-thread.sh --version
+
+GitHub-only. Forgejo/Gitea are unsupported (no GraphQL API for review-thread
+resolution or reactions); on a non-GitHub remote this script prints an
+unsupported notice and exits 2.
 
 Reaction values:
   THUMBS_UP THUMBS_DOWN LAUGH HOORAY CONFUSED HEART ROCKET EYES
@@ -177,6 +192,7 @@ main() {
     exit 1
   fi
 
+  # Handle help/version before any forge or auth checks so they work anywhere.
   case "$1" in
     --help|-h)
       usage
@@ -186,6 +202,28 @@ main() {
       printf 'resolve-thread.sh %s\n' "$VERSION"
       exit 0
       ;;
+  esac
+
+  # -------------------------------------------------------------------------
+  # Forge provider gate (GitHub-only feature)
+  # -------------------------------------------------------------------------
+  # resolveReviewThread/addReaction are GraphQL-only. Forgejo/Gitea have no
+  # GraphQL API, so detect the provider and short-circuit before the gh-auth
+  # check so a non-GitHub remote gets the honest "GitHub-only" message.
+
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "PR review-thread resolution"
+    exit 2
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    printf 'resolve-thread.sh: gh not authenticated. Run `gh auth login`.\n' >&2
+    exit 2
+  fi
+
+  case "$1" in
     resolve)
       shift
       cmd_resolve "$@"
@@ -209,10 +247,5 @@ main() {
       ;;
   esac
 }
-
-if ! gh auth status >/dev/null 2>&1; then
-  printf 'resolve-thread.sh: gh not authenticated. Run `gh auth login`.\n' >&2
-  exit 2
-fi
 
 main "$@"

--- a/.cursor-plugin/skills/prp-pr/SKILL.md
+++ b/.cursor-plugin/skills/prp-pr/SKILL.md
@@ -173,12 +173,27 @@ Use this default format:
 
 ### Create the PR
 
+PR creation is provider-aware. Detect the forge provider on `origin` first
+(`forge_detect_provider origin`) and route through the matching CLI: `gh pr
+create` for `github`, `tea pull create --title --description [--head]` for
+`forgejo`/`gitea`. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the operation-equivalence map. Log the resolved provider + CLI so the user
+sees which forge the PR targeted.
+
 ```bash
+# github
 gh pr create \
   --title "<PR title>" \
   --base <base-branch> \
   --body "<PR body>"
   # Add --draft if the --draft flag was parsed from $ARGUMENTS
+
+# forgejo / gitea
+tea pull create \
+  --title "<PR title>" \
+  --base <base-branch> \
+  --description "<PR body>"
 ```
 
 ---
@@ -233,6 +248,13 @@ were printed (otherwise `n/a`).
 **Trigger:** Runs ONLY when `--ci` was passed AND a PR is in scope (created in
 Phase 4, or an existing PR confirmed for monitoring per the Phase 1 modification
 above). Skip silently otherwise.
+
+**GitHub-only:** The CI auto-fix loop is GitHub-only (it depends on `gh run`
+controls). On a non-GitHub remote `ci-monitor.sh` returns
+`RESULT=unsupported-provider` (exit 2). Treat this like
+`pr-not-found`/`refused-default-branch`: report that the loop is GitHub-only and
+skip it cleanly — do not retry, do not error. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 
 **Step 1 — Verify PR is monitorable:** Confirm a PR number is in scope. If not,
 hard-stop: `--ci was passed but no PR is in scope to monitor.`
@@ -294,6 +316,7 @@ Branch on stdout `RESULT=...` per the Loop Protocol in `ci-monitoring.md`:
   goto Step 5 (do NOT apply any fix).
 - `bail-*` → Go to Step 6 (diagnosis). Do not push further.
 - `pr-not-found` / `refused-default-branch` → Surface the error; do not retry.
+- `unsupported-provider` → Remote is not GitHub; the CI auto-fix loop is GitHub-only. Report that the loop is GitHub-only and skip it cleanly; do not retry or treat as an error.
 
 **Step 6 — Final report:**
 

--- a/.cursor-plugin/skills/releaser/SKILL.md
+++ b/.cursor-plugin/skills/releaser/SKILL.md
@@ -280,6 +280,17 @@ If `--ci-config=generate` ran, append:
 # build the matrix and attach artifacts to the GitHub release.
 ```
 
+**Forge provider detection**: release creation is provider-aware.
+`publish-release.sh` detects the forge provider on `origin` first and routes
+through the matching CLI — `gh release create` for `github`, `tea release
+create --tag <tag> [--note-file]` for `forgejo`/`gitea` (per the
+operation-equivalence map). The `gh release create`/`gh release upload` commands
+emitted in the Phase 8 block above are the `github` path; on a `forgejo`/`gitea`
+remote the helper drives `tea release create` instead. Log the resolved provider
+
+- CLI. See
+  [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
+
 When the user passed `--publish[=create|edit|auto]`, after they review the rendered
 notes, run:
 
@@ -317,6 +328,15 @@ The contract (exit codes, `RESULT=` signaling, JSONL audit log, failure classifi
 signature dedup, default-branch refusal) mirrors `ci-monitor.sh` verbatim. See
 [`_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md),
 section "Release mode", for the single source of truth.
+
+**GitHub-only:** the release-CI auto-fix loop is GitHub-only — it depends on
+`gh run list`, `gh workflow run`, and `gh release` controls that have no `tea`
+equivalent. On a non-GitHub remote `release-ci-monitor.sh` returns
+`RESULT=unsupported-provider` (exit 2). Treat it like `not-found`: report that
+the loop is GitHub-only, render an 8.5.4-style diagnosis, and exit Phase 8.5
+cleanly without retrying. (Release _creation_ in Phase 8 remains provider-aware
+via `tea release create`; only this post-publish monitoring loop is gated.) See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 
 ### 8.5.0 Detect re-cut strategy
 
@@ -392,16 +412,17 @@ one human approval the bounded, destructive-capable loop depends on. Therefore:
 
 3. Branch on the exit code (identical contract to `ci-monitor.sh`):
 
-   | Exit | `RESULT=`         | Action                                                |
-   | ---- | ----------------- | ----------------------------------------------------- |
-   | 0    | `green`           | Success. Exit Phase 8.5, continue to Phase 9.         |
-   | 20   | `handoff`         | Step **8.5.3** (fix and re-cut), then loop to step 2. |
-   | 21   | `rerun-pending`   | `sleep 30`, then loop to step 2 (no fix applied).     |
-   | 10   | `bail-recurrence` | Step **8.5.4** (diagnosis), exit Phase 8.5.           |
-   | 11   | `bail-nonfixable` | Step **8.5.4**, exit Phase 8.5.                       |
-   | 12   | `bail-pushes`     | Step **8.5.4**, exit Phase 8.5.                       |
-   | 13   | `bail-timeout`    | Step **8.5.4**, exit Phase 8.5.                       |
-   | 2    | `not-found`       | Step **8.5.4**, exit Phase 8.5.                       |
+   | Exit | `RESULT=`              | Action                                                                     |
+   | ---- | ---------------------- | -------------------------------------------------------------------------- |
+   | 0    | `green`                | Success. Exit Phase 8.5, continue to Phase 9.                              |
+   | 20   | `handoff`              | Step **8.5.3** (fix and re-cut), then loop to step 2.                      |
+   | 21   | `rerun-pending`        | `sleep 30`, then loop to step 2 (no fix applied).                          |
+   | 10   | `bail-recurrence`      | Step **8.5.4** (diagnosis), exit Phase 8.5.                                |
+   | 11   | `bail-nonfixable`      | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 12   | `bail-pushes`          | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 13   | `bail-timeout`         | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 2    | `not-found`            | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 2    | `unsupported-provider` | Remote is not GitHub; loop is GitHub-only. Step **8.5.4**, exit Phase 8.5. |
 
 ### 8.5.3 Fix and re-cut on handoff
 

--- a/.cursor-plugin/skills/releaser/scripts/publish-release.sh
+++ b/.cursor-plugin/skills/releaser/scripts/publish-release.sh
@@ -1,14 +1,29 @@
 #!/usr/bin/env bash
-# publish-release.sh — Publish or update a GitHub release for a given tag.
+# publish-release.sh — Publish or update a release for a given tag.
+#
+# Provider-aware: routes through the CLI that matches the detected forge.
+#   github          → gh release create/edit  (behavior unchanged)
+#   forgejo / gitea → tea release create/edit
+#   gitlab / unknown→ release creation is not supported here; exits 1 with the
+#                     manual command to run.
 #
 # Usage:
 #   publish-release.sh [--mode=create|edit|auto] [--confirm] <tag> <notes-file>
 #
-# By default (no --confirm) prints the resolved gh command and exits 0.
+# By default (no --confirm) prints the resolved command and exits 0.
 # With --confirm the resolved command is executed.
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# --- forge detection -------------------------------------------------------
+# Detect the forge provider and select the matching CLI (gh / tea). Prefer the
+# plugin-root install path; fall back to the source-tree relative path.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
 
 # --- diagnostic helpers ---
 fail()  { echo "${SCRIPT_NAME}: FAIL: $*" >&2; }
@@ -19,8 +34,9 @@ usage() {
     cat <<EOF
 Usage: ${SCRIPT_NAME} [options] <tag> <notes-file>
 
-Publish (create or update) a GitHub release for <tag> using <notes-file> as
-the release body.
+Publish (create or update) a release for <tag> using <notes-file> as the
+release body. The forge provider is auto-detected from origin (GitHub via gh,
+Forgejo/Gitea via tea).
 
 Arguments:
   <tag>          Git tag (e.g. v1.4.0 or 1.4.0 — normalised to v-prefix if semver)
@@ -30,16 +46,18 @@ Options:
   --mode=create  Create a new release (fails if release already exists)
   --mode=edit    Edit an existing release (fails if release does not exist)
   --mode=auto    Auto-detect: create if missing, edit if present (default)
-  --confirm      Actually run the resolved gh command (default: print only)
+  --confirm      Actually run the resolved command (default: print only)
   -h, --help     Show this help
 
 Print-only mode (no --confirm):
-  Prints the exact gh command that would be run, then exits 0. gh is NOT called.
+  Prints the exact command that would be run, then exits 0. The forge CLI is
+  NOT called.
 
 Authentication:
-  In --mode=auto, gh auth status is checked. If unauthenticated, the script
-  exits 1 with a warning. In --mode=create or --mode=edit, gh itself will
-  surface authentication errors when --confirm is used.
+  In --mode=auto, the detected forge CLI's auth state is checked. If
+  unauthenticated, the script exits 1 with a warning. In --mode=create or
+  --mode=edit, the CLI itself surfaces authentication errors when --confirm
+  is used.
 
 Examples:
   # Preview what would be run for tag v1.4.0:
@@ -144,22 +162,67 @@ if ! git show-ref --verify --quiet "refs/tags/${TAG}"; then
     exit 1
 fi
 
-# --- gh authentication check (auto mode only) ---
+# --- provider routing -------------------------------------------------------
+# Resolve the forge provider for origin and reject providers this script cannot
+# create releases for. github keeps its exact prior semantics; forgejo/gitea
+# route through tea; gitlab/unknown exit with the manual command.
+PROVIDER="$(forge_detect_provider origin)"
+FORGE_CLI="$(forge_cli "${PROVIDER}")"
+
+case "${PROVIDER}" in
+    github|forgejo|gitea)
+        ;;  # supported for release create/edit
+    gitlab)
+        fail "GitLab release creation is not supported by this script"
+        hint "create the release manually: glab release create ${TAG} --notes-file ${NOTES_FILE}"
+        exit 1
+        ;;
+    *)
+        fail "could not determine the forge provider for 'origin'"
+        hint "origin = $(forge_remote_url origin)"
+        hint "supported: GitHub (gh), Forgejo/Gitea (tea)"
+        exit 1
+        ;;
+esac
+
+# --- forge CLI availability check ---
+if ! command -v "${FORGE_CLI}" >/dev/null 2>&1; then
+    fail "${FORGE_CLI} CLI (for ${PROVIDER}) is not installed"
+    case "${PROVIDER}" in
+        github) hint "install gh:  https://github.com/cli/cli#installation" ;;
+        *)      hint "install tea: https://gitea.com/gitea/tea#installation" ;;
+    esac
+    exit 1
+fi
+
+# --- authentication check (auto mode only) ---
 if [[ "${MODE}" == "auto" ]]; then
-    if ! gh auth status >/dev/null 2>&1; then
-        warn "gh not authenticated; cannot determine release state — re-run with explicit --mode=create or --mode=edit"
+    if ! forge_auth_ok "${PROVIDER}"; then
+        warn "${FORGE_CLI} not authenticated (${PROVIDER}); cannot determine release state — re-run with explicit --mode=create or --mode=edit"
+        case "${PROVIDER}" in
+            github) hint "authenticate with: gh auth login" ;;
+            *)      hint "authenticate with: tea login add" ;;
+        esac
         exit 1
     fi
 fi
 
 # --- release existence detection ---
-# Always probe GitHub (including --mode=create) so create-mode can detect an
-# existing release and suggest --mode=edit instead of failing later on gh.
+# Always probe the forge (including --mode=create) so create-mode can detect an
+# existing release and suggest --mode=edit instead of failing later in the CLI.
 RELEASE_JSON=""
 RELEASE_EXISTS=0
-RELEASE_JSON="$(gh release view "${TAG}" --json url,tagName,body 2>/dev/null || true)"
-if [[ -n "${RELEASE_JSON}" ]]; then
-    RELEASE_EXISTS=1
+if [[ "${PROVIDER}" == "github" ]]; then
+    RELEASE_JSON="$(gh release view "${TAG}" --json url,tagName,body 2>/dev/null || true)"
+    if [[ -n "${RELEASE_JSON}" ]]; then
+        RELEASE_EXISTS=1
+    fi
+else
+    # tea has no per-tag "view"; list releases as JSON and match the tag_name.
+    if tea release list --output json 2>/dev/null \
+        | grep -qE "\"tag_name\"[[:space:]]*:[[:space:]]*\"${TAG}\""; then
+        RELEASE_EXISTS=1
+    fi
 fi
 
 # --- mode conflict checks ---
@@ -186,10 +249,22 @@ case "${MODE}" in
 esac
 
 # --- build resolved command ---
-if [[ "${MODE}" == "create" ]]; then
-    RESOLVED_CMD="gh release create $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}") --title $(printf '%q' "${TAG}") --verify-tag"
+# github keeps its prior gh commands verbatim. tea (forgejo/gitea) uses
+# `tea release create --note-file` for create, but `tea release edit` has no
+# --note-file in 0.14.x, so edit passes the notes inline via --note.
+if [[ "${PROVIDER}" == "github" ]]; then
+    if [[ "${MODE}" == "create" ]]; then
+        RESOLVED_CMD="gh release create $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}") --title $(printf '%q' "${TAG}") --verify-tag"
+    else
+        RESOLVED_CMD="gh release edit $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}")"
+    fi
 else
-    RESOLVED_CMD="gh release edit $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}")"
+    if [[ "${MODE}" == "create" ]]; then
+        RESOLVED_CMD="tea release create --tag $(printf '%q' "${TAG}") --title $(printf '%q' "${TAG}") --note-file $(printf '%q' "${NOTES_FILE}")"
+    else
+        # `tea release edit` lacks --note-file; pass the notes file inline.
+        RESOLVED_CMD="tea release edit $(printf '%q' "${TAG}") --note \"\$(cat $(printf '%q' "${NOTES_FILE}"))\""
+    fi
 fi
 
 # --- print-only mode (no --confirm) ---
@@ -200,14 +275,28 @@ fi
 
 # --- confirm mode: warn before destructive edit ---
 if [[ "${MODE}" == "edit" ]]; then
-    existing_body="$(printf '%s' "${RELEASE_JSON}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("body","") or "")' 2>/dev/null || true)"
-    warn "about to overwrite release body for ${TAG}. Current body:"
-    printf '%s\n' "---" "${existing_body}" "---" >&2
+    if [[ "${PROVIDER}" == "github" ]]; then
+        existing_body="$(printf '%s' "${RELEASE_JSON}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("body","") or "")' 2>/dev/null || true)"
+        warn "about to overwrite release body for ${TAG}. Current body:"
+        printf '%s\n' "---" "${existing_body}" "---" >&2
+    else
+        warn "about to overwrite release notes for ${TAG} on ${PROVIDER}."
+    fi
 fi
 
 # --- execute ---
-if [[ "${MODE}" == "create" ]]; then
-    gh release create "${TAG}" --notes-file "${NOTES_FILE}" --title "${TAG}" --verify-tag
+if [[ "${PROVIDER}" == "github" ]]; then
+    if [[ "${MODE}" == "create" ]]; then
+        gh release create "${TAG}" --notes-file "${NOTES_FILE}" --title "${TAG}" --verify-tag
+    else
+        gh release edit "${TAG}" --notes-file "${NOTES_FILE}"
+    fi
 else
-    gh release edit "${TAG}" --notes-file "${NOTES_FILE}"
+    if [[ "${MODE}" == "create" ]]; then
+        tea release create --tag "${TAG}" --title "${TAG}" --note-file "${NOTES_FILE}"
+    else
+        # `tea release edit` lacks --note-file; read the notes file inline.
+        NOTES_BODY="$(cat "${NOTES_FILE}")"
+        tea release edit "${TAG}" --note "${NOTES_BODY}"
+    fi
 fi

--- a/.cursor-plugin/skills/research-to-issues/SKILL.md
+++ b/.cursor-plugin/skills/research-to-issues/SKILL.md
@@ -33,6 +33,22 @@ Parse arguments:
 
 ## Tool Preference Strategy
 
+### Step 0a: Detect forge provider
+
+Issue creation is provider-aware. Detect the forge provider on `origin` first
+(`forge_detect_provider origin`) and route through the matching CLI:
+`gh issue create --title --body` for `github`, `tea issues create --title
+--description` for `forgejo`/`gitea`. `validate-prerequisites.sh` runs the same
+detection and gates the per-provider issue prerequisites. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the operation-equivalence map. Log the resolved provider + CLI.
+
+**Forgejo/Gitea caveats**: repo-slug resolution (`gh repo view`) and some label
+operations (`gh label create`) are `gh`-only and have no `tea` equivalent — skip
+them on `forgejo`/`gitea` (create labels via the Forgejo/Gitea UI, and bind
+`tea` to the `origin`-bound repo rather than resolving an owner/name slug). The
+GitHub MCP path below applies only to `github`.
+
 ### Step 0: Detect GitHub MCP Server
 
 Check if GitHub MCP tools are available by looking for tools matching `mcp__github__*`.

--- a/.cursor-plugin/skills/research-to-issues/scripts/validate-prerequisites.sh
+++ b/.cursor-plugin/skills/research-to-issues/scripts/validate-prerequisites.sh
@@ -14,13 +14,21 @@ set -euo pipefail
 # Auto-detects type from path/content if --type is not specified.
 #
 # Checks:
-#   1. gh CLI is installed and authenticated
-#   2. Current directory is a git repo with a GitHub remote
+#   1. The forge CLI for the detected provider is installed and authenticated
+#      (gh for GitHub, tea for Forgejo/Gitea)
+#   2. Current directory is a git repo on a supported forge
 #   3. Source path exists and matches expected structure
 #
 # Exit codes:
 #   0 = all prerequisites met
 #   1 = missing prerequisite
+
+# Detect the forge provider and select the matching CLI (gh / tea).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CURSOR_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
 
 SOURCE_PATH="${1:-}"
 EXPLICIT_TYPE=""
@@ -41,35 +49,60 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# --- Check gh CLI ---
-if ! command -v gh &>/dev/null; then
-  ERRORS+=("ERROR: GitHub CLI (gh) is not installed. Install: https://cli.github.com/")
-else
-  if ! gh auth status &>/dev/null 2>&1; then
-    ERRORS+=("ERROR: GitHub CLI is not authenticated. Run: gh auth login")
-  else
-    echo "OK: gh CLI installed and authenticated"
-  fi
-fi
-
-# --- Check git repo with GitHub remote ---
+# --- Check git repo and detect forge provider ---
+PROVIDER="unknown"
+FORGE_CLI=""
 if ! git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
   ERRORS+=("ERROR: Not inside a git repository")
 else
   REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
   if [[ -z "$REMOTE_URL" ]]; then
     ERRORS+=("ERROR: No 'origin' remote configured")
-  elif [[ "$REMOTE_URL" != *"github.com"* && "$REMOTE_URL" != *"github:"* ]]; then
-    ERRORS+=("WARNING: Remote may not be GitHub: $REMOTE_URL")
   else
-    REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
-    if [[ -n "$REPO" ]]; then
-      echo "OK: GitHub repo detected: $REPO"
-    else
-      ERRORS+=("ERROR: Could not determine GitHub repo from remote")
-    fi
+    PROVIDER="$(forge_detect_provider origin)"
+    FORGE_CLI="$(forge_cli "$PROVIDER")"
+
+    case "$PROVIDER" in
+      github|forgejo|gitea)
+        echo "OK: Forge provider detected: $PROVIDER (using $FORGE_CLI)"
+        ;;
+      gitlab|unknown)
+        ERRORS+=("ERROR: Issue creation requires GitHub (gh) or Forgejo/Gitea (tea); detected provider '$PROVIDER' (origin: $REMOTE_URL) is not supported")
+        ;;
+    esac
   fi
 fi
+
+# --- Check the matching forge CLI is installed and authenticated ---
+case "$PROVIDER" in
+  github|forgejo|gitea)
+    if ! command -v "$FORGE_CLI" &>/dev/null; then
+      case "$PROVIDER" in
+        github) ERRORS+=("ERROR: GitHub CLI (gh) is not installed. Install: https://cli.github.com/") ;;
+        *)      ERRORS+=("ERROR: tea CLI (for $PROVIDER) is not installed. Install: https://gitea.com/gitea/tea#installation") ;;
+      esac
+    elif ! forge_auth_ok "$PROVIDER"; then
+      case "$PROVIDER" in
+        github) ERRORS+=("ERROR: GitHub CLI is not authenticated. Run: gh auth login") ;;
+        *)      ERRORS+=("ERROR: tea is not authenticated for $PROVIDER. Run: tea login add") ;;
+      esac
+    else
+      echo "OK: $FORGE_CLI CLI installed and authenticated"
+      # GitHub-only: confirm the repo slug resolves via the host API. tea v0.14
+      # has no clean equivalent, so this sub-check is skipped on Forgejo/Gitea.
+      if [[ "$PROVIDER" == "github" ]]; then
+        REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+        if [[ -n "$REPO" ]]; then
+          echo "OK: GitHub repo detected: $REPO"
+        else
+          ERRORS+=("ERROR: Could not determine GitHub repo from remote")
+        fi
+      else
+        echo "NOTICE: Skipping repo-slug resolution check (no clean tea equivalent on $PROVIDER)"
+      fi
+    fi
+    ;;
+esac
 
 # --- Check source path ---
 if [[ -z "$SOURCE_PATH" ]]; then

--- a/.cursor-plugin/skills/review-fix/SKILL.md
+++ b/.cursor-plugin/skills/review-fix/SKILL.md
@@ -871,6 +871,16 @@ ${CURSOR_PLUGIN_ROOT}/skills/_shared/references/goal-pairing.md
 
 ## Important Notes
 
+- **PR posting is GitHub-only**: The PR-coupled steps here use `gh` (resolving the
+  PR head via `gh pr view`, and the commit+push to the PR branch in worktree mode).
+  Those depend on GitHub plumbing that has no `tea` equivalent. Detect the forge
+  provider on `origin` (`forge_detect_provider origin`) before any `gh pr` call. On a
+  non-`github` provider, apply the fixes **locally** (Path A/B/C all edit files in the
+  working tree regardless of forge) and **skip the PR-posting step** with a notice:
+  "PR posting is GitHub-only on provider `<provider>`; fixes applied locally — commit
+  and push them yourself." Mark `REPORT_COMMITTED: n/a` in that case. The artifact
+  parse, filter, fix, Status updates, and Phase 5 validation are all provider-neutral.
+  See [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 - **In-place Status updates**: The source review file is the source of truth. This skill mutates it in place via `Edit`, updating only the `Status` line of each processed finding. All other content is preserved.
 - **No scope creep**: Each `review-fixer` agent is scope-disciplined — it fixes exactly what the finding specifies. If the fix reveals a larger issue, the agent reports it, but the skill does not chase down related problems.
 - **Resumable**: Re-running on the same review file skips already-processed findings.

--- a/.opencode-plugin/shared/references/ci-monitoring.md
+++ b/.opencode-plugin/shared/references/ci-monitoring.md
@@ -22,6 +22,27 @@ must not diverge from either.
 
 ---
 
+## Provider Support
+
+The CI-autofix loop is **GitHub-only**. Both `ci-monitor.sh` and
+`release-ci-monitor.sh` depend on `gh` run controls (`gh run view
+--log-failed`, `gh run rerun`, `gh run list`) that have no Forgejo/Gitea (`tea`)
+or GitLab (`glab`) equivalent. Before entering the loop the scripts detect the
+forge provider on the watched remote; on any non-GitHub remote they emit
+`RESULT=unsupported-provider` (exit 2) and do nothing else.
+
+The detection contract — provider values `github` / `forgejo` / `gitea` /
+`gitlab` / `unknown`, the `forge_detect_provider` / `forge_cli` law — lives in
+[`forge-detection.md`](forge-detection.md) (capability matrix: "CI-autofix loop
+(`--ci`)" is GitHub-only).
+
+**Skill loop handling:** treat `RESULT=unsupported-provider` exactly like
+`pr-not-found` / `refused-default-branch` — surface it directly and do **not**
+loop. State that the loop is GitHub-only, skip it cleanly, and never re-invoke
+the monitor. It is a terminal non-loop result, not an error to retry.
+
+---
+
 ## Trust Boundary
 
 `--ci` grants the following standing authorization for the duration of one skill
@@ -109,6 +130,7 @@ corresponding code.
 | `bail-timeout`           | 13        | Wall-clock ≥ `--ci-timeout-min`, or checks never registered              |
 | `pr-not-found`           | 2         | PR does not exist or is unreachable                                      |
 | `refused-default-branch` | 2         | Will not operate when head branch equals the default branch              |
+| `unsupported-provider`   | 2         | Remote is not GitHub; the CI-autofix loop is GitHub-only                 |
 
 Exit code 1 is reserved for argument/usage errors and never appears in the loop.
 
@@ -174,8 +196,10 @@ the skill.
      - The cap or constraint that fired
        Exit phase; do not push further.
 
-   - **`pr-not-found`** / **`refused-default-branch`** — surface the error
-     directly; do not enter the loop.
+   - **`pr-not-found`** / **`refused-default-branch`** / **`unsupported-provider`**
+     — surface the error directly; do not enter the loop. For
+     `unsupported-provider`, state that the CI-autofix loop is GitHub-only (see
+     the Provider Support section above) and skip it cleanly.
 
 ---
 

--- a/.opencode-plugin/shared/references/forge-detection.md
+++ b/.opencode-plugin/shared/references/forge-detection.md
@@ -1,0 +1,155 @@
+# Forge Provider Detection & Tooling Selection
+
+Single source of truth for how every git skill in the `ycc` bundle decides
+**which forge it is talking to** and **which CLI to drive**. Any skill that
+creates PRs, files issues, cuts releases, posts review comments, or watches CI
+must run this detection first and route accordingly.
+
+The programmatic counterpart is
+[`_shared/scripts/lib/forge.sh`](../scripts/lib/forge.sh) — a sourceable bash
+library that implements the detection law described here. Scripts source it;
+SKILL prose references this document. The two must never diverge.
+
+> **Why this exists.** The bundle was historically GitHub-only (`gh`
+> everywhere). Self-hosted **Forgejo** and **Gitea** repositories need the same
+> workflows driven through the `tea` CLI. Detection lets one skill serve both
+> without the user passing a `--provider` flag.
+
+---
+
+## Provider values
+
+| Provider  | Hosts                          | CLI    | Notes                                  |
+| --------- | ------------------------------ | ------ | -------------------------------------- |
+| `github`  | github.com, GitHub Enterprise  | `gh`   | Full feature support                   |
+| `forgejo` | self-hosted Forgejo            | `tea`  | Gitea fork; same tooling as `gitea`    |
+| `gitea`   | self-hosted Gitea              | `tea`  | Generic Gitea-family label             |
+| `gitlab`  | gitlab.com, self-hosted GitLab | `glab` | Pre-existing partial support           |
+| `unknown` | anything else                  | (none) | Skip host-API steps with a loud notice |
+
+`forgejo` and `gitea` are the **same tooling family** — both driven by `tea`.
+They are distinguished only for accurate user-facing messages. For command
+selection, treat them identically (`forge_cli` maps both to `tea`).
+
+---
+
+## Detection algorithm
+
+`forge_detect_provider [remote] [--probe]` (default remote: `origin`):
+
+1. Read `git remote get-url <remote>`. No remote → `unknown`.
+2. Extract the bare host from the URL (handles `git@host:owner/repo.git`,
+   `ssh://git@host:port/...`, `https://host/...`, `git://host/...`; strips a
+   trailing `.git`).
+3. **GitHub** if the host is `github.com` / `*.github.com`, equals `$GH_HOST`
+   or `$GITHUB_HOST`, or appears in `~/.config/gh/hosts.yml`.
+4. **GitLab** if the host is `gitlab.com` / `*.gitlab.com`, or appears in
+   `~/.config/glab-cli/config.yml`.
+5. **Gitea family** if the host matches a configured `tea login list` entry.
+   With `--probe`, a best-effort `GET https://<host>/api/v1/version` (plus the
+   Server header) distinguishes `forgejo` from `gitea`; offline, default to
+   `gitea`.
+6. With `--probe` and no local match, the `/api/v1/version` probe can still
+   classify an unconfigured Gitea/Forgejo host.
+7. Otherwise → `unknown`.
+
+Steps 3–4 and the `tea login list` read in step 5 are **local only** — no
+network, no rate-limit cost. The `/api/v1/version` probe in steps 5–6 is
+opt-in via `--probe` so default detection stays fast and offline-friendly.
+
+---
+
+## Auth probes (run once, cache the result)
+
+Never call the host API to check auth — use the local status commands:
+
+```bash
+# github
+command -v gh   >/dev/null && gh   auth status >/dev/null 2>&1   # → authed
+
+# forgejo / gitea  (tea has no `auth status`; a configured login is the signal)
+command -v tea  >/dev/null && tea login list 2>/dev/null | grep -q '://'
+
+# gitlab
+command -v glab >/dev/null && glab auth status >/dev/null 2>&1
+```
+
+The lib exposes these as `forge_auth_ok <provider>`. If the matched provider's
+CLI is missing or unauthenticated, surface a precise remediation (`gh auth
+login`, `tea login add`, `glab auth login`) and fall back to local-only mode
+rather than guessing.
+
+---
+
+## Operation equivalence map
+
+Core operations are supported on **both** families. Drive them through the CLI
+that `forge_cli <provider>` returns.
+
+| Operation             | GitHub (`gh`)                            | Forgejo / Gitea (`tea`)                          |
+| --------------------- | ---------------------------------------- | ------------------------------------------------ |
+| Default branch        | `gh repo view --json defaultBranchRef`   | `git symbolic-ref refs/remotes/origin/HEAD`      |
+| Create PR             | `gh pr create --title --body [--draft]`  | `tea pull create --title --description [--head]` |
+| PR for current branch | `gh pr list --head <branch>`             | `tea pull list` (filter by head branch)          |
+| View PR state         | `gh pr view <n> --json state`            | `tea pull <n>`                                   |
+| List open issues      | `gh issue list`                          | `tea issues list`                                |
+| Create issue          | `gh issue create --title --body`         | `tea issues create --title --description`        |
+| Close issue           | `gh issue close <n>`                     | `tea issues close <n>`                           |
+| Create release        | `gh release create <tag> [--notes-file]` | `tea release create --tag <tag> [--note-file]`   |
+| Delete remote branch  | `git push <remote> --delete <branch>`    | `git push <remote> --delete <branch>` (same)     |
+
+`tea` operates on the repo bound to the current directory's `origin` remote (it
+reads `.git/config`); pass `--repo owner/name` only when overriding.
+
+---
+
+## Capability matrix — GitHub-only features
+
+Some advanced features depend on APIs that **do not exist** on Forgejo/Gitea.
+These degrade gracefully: detect the provider, and on a non-GitHub remote emit
+`forge_unsupported_notice` and exit cleanly rather than faking parity.
+
+| Feature                              | GitHub | Forgejo / Gitea | Why                                                         |
+| ------------------------------------ | ------ | --------------- | ----------------------------------------------------------- |
+| PR / issue / release create + list   | ✅     | ✅              | Covered by `gh` and `tea`                                   |
+| Review-thread resolution (`resolve`) | ✅     | ❌              | Requires GraphQL `resolveReviewThread`; no GraphQL on Gitea |
+| Per-comment PR autofix harvesting    | ✅     | ❌              | `fetch-pr-comments.sh` uses the GitHub GraphQL API          |
+| CI-autofix loop (`--ci`)             | ✅     | ❌              | Depends on `gh run view --log-failed` / `gh run rerun`      |
+| Emoji reactions on comments          | ✅     | ❌              | GraphQL `addReaction`                                       |
+
+For ❌ features on a non-GitHub remote, the skill must:
+
+1. Detect the provider in its Phase 0.
+2. Tell the user the feature is GitHub-only and **why** (one line).
+3. Offer the manual alternative (e.g. "resolve the thread in the Forgejo UI").
+4. Continue with whatever **is** supported (e.g. still create the PR via `tea`),
+   skipping only the unsupported step.
+
+Never silently no-op and never pretend an unsupported step succeeded.
+
+---
+
+## Skill integration pattern (Phase 0)
+
+Every git-operation skill adds a detection step before any host call:
+
+```bash
+# shellcheck source=/dev/null
+source "~/.config/opencode/shared/scripts/lib/forge.sh"
+provider="$(forge_detect_provider origin)"
+cli="$(forge_cli "$provider")"
+forge_auth_ok "$provider" || { echo "Auth needed for $provider"; exit 2; }
+```
+
+Then branch on `$provider` for the operation, or call a script that does the
+branching internally. Log the resolved provider + CLI so the user sees which
+forge the workflow targeted.
+
+---
+
+## References
+
+- [`_shared/scripts/lib/forge.sh`](../scripts/lib/forge.sh) — the detection lib
+- [`git-cleanup/references/host-detection.md`](../../git-cleanup/references/host-detection.md)
+  — the older GitHub/GitLab host-detection notes this generalizes
+- [`ci-monitoring.md`](ci-monitoring.md) — CI-autofix loop (GitHub-only; gated here)

--- a/.opencode-plugin/shared/scripts/ci-monitor.sh
+++ b/.opencode-plugin/shared/scripts/ci-monitor.sh
@@ -38,6 +38,16 @@ VERSION="1.0.0"
 . "$(dirname "$0")/lib/ci-classify.sh"
 
 # ---------------------------------------------------------------------------
+# Forge provider detection (sourced)
+# ---------------------------------------------------------------------------
+# The CI-autofix loop depends on `gh run view --log-failed` / `gh run rerun`,
+# which have no Forgejo/Gitea equivalent. The loop is GitHub-only; on any other
+# provider this script exits early with RESULT=unsupported-provider.
+
+# shellcheck source=lib/forge.sh
+. "$(dirname "$0")/lib/forge.sh"
+
+# ---------------------------------------------------------------------------
 # Usage
 # ---------------------------------------------------------------------------
 
@@ -383,6 +393,18 @@ main() {
     log_jsonl "$log_file" "$ts" "$iteration" "$pr" "0" "" "success" "" "green" "$push_count" "" '"dry_run":true'
     printf 'RESULT=green\n'
     exit 0
+  fi
+
+  # -------------------------------------------------------------------------
+  # Step 0: Forge provider gate (GitHub-only feature)
+  # -------------------------------------------------------------------------
+
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "the --ci auto-fix loop"
+    printf 'RESULT=unsupported-provider\n'
+    exit 2
   fi
 
   # -------------------------------------------------------------------------

--- a/.opencode-plugin/shared/scripts/lib/forge.sh
+++ b/.opencode-plugin/shared/scripts/lib/forge.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# forge.sh — Git forge provider detection and tooling selection.
+#
+# Sourceable library. Sourcing it has NO side effects (no network, no writes,
+# no `set` changes that leak to the caller). Every consumer that talks to a
+# remote git host (GitHub / Forgejo / Gitea / GitLab) routes through these
+# helpers so a single detection law governs the whole bundle.
+#
+# Provider values returned by forge_detect_provider:
+#   github   — GitHub.com or GitHub Enterprise        → CLI: gh
+#   forgejo  — Forgejo instance (Gitea fork)          → CLI: tea
+#   gitea    — Gitea instance                          → CLI: tea
+#   gitlab   — GitLab.com or self-hosted GitLab        → CLI: glab
+#   unknown  — could not be determined                 → CLI: (none)
+#
+# `forgejo` and `gitea` are the same tooling family (both driven by `tea`);
+# they are distinguished only for accurate messaging. Treat them identically
+# for command selection — forge_cli maps both to `tea`.
+#
+# Contract: see _shared/references/forge-detection.md (single source of truth).
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+# forge_strip_git_suffix <url> — strip a trailing ".git".
+forge_strip_git_suffix() {
+  printf '%s' "${1%.git}"
+}
+
+# forge_remote_url [remote] — print the fetch URL for a remote (default origin).
+# Prints nothing and returns 1 if the remote does not exist.
+forge_remote_url() {
+  local remote="${1:-origin}"
+  git remote get-url "$remote" 2>/dev/null
+}
+
+# forge_host_from_url <url> — extract the bare hostname from an ssh, https, or
+# git:// remote URL. Handles:
+#   git@host:owner/repo.git
+#   ssh://git@host:22/owner/repo.git
+#   https://host/owner/repo.git
+#   git://host/owner/repo.git
+forge_host_from_url() {
+  local url="$1"
+  url="$(forge_strip_git_suffix "$url")"
+
+  case "$url" in
+    *://*)
+      # scheme://[user@]host[:port]/path
+      local rest="${url#*://}"
+      rest="${rest#*@}"      # drop optional user@
+      rest="${rest%%/*}"     # keep host[:port]
+      printf '%s' "${rest%%:*}"  # drop :port
+      ;;
+    *@*:*)
+      # scp-like: [user@]host:path
+      local rest="${url#*@}"
+      printf '%s' "${rest%%:*}"
+      ;;
+    *:*)
+      # host:path with no user
+      printf '%s' "${url%%:*}"
+      ;;
+    *)
+      printf '%s' "$url"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Configured-host probes (local only — no network)
+# ---------------------------------------------------------------------------
+
+# forge_host_is_github <host> — true if the host is GitHub.com, a configured
+# GH_HOST/GITHUB_HOST enterprise host, or listed in ~/.config/gh/hosts.yml.
+forge_host_is_github() {
+  local host="$1"
+  case "$host" in
+    github.com|*.github.com) return 0 ;;
+  esac
+  if [[ -n "${GH_HOST:-}" && "$host" == "${GH_HOST}" ]]; then return 0; fi
+  if [[ -n "${GITHUB_HOST:-}" && "$host" == "${GITHUB_HOST}" ]]; then return 0; fi
+  local hosts_yml="${HOME}/.config/gh/hosts.yml"
+  if [[ -f "$hosts_yml" ]] && grep -qE "^${host}:" "$hosts_yml" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# forge_host_is_gitlab <host> — true if GitLab.com or a configured glab host.
+forge_host_is_gitlab() {
+  local host="$1"
+  case "$host" in
+    gitlab.com|*.gitlab.com) return 0 ;;
+  esac
+  local glab_cfg="${HOME}/.config/glab-cli/config.yml"
+  if [[ -f "$glab_cfg" ]] && grep -qE "^[[:space:]]*${host}:" "$glab_cfg" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# forge_host_in_tea <host> — true if the host matches a configured `tea` login
+# (Gitea/Forgejo). Reads `tea login list` so no network call is made.
+forge_host_in_tea() {
+  local host="$1"
+  command -v tea >/dev/null 2>&1 || return 1
+  # `tea login list` prints a table containing the URL and SSH host columns.
+  tea login list 2>/dev/null | grep -qiF "$host"
+}
+
+# ---------------------------------------------------------------------------
+# Optional network probe — distinguishes Forgejo from Gitea, and confirms a
+# gitea-family host when no local config exists. Best-effort; never required.
+# ---------------------------------------------------------------------------
+
+# forge_probe_gitea_family <host> — echo "forgejo" or "gitea" if the host serves
+# the Gitea REST API, else echo nothing and return 1. Hits /api/v1/version,
+# which is public on virtually all instances.
+forge_probe_gitea_family() {
+  local host="$1"
+  command -v curl >/dev/null 2>&1 || return 1
+  local body
+  body="$(curl -fsSL --max-time 5 "https://${host}/api/v1/version" 2>/dev/null)" || return 1
+  # The version endpoint returns {"version":"..."}. Forgejo advertises itself in
+  # the Server header; fall back to assuming gitea for the bare version payload.
+  case "$body" in
+    *version*)
+      local server
+      server="$(curl -fsSLI --max-time 5 "https://${host}/api/v1/version" 2>/dev/null | tr -d '\r')"
+      if printf '%s' "$server" | grep -qi 'forgejo'; then
+        printf 'forgejo'
+      else
+        printf 'gitea'
+      fi
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Provider detection
+# ---------------------------------------------------------------------------
+
+# forge_detect_provider [remote] [--probe]
+#   Detect the forge provider for a remote (default origin).
+#   Pass --probe to allow the network /api/v1/version fallback (off by default
+#   so detection stays fast and offline-friendly).
+#   Echoes one of: github | forgejo | gitea | gitlab | unknown
+forge_detect_provider() {
+  local remote="origin" probe="false"
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --probe) probe="true" ;;
+      *) remote="$arg" ;;
+    esac
+  done
+
+  local url host
+  url="$(forge_remote_url "$remote")" || { printf 'unknown'; return 0; }
+  [[ -z "$url" ]] && { printf 'unknown'; return 0; }
+  host="$(forge_host_from_url "$url")"
+  [[ -z "$host" ]] && { printf 'unknown'; return 0; }
+
+  if forge_host_is_github "$host"; then printf 'github'; return 0; fi
+  if forge_host_is_gitlab "$host"; then printf 'gitlab'; return 0; fi
+  if forge_host_in_tea "$host"; then
+    if [[ "$probe" == "true" ]]; then
+      local fam
+      fam="$(forge_probe_gitea_family "$host")" && { printf '%s' "$fam"; return 0; }
+    fi
+    # tea is configured for this host but we can't tell Forgejo from Gitea
+    # offline — default to the generic family label.
+    printf 'gitea'
+    return 0
+  fi
+  if [[ "$probe" == "true" ]]; then
+    local fam
+    fam="$(forge_probe_gitea_family "$host")" && { printf '%s' "$fam"; return 0; }
+  fi
+  printf 'unknown'
+}
+
+# ---------------------------------------------------------------------------
+# Tooling selection
+# ---------------------------------------------------------------------------
+
+# forge_cli <provider> — echo the CLI binary name for a provider.
+#   github → gh, forgejo|gitea → tea, gitlab → glab, unknown → (empty)
+forge_cli() {
+  case "$1" in
+    github) printf 'gh' ;;
+    forgejo|gitea) printf 'tea' ;;
+    gitlab) printf 'glab' ;;
+    *) printf '' ;;
+  esac
+}
+
+# forge_is_gitea_family <provider> — true for forgejo or gitea.
+forge_is_gitea_family() {
+  case "$1" in
+    forgejo|gitea) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# forge_cli_available <provider> — true if the provider's CLI is installed.
+forge_cli_available() {
+  local cli
+  cli="$(forge_cli "$1")"
+  [[ -n "$cli" ]] && command -v "$cli" >/dev/null 2>&1
+}
+
+# forge_auth_ok <provider> — true if the provider's CLI is authenticated.
+# Uses only local auth-status checks (no API/rate-limit cost).
+forge_auth_ok() {
+  case "$1" in
+    github) command -v gh   >/dev/null 2>&1 && gh   auth status >/dev/null 2>&1 ;;
+    forgejo|gitea)
+      # `tea` has no `auth status`; a configured login list is the local signal.
+      command -v tea  >/dev/null 2>&1 && tea login list 2>/dev/null | grep -q '://'
+      ;;
+    gitlab) command -v glab >/dev/null 2>&1 && glab auth status >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# forge_default_branch <provider> — echo the repository default branch, or
+# fall back to "main". Provider-neutral.
+forge_default_branch() {
+  local provider="$1" b=""
+  case "$provider" in
+    github)
+      b="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null)"
+      ;;
+    forgejo|gitea)
+      # `tea repos search`/`tea` lacks a stable default-branch field across
+      # versions; infer from the remote HEAD instead.
+      b="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+      ;;
+    gitlab)
+      b="$(glab repo view --output json 2>/dev/null | grep -o '"default_branch":"[^"]*"' | head -n1 | sed 's/.*:"//;s/"//')"
+      ;;
+  esac
+  if [[ -z "$b" ]]; then
+    b="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+  fi
+  printf '%s' "${b:-main}"
+}
+
+# forge_unsupported_notice <provider> <feature> — print a uniform, honest
+# message to stderr when an advanced feature is GitHub-only. Returns 0 so the
+# caller controls the exit code.
+forge_unsupported_notice() {
+  local provider="$1" feature="$2"
+  printf '%s: %s is a GitHub-only feature; provider "%s" is not supported.\n' \
+    "${0##*/}" "$feature" "$provider" >&2
+  printf '  Reason: Forgejo/Gitea expose only the REST v1 API (no GraphQL) and\n' >&2
+  printf '  the tea CLI does not surface CI-run logs/rerun controls. Run this\n' >&2
+  printf '  feature on a GitHub remote, or do the action manually on %s.\n' "$provider" >&2
+}

--- a/.opencode-plugin/shared/scripts/release-ci-monitor.sh
+++ b/.opencode-plugin/shared/scripts/release-ci-monitor.sh
@@ -35,6 +35,11 @@ VERSION="1.0.0"
 # shellcheck source=lib/ci-classify.sh
 . "$(dirname "$0")/lib/ci-classify.sh"
 
+# Forge provider detection. The release CI-autofix loop depends on
+# `gh run` controls with no Forgejo/Gitea equivalent — GitHub-only.
+# shellcheck source=lib/forge.sh
+. "$(dirname "$0")/lib/forge.sh"
+
 # ---------------------------------------------------------------------------
 # Usage
 # ---------------------------------------------------------------------------
@@ -417,6 +422,15 @@ main() {
     log_jsonl "$log_file" "$ts" "$iteration" "$tag" "0" "" "success" "" "green" "$push_count" "" '"dry_run":true'
     printf 'RESULT=green\n'
     exit 0
+  fi
+
+  # Forge provider gate (GitHub-only feature).
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "the release --ci auto-fix loop"
+    printf 'RESULT=unsupported-provider\n'
+    exit 2
   fi
 
   # Workflow file must be resolvable in non-dry-run mode.

--- a/.opencode-plugin/skills/code-review/SKILL.md
+++ b/.opencode-plugin/skills/code-review/SKILL.md
@@ -321,6 +321,15 @@ write an artifact here — quick-review owns the artifact lifecycle.
 
 Comprehensive GitHub PR review — fetches diff, reads full files, runs validation, posts review.
 
+**GitHub-only.** PR mode is GitHub-only: it reads and posts on PRs through the
+`gh` PR/review plumbing (`gh pr view`/`gh pr diff`/`gh pr review` + the GitHub
+review-comments API), which has no `tea` equivalent. Detect the forge provider
+on `origin` first (`forge_detect_provider origin`); if it is **not** `github`,
+state that PR mode is GitHub-only and offer **Local Review Mode** instead
+(local-diff review works on any provider). Do not attempt the `gh` PR calls on a
+non-GitHub remote. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
+
 Detect whether GitHub MCP tools are available (look for `mcp__github__*`). If they are, prefer those for PR fetch/view/review operations. Otherwise fall back to the `gh` CLI examples shown below.
 
 ### Phase 1 — FETCH

--- a/.opencode-plugin/skills/git-cleanup/SKILL.md
+++ b/.opencode-plugin/skills/git-cleanup/SKILL.md
@@ -39,13 +39,21 @@ Parse `$ARGUMENTS`:
 1. **Verify working tree is a git repo**: `git rev-parse --git-dir`. Abort if not.
 2. **Determine default branch**: `git symbolic-ref refs/remotes/origin/HEAD` →
    fall back to `main` / `master` if unset.
-3. **Detect host CLIs and MCP tools**. See
-   `~/.config/opencode/skills/git-cleanup/references/host-detection.md` for
-   the full decision table. Summary:
+3. **Detect host CLIs and MCP tools**. Detection follows the bundle-wide
+   contract in
+   `~/.config/opencode/shared/references/forge-detection.md`
+   (`forge_detect_provider origin` → `github` / `forgejo` / `gitea` / `gitlab` /
+   `unknown`; `forge_cli` → `gh` / `tea` / `glab`); the git-cleanup-specific
+   operation map lives in
+   `~/.config/opencode/skills/git-cleanup/references/host-detection.md`.
+   Summary:
    - Prefer `mcp__github__*` tools if available for GitHub operations.
-   - Else `gh auth status` for GitHub, `glab auth status` for GitLab.
-   - If `--host=auto`, parse `git remote get-url origin`. Unknown hosts skip
-     the remote-domain audits with a loud notice.
+   - Else `gh auth status` for GitHub, `tea login list` for the Forgejo/Gitea
+     family, `glab auth status` for GitLab.
+   - If `--host=auto`, parse `git remote get-url origin` via the shared lib.
+     A Forgejo/Gitea remote (matched against `tea login list`) routes PR/issue
+     cleanup through `tea` (`tea pull list/close`, `tea issues list/close`).
+     Unknown hosts skip the remote-domain audits with a loud notice.
 4. **Check working-tree state**: Capture `git status --porcelain` and
    `git stash list`. Record whether the current branch has unpushed commits.
 5. **Initialize progress tracking** with the todo tracker (one entry per phase).

--- a/.opencode-plugin/skills/git-cleanup/references/host-detection.md
+++ b/.opencode-plugin/skills/git-cleanup/references/host-detection.md
@@ -1,5 +1,14 @@
 # Host Detection and Client Selection
 
+> **Canonical source of truth:** the bundle-wide forge-detection contract lives at
+> [`../../_shared/references/forge-detection.md`](../../_shared/references/forge-detection.md)
+> (provider values `github` / `forgejo` / `gitea` / `gitlab` / `unknown`; CLIs
+> `gh` / `tea` / `glab`; the `forge_detect_provider`, `forge_cli`, `forge_auth_ok`
+> detection law implemented in `_shared/scripts/lib/forge.sh`). Prefer that document
+> and library for detection. This file is the **git-cleanup-specific supplement**:
+> it maps the resolved provider to the concrete read/write cleanup operations this
+> skill performs. When the two disagree on detection, the canonical reference wins.
+
 Reference for Phase 0 of `.opencode-plugin/skills/git-cleanup/SKILL.md`. Given a repository,
 determine (1) which remote host the audit should query and (2) which client
 library / CLI / MCP server to use for each operation.
@@ -17,6 +26,12 @@ For GitLab repositories, pick the first available:
 1. **`glab` CLI** — authenticated (`glab auth status` returns 0).
 2. **Local-only mode** — skip `--prs` and `--issues` with a loud notice.
 
+For Forgejo / Gitea repositories (provider `forgejo` or `gitea` — same tooling
+family, both driven by `tea`), pick the first available:
+
+1. **`tea` CLI** — a configured login (`tea login list` shows a `://` entry).
+2. **Local-only mode** — skip `--prs` and `--issues` with a loud notice.
+
 Never mix clients within a single audit. Decide once in Phase 0 and log the
 decision in `.git-cleanup/report.md` under "Host-API notes".
 
@@ -24,13 +39,14 @@ decision in `.git-cleanup/report.md` under "Host-API notes".
 
 When `--host=auto` (default), parse `git remote get-url origin`:
 
-| Pattern match                                 | Inferred host |
-| --------------------------------------------- | ------------- |
-| `github.com:`, `github.com/`, `*.github.com/` | GitHub        |
-| `gitlab.com:`, `gitlab.com/`, `/api/v4/`      | GitLab        |
-| Self-hosted GitHub Enterprise (`GHE_HOST`)    | GitHub        |
-| Self-hosted GitLab                            | GitLab        |
-| Anything else                                 | Unknown       |
+| Pattern match                                 | Inferred host   |
+| --------------------------------------------- | --------------- |
+| `github.com:`, `github.com/`, `*.github.com/` | GitHub          |
+| `gitlab.com:`, `gitlab.com/`, `/api/v4/`      | GitLab          |
+| Self-hosted GitHub Enterprise (`GHE_HOST`)    | GitHub          |
+| Self-hosted GitLab                            | GitLab          |
+| Self-hosted Forgejo / Gitea                   | Forgejo / Gitea |
+| Anything else                                 | Unknown         |
 
 Accept SSH, HTTPS, and `git://` URLs. Strip any `.git` suffix before matching.
 
@@ -40,6 +56,12 @@ as GitHub and route `gh` calls to that host.
 
 **Self-hosted GitLab:** `glab` reads its host list from `~/.config/glab-cli/`.
 If the `origin` host matches one of its configured hosts, treat as GitLab.
+
+**Self-hosted Forgejo / Gitea:** `tea` reads its login list from
+`~/.config/tea/`. If the `origin` host matches a configured `tea login list`
+entry, treat as the Gitea family and route `tea` calls to that host. The two are
+the same tooling family (`forge_cli` maps both to `tea`); the canonical reference
+distinguishes `forgejo` from `gitea` only for messaging.
 
 ## Detecting MCP availability
 
@@ -101,6 +123,25 @@ GitLab's "Merge Request" maps to GitHub's "Pull Request" one-for-one for this
 skill's purposes. Both concepts share the same R-rules (see
 `active-code-rules.md`).
 
+### Forgejo / Gitea (`tea` fallbacks)
+
+```bash
+# Open PRs ("pulls") for the current repo
+tea pull list --state open
+
+# Merged/closed PRs (filter the list output for merged state)
+tea pull list --state closed
+
+# Open issues
+tea issues list --state open
+```
+
+`tea` operates on the repo bound to the current directory's `origin` remote (it
+reads `.git/config`); pass `--repo owner/name` only when overriding. Forgejo's
+"Pull Request" maps to GitHub's one-for-one and shares the same R-rules (see
+`active-code-rules.md`). `tea` paginates with `--limit` (alias for page size);
+bound large lists the same way `--limit` bounds `gh` output.
+
 ## Write operations (only with `--apply` + user approval)
 
 ### GitHub
@@ -119,6 +160,15 @@ skill's purposes. Both concepts share the same R-rules (see
 | Close an MR    | `glab mr close <iid>`                 |
 | Close an issue | `glab issue close <iid>`              |
 | Add a label    | `glab issue update <iid> --label ...` |
+
+### Forgejo / Gitea
+
+| Action                 | `tea` command                                     |
+| ---------------------- | ------------------------------------------------- |
+| Close a PR             | `tea pull close <n>`                              |
+| Close an issue         | `tea issues close <n>`                            |
+| Add a label            | `tea issues edit <n> --add-labels ...`            |
+| Delete a remote branch | (n/a — use git) `git push origin --delete <name>` |
 
 ## Rate-limit awareness
 

--- a/.opencode-plugin/skills/git-workflow/SKILL.md
+++ b/.opencode-plugin/skills/git-workflow/SKILL.md
@@ -654,6 +654,15 @@ This provides:
 - Documentation changes
 - Suggested PR title and scope
 
+**Forge provider detection**: `create-pr.sh` runs forge detection on `origin`
+first and routes PR creation through the matching CLI — `gh` for `github`,
+`tea` for `forgejo`/`gitea` (`gh pr create` ↔ `tea pull create`). The MCP-first
+path above applies only to `github`; on a `forgejo`/`gitea` remote the script
+drives `tea` directly. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the detection algorithm and operation-equivalence map. Log the resolved
+provider + CLI so the user sees which forge the PR targeted.
+
 ### Step 25: Generate PR Title
 
 PR titles **MUST** follow the conventional commit format: `<type>(<scope>): <description>`
@@ -905,6 +914,15 @@ If repository has `.github/PULL_REQUEST_TEMPLATE.md`:
 
 **Trigger:** This phase runs ONLY when `--ci ∈ flags`. Skip silently otherwise. Phase 6 does not require Phase 5 to have run — bare `--ci` and `--push --ci` both reach this phase by design.
 
+**GitHub-only:** The CI auto-fix loop is GitHub-only — it depends on `gh run`
+controls (`gh run view --log-failed`, `gh run rerun`). On a non-GitHub remote
+`ci-monitor.sh` returns `RESULT=unsupported-provider` (exit 2). Treat this like
+`pr-not-found`/`refused-default-branch`: report it directly and **skip the loop
+without erroring**. State that the loop is GitHub-only and why, then end Phase 6
+cleanly. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+and [`../_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md).
+
 ### Step 32: Discover PR for the current branch
 
 If a `PR_NUMBER` was captured in Phase 5 (either newly created in Steps 23-30 or detected as existing in Step 22a), use it directly and skip ahead to Step 33.
@@ -975,6 +993,7 @@ Branch on stdout `RESULT=...` per the **Loop Protocol** section of `ci-monitorin
 - `rerun-pending` → Flake-suspected; the script already triggered `gh run rerun --failed`. Do NOT apply any fix. Sleep 30 seconds (`sleep 30`), then goto Step 36.
 - `bail-recurrence` / `bail-nonfixable` / `bail-pushes` / `bail-timeout` → Render a diagnosis block citing the audit log path, the `RESULT=` value, the `REASON=` line if present, and the cap that fired. End Phase 6 (do NOT push further).
 - `pr-not-found` / `refused-default-branch` → Surface the error directly; do not retry.
+- `unsupported-provider` → Remote is not GitHub; the CI auto-fix loop is GitHub-only. Report that the loop is GitHub-only and skip it cleanly; do not retry and do not treat as an error.
 
 ### Step 37: Final report
 

--- a/.opencode-plugin/skills/git-workflow/scripts/create-pr.sh
+++ b/.opencode-plugin/skills/git-workflow/scripts/create-pr.sh
@@ -44,24 +44,54 @@ if ! git rev-parse --git-dir > /dev/null 2>&1; then
     exit 1
 fi
 
-# Check if gh CLI is available
-if ! command -v gh &> /dev/null; then
-    echo -e "${RED}Error: GitHub CLI (gh) is not installed${NC}" >&2
+# Detect the forge provider and select the matching CLI (gh / tea / glab).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.config/opencode/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
+PROVIDER="$(forge_detect_provider origin)"
+FORGE_CLI="$(forge_cli "$PROVIDER")"
+
+case "$PROVIDER" in
+    github|forgejo|gitea) ;;  # supported for PR creation
+    gitlab)
+        echo -e "${RED}Error: GitLab PR creation is not yet supported by this script${NC}" >&2
+        echo "Create the merge request with: glab mr create" >&2
+        exit 1
+        ;;
+    *)
+        echo -e "${RED}Error: Could not determine the forge provider for 'origin'${NC}" >&2
+        echo "origin = $(forge_remote_url origin)" >&2
+        echo "Supported: GitHub (gh), Forgejo/Gitea (tea)." >&2
+        exit 1
+        ;;
+esac
+
+# Check the matching CLI is installed
+if ! command -v "$FORGE_CLI" &> /dev/null; then
+    echo -e "${RED}Error: ${FORGE_CLI} CLI (for ${PROVIDER}) is not installed${NC}" >&2
     echo "" >&2
-    echo "Install with:" >&2
-    echo "  macOS:   brew install gh" >&2
-    echo "  Linux:   See https://github.com/cli/cli/blob/trunk/docs/install_linux.md" >&2
+    case "$PROVIDER" in
+        github) echo "Install gh:  https://github.com/cli/cli#installation" >&2 ;;
+        *)      echo "Install tea: https://gitea.com/gitea/tea#installation" >&2 ;;
+    esac
     exit 1
 fi
 
-# Check if authenticated with gh
-if ! gh auth status &> /dev/null; then
-    echo -e "${RED}Error: Not authenticated with GitHub CLI${NC}" >&2
+# Check authentication for the detected provider
+if ! forge_auth_ok "$PROVIDER"; then
+    echo -e "${RED}Error: Not authenticated with ${FORGE_CLI} (${PROVIDER})${NC}" >&2
     echo "" >&2
-    echo "Authenticate with:" >&2
-    echo "  gh auth login" >&2
+    case "$PROVIDER" in
+        github) echo "Authenticate with: gh auth login" >&2 ;;
+        *)      echo "Authenticate with: tea login add" >&2 ;;
+    esac
     exit 1
 fi
+
+echo -e "${BLUE}Forge provider:${NC} ${PROVIDER} (using ${FORGE_CLI})" >&2
 
 # Get current branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -71,8 +101,8 @@ if [ "$CURRENT_BRANCH" = "HEAD" ]; then
     exit 1
 fi
 
-# Get default branch (usually main or master)
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+# Get default branch (usually main or master) — provider-neutral
+DEFAULT_BRANCH=$(forge_default_branch "$PROVIDER")
 
 # Check if branch exists on remote
 if ! git ls-remote --exit-code --heads origin "$CURRENT_BRANCH" &> /dev/null; then
@@ -219,8 +249,13 @@ echo ""
 if [ "$MODE" = "analyze" ]; then
     echo -e "${BLUE}=== Analysis Complete ===${NC}\n"
     echo "To create PR:"
-    echo "  Regular: gh pr create --web"
-    echo "  Draft:   gh pr create --draft --web"
+    if [ "$PROVIDER" = "github" ]; then
+        echo "  Regular: gh pr create --web"
+        echo "  Draft:   gh pr create --draft --web"
+    else
+        echo "  Regular: tea pull create --head $CURRENT_BRANCH --base $DEFAULT_BRANCH"
+        echo "  (Forgejo/Gitea: 'tea' has no --draft or --web; open the PR in the web UI to mark it draft)"
+    fi
     exit 0
 fi
 
@@ -228,13 +263,22 @@ fi
 echo -e "${BLUE}=== Creating Pull Request ===${NC}\n"
 
 # Check if PR already exists
-EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+if [ "$PROVIDER" = "github" ]; then
+    EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+else
+    # tea pull list — match the head branch column; best-effort across tea versions
+    EXISTING_PR=$(tea pull list --output simple 2>/dev/null | grep -F "$CURRENT_BRANCH" | grep -oE '^#?[0-9]+' | head -n1 | tr -d '#' || echo "")
+fi
 
 if [ -n "$EXISTING_PR" ]; then
     echo -e "${YELLOW}⚠ PR already exists for this branch: #$EXISTING_PR${NC}"
     echo ""
-    echo "View PR: gh pr view $EXISTING_PR"
-    echo "Edit PR: gh pr edit $EXISTING_PR"
+    if [ "$PROVIDER" = "github" ]; then
+        echo "View PR: gh pr view $EXISTING_PR"
+        echo "Edit PR: gh pr edit $EXISTING_PR"
+    else
+        echo "View PR: tea pull $EXISTING_PR"
+    fi
     exit 1
 fi
 
@@ -309,32 +353,58 @@ Closes #
 echo "Creating PR..."
 echo ""
 
-if [ "$DRAFT" = true ]; then
-    set +e
-    gh pr create \
-        --title "$PR_TITLE" \
-        --body "$PR_DESCRIPTION" \
-        --draft \
-        --web
-    rc=$?
-    set -e
+if [ "$PROVIDER" = "github" ]; then
+    if [ "$DRAFT" = true ]; then
+        set +e
+        gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_DESCRIPTION" \
+            --draft \
+            --web
+        rc=$?
+        set -e
 
-    if [ $rc -eq 0 ]; then
-        echo ""
-        echo -e "${GREEN}✓ Draft PR created successfully${NC}"
-        echo ""
-        echo "Mark ready when complete: gh pr ready"
+        if [ $rc -eq 0 ]; then
+            echo ""
+            echo -e "${GREEN}✓ Draft PR created successfully${NC}"
+            echo ""
+            echo "Mark ready when complete: gh pr ready"
+        else
+            echo ""
+            echo -e "${RED}✗ Failed to create PR${NC}"
+            exit 1
+        fi
     else
-        echo ""
-        echo -e "${RED}✗ Failed to create PR${NC}"
-        exit 1
+        set +e
+        gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_DESCRIPTION" \
+            --web
+        rc=$?
+        set -e
+
+        if [ $rc -eq 0 ]; then
+            echo ""
+            echo -e "${GREEN}✓ PR created successfully${NC}"
+        else
+            echo ""
+            echo -e "${RED}✗ Failed to create PR${NC}"
+            exit 1
+        fi
     fi
 else
+    # Forgejo / Gitea via tea. No --draft or --web support; create directly.
+    if [ "$DRAFT" = true ]; then
+        echo -e "${YELLOW}⚠ 'tea' does not support draft PRs; creating a normal PR.${NC}" >&2
+        echo "  Mark it draft in the ${PROVIDER} web UI if needed." >&2
+        echo ""
+    fi
     set +e
-    gh pr create \
+    tea pull create \
         --title "$PR_TITLE" \
-        --body "$PR_DESCRIPTION" \
-        --web
+        --description "$PR_DESCRIPTION" \
+        --head "$CURRENT_BRANCH" \
+        --base "$DEFAULT_BRANCH"
     rc=$?
     set -e
 

--- a/.opencode-plugin/skills/pr-autofix/SKILL.md
+++ b/.opencode-plugin/skills/pr-autofix/SKILL.md
@@ -18,6 +18,16 @@ Vendor-neutral counterpart to `coderabbit:autofix`. Pulls **every** comment surf
 **Golden rule**: Never mutate a comment body. Reply with the result, then resolve. The audit trail lives in the PR threads, not in this skill's report file.
 
 > Sister skills: `/review-fix` consumes `/code-review` artifacts (review-finding ID + Status fields). `/pr-autofix` (this) consumes GitHub PR comments directly. The two cover different inputs but share the per-finding agent dispatch model and the CI auto-fix loop.
+>
+> **GitHub-only.** This skill is GitHub-only. Forgejo/Gitea expose only the REST
+> v1 API — no GraphQL `resolveReviewThread`, no review-thread resolution, no
+> per-comment harvesting — and the CI loop depends on `gh run` controls. There
+> is no `tea` equivalent for any of these, so the workflow cannot degrade to a
+> partial mode here. Phase 0 detects the provider; on a non-`github` remote it
+> tells the user the skill is GitHub-only and **why**, then stops gracefully.
+> See [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+> (capability matrix: "Review-thread resolution", "Per-comment PR autofix
+> harvesting", "CI-autofix loop").
 
 ---
 
@@ -74,10 +84,21 @@ gh pr view "$PR_NUMBER" --json number,headRefName,baseRefName,headRepositoryOwne
 
 Record `HEAD_BRANCH`, `BASE_BRANCH`, `STATE`.
 
+### Provider detection
+
+Before the GitHub checks below, detect the forge provider on `origin` per
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+(`forge_detect_provider origin`). If the provider is **not** `github`, stop
+gracefully: "`/pr-autofix` is GitHub-only. Provider `<provider>` lacks the
+GraphQL review-thread resolution and per-comment harvesting this skill requires
+(Forgejo/Gitea expose only the REST v1 API). Resolve threads in the `<provider>`
+UI, or use local review tooling." Do not proceed to FETCH.
+
 ### Preflight refusals
 
 | Check                              | Action on failure                                                                                                  |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Provider is `github`               | Stop: GitHub-only (see Provider detection above).                                                                  |
 | `gh auth status` succeeds          | Stop: "Run `gh auth login` first."                                                                                 |
 | `STATE == "OPEN"`                  | Stop: "PR #<N> is <state>; nothing to autofix."                                                                    |
 | `HEAD_BRANCH != $(default-branch)` | Stop: "Refusing: PR head equals the default branch." (Same constraint as `ci-monitor.sh` — never push to default.) |
@@ -359,6 +380,8 @@ Track closure results in the status map: `closed_ok`, `closed_failed`, `reply_on
 **Trigger**: `--ci` was passed AND at least one fixer returned `Fixed` AND the push in Phase 5 succeeded. Skip silently otherwise.
 
 This phase is a thin wrapper over the same loop used by `/prp-pr` Phase 7 and `/git-workflow` Phase 6. **The policy lives in `~/.config/opencode/shared/references/ci-monitoring.md` — do not restate it here.**
+
+The `--ci` loop is GitHub-only (it depends on `gh run` controls); since this entire skill is already gated to `github` in Phase 0, the loop never reaches a non-GitHub remote. If `ci-monitor.sh` ever returns `RESULT=unsupported-provider`, treat it like the other non-loop terminal results below: surface it and exit.
 
 ### Step 1 — Authorization prompt (skip if `--ci-yes`)
 

--- a/.opencode-plugin/skills/pr-autofix/scripts/fetch-pr-comments.sh
+++ b/.opencode-plugin/skills/pr-autofix/scripts/fetch-pr-comments.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # fetch-pr-comments.sh — Fetch all actionable PR comments via GitHub GraphQL
 #
+# GitHub-only. Forgejo/Gitea are unsupported: they expose no GraphQL API, so
+# review-thread harvesting cannot be replicated. On a non-GitHub remote this
+# script emits a uniform unsupported notice and exits 2.
+#
 # Purpose:
 #   Single-source fetcher used by pr-autofix. Pulls every actionable
 #   comment surface on a PR — review threads (file/line anchored) and
@@ -36,12 +40,21 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.config/opencode/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
   fetch-pr-comments.sh --pr <number> --out <file> [--owner <owner>] [--repo <repo>]
   fetch-pr-comments.sh --help
   fetch-pr-comments.sh --version
+
+GitHub-only. Forgejo/Gitea are unsupported (no GraphQL API); on a non-GitHub
+remote this script prints an unsupported notice and exits 2.
 
 Options:
   --pr <number>     PR number to fetch comments for (required)
@@ -133,6 +146,18 @@ for dep in gh jq; do
     exit 1
   fi
 done
+
+# ---------------------------------------------------------------------------
+# Forge provider gate (GitHub-only feature)
+# ---------------------------------------------------------------------------
+# Review-thread harvesting uses the GitHub GraphQL API. Forgejo/Gitea have no
+# GraphQL API, so detect the provider before any gh call and degrade gracefully.
+
+PROVIDER="$(forge_detect_provider origin)"
+if [[ "$PROVIDER" != "github" ]]; then
+  forge_unsupported_notice "$PROVIDER" "PR review-comment harvesting"
+  exit 2
+fi
 
 if ! gh auth status >/dev/null 2>&1; then
   printf 'fetch-pr-comments.sh: gh not authenticated. Run `gh auth login`.\n' >&2

--- a/.opencode-plugin/skills/pr-autofix/scripts/post-summary.sh
+++ b/.opencode-plugin/skills/pr-autofix/scripts/post-summary.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # post-summary.sh — Post a single consolidated summary comment on a PR
 #
+# GitHub-only. Forgejo/Gitea are unsupported: this script is part of the
+# GraphQL-driven pr-autofix flow and posts via `gh`. On a non-GitHub remote it
+# emits a uniform unsupported notice and exits 2 (the --dry-run render still
+# works on any provider).
+#
 # Purpose:
 #   At the end of a pr-autofix run, render and post one summary comment to
 #   the PR conversation. Built only from local counters — never echoes raw
@@ -34,12 +39,22 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.config/opencode/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
   post-summary.sh --pr <number> --fixed <N> --failed <N> --skipped <N> --deferred <N> \
                   --commit-sha <sha> --branch <name> \
                   [--ci-result <value>] [--ci-iterations <N>] [--ci-pushes <N>] [--dry-run]
+
+GitHub-only. Forgejo/Gitea are unsupported (part of the GraphQL-driven autofix
+flow); on a non-GitHub remote this script prints an unsupported notice and exits
+2. The --dry-run render works on any provider.
 
 Exit codes:
   0  success (or skipped as no-op)
@@ -182,6 +197,19 @@ ${body_footer}"
 if [[ "$DRY_RUN" == "true" ]]; then
   printf '%s\n' "$BODY"
   exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Forge provider gate (GitHub-only feature)
+# ---------------------------------------------------------------------------
+# This script posts via `gh` as part of the GraphQL-driven pr-autofix flow.
+# Detect the provider before the gh-auth check so a non-GitHub remote gets the
+# honest "GitHub-only" message instead of a confusing auth error.
+
+PROVIDER="$(forge_detect_provider origin)"
+if [[ "$PROVIDER" != "github" ]]; then
+  forge_unsupported_notice "$PROVIDER" "PR summary posting"
+  exit 2
 fi
 
 if ! command -v gh >/dev/null 2>&1; then

--- a/.opencode-plugin/skills/pr-autofix/scripts/resolve-thread.sh
+++ b/.opencode-plugin/skills/pr-autofix/scripts/resolve-thread.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # resolve-thread.sh — Mutate PR review threads and conversation comments
 #
+# GitHub-only. Forgejo/Gitea are unsupported: review-thread resolution and emoji
+# reactions require the GitHub GraphQL API (resolveReviewThread, addReaction),
+# which has no Forgejo/Gitea equivalent. On a non-GitHub remote this script emits
+# a uniform unsupported notice and exits 2.
+#
 # Purpose:
 #   Wraps the four mutations pr-autofix needs to close out comments:
 #     resolve      — resolveReviewThread(threadId) via GraphQL
@@ -35,6 +40,12 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.config/opencode/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -45,6 +56,10 @@ Usage:
 
   resolve-thread.sh --help
   resolve-thread.sh --version
+
+GitHub-only. Forgejo/Gitea are unsupported (no GraphQL API for review-thread
+resolution or reactions); on a non-GitHub remote this script prints an
+unsupported notice and exits 2.
 
 Reaction values:
   THUMBS_UP THUMBS_DOWN LAUGH HOORAY CONFUSED HEART ROCKET EYES
@@ -177,6 +192,7 @@ main() {
     exit 1
   fi
 
+  # Handle help/version before any forge or auth checks so they work anywhere.
   case "$1" in
     --help|-h)
       usage
@@ -186,6 +202,28 @@ main() {
       printf 'resolve-thread.sh %s\n' "$VERSION"
       exit 0
       ;;
+  esac
+
+  # -------------------------------------------------------------------------
+  # Forge provider gate (GitHub-only feature)
+  # -------------------------------------------------------------------------
+  # resolveReviewThread/addReaction are GraphQL-only. Forgejo/Gitea have no
+  # GraphQL API, so detect the provider and short-circuit before the gh-auth
+  # check so a non-GitHub remote gets the honest "GitHub-only" message.
+
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "PR review-thread resolution"
+    exit 2
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    printf 'resolve-thread.sh: gh not authenticated. Run `gh auth login`.\n' >&2
+    exit 2
+  fi
+
+  case "$1" in
     resolve)
       shift
       cmd_resolve "$@"
@@ -209,10 +247,5 @@ main() {
       ;;
   esac
 }
-
-if ! gh auth status >/dev/null 2>&1; then
-  printf 'resolve-thread.sh: gh not authenticated. Run `gh auth login`.\n' >&2
-  exit 2
-fi
 
 main "$@"

--- a/.opencode-plugin/skills/prp-pr/SKILL.md
+++ b/.opencode-plugin/skills/prp-pr/SKILL.md
@@ -165,12 +165,27 @@ Use this default format:
 
 ### Create the PR
 
+PR creation is provider-aware. Detect the forge provider on `origin` first
+(`forge_detect_provider origin`) and route through the matching CLI: `gh pr
+create` for `github`, `tea pull create --title --description [--head]` for
+`forgejo`/`gitea`. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the operation-equivalence map. Log the resolved provider + CLI so the user
+sees which forge the PR targeted.
+
 ```bash
+# github
 gh pr create \
   --title "<PR title>" \
   --base <base-branch> \
   --body "<PR body>"
   # Add --draft if the --draft flag was parsed from $ARGUMENTS
+
+# forgejo / gitea
+tea pull create \
+  --title "<PR title>" \
+  --base <base-branch> \
+  --description "<PR body>"
 ```
 
 ---
@@ -225,6 +240,13 @@ were printed (otherwise `n/a`).
 **Trigger:** Runs ONLY when `--ci` was passed AND a PR is in scope (created in
 Phase 4, or an existing PR confirmed for monitoring per the Phase 1 modification
 above). Skip silently otherwise.
+
+**GitHub-only:** The CI auto-fix loop is GitHub-only (it depends on `gh run`
+controls). On a non-GitHub remote `ci-monitor.sh` returns
+`RESULT=unsupported-provider` (exit 2). Treat this like
+`pr-not-found`/`refused-default-branch`: report that the loop is GitHub-only and
+skip it cleanly — do not retry, do not error. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 
 **Step 1 — Verify PR is monitorable:** Confirm a PR number is in scope. If not,
 hard-stop: `--ci was passed but no PR is in scope to monitor.`
@@ -286,6 +308,7 @@ Branch on stdout `RESULT=...` per the Loop Protocol in `ci-monitoring.md`:
   goto Step 5 (do NOT apply any fix).
 - `bail-*` → Go to Step 6 (diagnosis). Do not push further.
 - `pr-not-found` / `refused-default-branch` → Surface the error; do not retry.
+- `unsupported-provider` → Remote is not GitHub; the CI auto-fix loop is GitHub-only. Report that the loop is GitHub-only and skip it cleanly; do not retry or treat as an error.
 
 **Step 6 — Final report:**
 

--- a/.opencode-plugin/skills/releaser/SKILL.md
+++ b/.opencode-plugin/skills/releaser/SKILL.md
@@ -269,6 +269,17 @@ If `--ci-config=generate` ran, append:
 # build the matrix and attach artifacts to the GitHub release.
 ```
 
+**Forge provider detection**: release creation is provider-aware.
+`publish-release.sh` detects the forge provider on `origin` first and routes
+through the matching CLI — `gh release create` for `github`, `tea release
+create --tag <tag> [--note-file]` for `forgejo`/`gitea` (per the
+operation-equivalence map). The `gh release create`/`gh release upload` commands
+emitted in the Phase 8 block above are the `github` path; on a `forgejo`/`gitea`
+remote the helper drives `tea release create` instead. Log the resolved provider
+
+- CLI. See
+  [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
+
 When the user passed `--publish[=create|edit|auto]`, after they review the rendered
 notes, run:
 
@@ -306,6 +317,15 @@ The contract (exit codes, `RESULT=` signaling, JSONL audit log, failure classifi
 signature dedup, default-branch refusal) mirrors `ci-monitor.sh` verbatim. See
 [`_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md),
 section "Release mode", for the single source of truth.
+
+**GitHub-only:** the release-CI auto-fix loop is GitHub-only — it depends on
+`gh run list`, `gh workflow run`, and `gh release` controls that have no `tea`
+equivalent. On a non-GitHub remote `release-ci-monitor.sh` returns
+`RESULT=unsupported-provider` (exit 2). Treat it like `not-found`: report that
+the loop is GitHub-only, render an 8.5.4-style diagnosis, and exit Phase 8.5
+cleanly without retrying. (Release _creation_ in Phase 8 remains provider-aware
+via `tea release create`; only this post-publish monitoring loop is gated.) See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 
 ### 8.5.0 Detect re-cut strategy
 
@@ -381,16 +401,17 @@ one human approval the bounded, destructive-capable loop depends on. Therefore:
 
 3. Branch on the exit code (identical contract to `ci-monitor.sh`):
 
-   | Exit | `RESULT=`         | Action                                                |
-   | ---- | ----------------- | ----------------------------------------------------- |
-   | 0    | `green`           | Success. Exit Phase 8.5, continue to Phase 9.         |
-   | 20   | `handoff`         | Step **8.5.3** (fix and re-cut), then loop to step 2. |
-   | 21   | `rerun-pending`   | `sleep 30`, then loop to step 2 (no fix applied).     |
-   | 10   | `bail-recurrence` | Step **8.5.4** (diagnosis), exit Phase 8.5.           |
-   | 11   | `bail-nonfixable` | Step **8.5.4**, exit Phase 8.5.                       |
-   | 12   | `bail-pushes`     | Step **8.5.4**, exit Phase 8.5.                       |
-   | 13   | `bail-timeout`    | Step **8.5.4**, exit Phase 8.5.                       |
-   | 2    | `not-found`       | Step **8.5.4**, exit Phase 8.5.                       |
+   | Exit | `RESULT=`              | Action                                                                     |
+   | ---- | ---------------------- | -------------------------------------------------------------------------- |
+   | 0    | `green`                | Success. Exit Phase 8.5, continue to Phase 9.                              |
+   | 20   | `handoff`              | Step **8.5.3** (fix and re-cut), then loop to step 2.                      |
+   | 21   | `rerun-pending`        | `sleep 30`, then loop to step 2 (no fix applied).                          |
+   | 10   | `bail-recurrence`      | Step **8.5.4** (diagnosis), exit Phase 8.5.                                |
+   | 11   | `bail-nonfixable`      | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 12   | `bail-pushes`          | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 13   | `bail-timeout`         | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 2    | `not-found`            | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 2    | `unsupported-provider` | Remote is not GitHub; loop is GitHub-only. Step **8.5.4**, exit Phase 8.5. |
 
 ### 8.5.3 Fix and re-cut on handoff
 

--- a/.opencode-plugin/skills/releaser/scripts/publish-release.sh
+++ b/.opencode-plugin/skills/releaser/scripts/publish-release.sh
@@ -1,14 +1,29 @@
 #!/usr/bin/env bash
-# publish-release.sh — Publish or update a GitHub release for a given tag.
+# publish-release.sh — Publish or update a release for a given tag.
+#
+# Provider-aware: routes through the CLI that matches the detected forge.
+#   github          → gh release create/edit  (behavior unchanged)
+#   forgejo / gitea → tea release create/edit
+#   gitlab / unknown→ release creation is not supported here; exits 1 with the
+#                     manual command to run.
 #
 # Usage:
 #   publish-release.sh [--mode=create|edit|auto] [--confirm] <tag> <notes-file>
 #
-# By default (no --confirm) prints the resolved gh command and exits 0.
+# By default (no --confirm) prints the resolved command and exits 0.
 # With --confirm the resolved command is executed.
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# --- forge detection -------------------------------------------------------
+# Detect the forge provider and select the matching CLI (gh / tea). Prefer the
+# plugin-root install path; fall back to the source-tree relative path.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.config/opencode/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
 
 # --- diagnostic helpers ---
 fail()  { echo "${SCRIPT_NAME}: FAIL: $*" >&2; }
@@ -19,8 +34,9 @@ usage() {
     cat <<EOF
 Usage: ${SCRIPT_NAME} [options] <tag> <notes-file>
 
-Publish (create or update) a GitHub release for <tag> using <notes-file> as
-the release body.
+Publish (create or update) a release for <tag> using <notes-file> as the
+release body. The forge provider is auto-detected from origin (GitHub via gh,
+Forgejo/Gitea via tea).
 
 Arguments:
   <tag>          Git tag (e.g. v1.4.0 or 1.4.0 — normalised to v-prefix if semver)
@@ -30,16 +46,18 @@ Options:
   --mode=create  Create a new release (fails if release already exists)
   --mode=edit    Edit an existing release (fails if release does not exist)
   --mode=auto    Auto-detect: create if missing, edit if present (default)
-  --confirm      Actually run the resolved gh command (default: print only)
+  --confirm      Actually run the resolved command (default: print only)
   -h, --help     Show this help
 
 Print-only mode (no --confirm):
-  Prints the exact gh command that would be run, then exits 0. gh is NOT called.
+  Prints the exact command that would be run, then exits 0. The forge CLI is
+  NOT called.
 
 Authentication:
-  In --mode=auto, gh auth status is checked. If unauthenticated, the script
-  exits 1 with a warning. In --mode=create or --mode=edit, gh itself will
-  surface authentication errors when --confirm is used.
+  In --mode=auto, the detected forge CLI's auth state is checked. If
+  unauthenticated, the script exits 1 with a warning. In --mode=create or
+  --mode=edit, the CLI itself surfaces authentication errors when --confirm
+  is used.
 
 Examples:
   # Preview what would be run for tag v1.4.0:
@@ -144,22 +162,67 @@ if ! git show-ref --verify --quiet "refs/tags/${TAG}"; then
     exit 1
 fi
 
-# --- gh authentication check (auto mode only) ---
+# --- provider routing -------------------------------------------------------
+# Resolve the forge provider for origin and reject providers this script cannot
+# create releases for. github keeps its exact prior semantics; forgejo/gitea
+# route through tea; gitlab/unknown exit with the manual command.
+PROVIDER="$(forge_detect_provider origin)"
+FORGE_CLI="$(forge_cli "${PROVIDER}")"
+
+case "${PROVIDER}" in
+    github|forgejo|gitea)
+        ;;  # supported for release create/edit
+    gitlab)
+        fail "GitLab release creation is not supported by this script"
+        hint "create the release manually: glab release create ${TAG} --notes-file ${NOTES_FILE}"
+        exit 1
+        ;;
+    *)
+        fail "could not determine the forge provider for 'origin'"
+        hint "origin = $(forge_remote_url origin)"
+        hint "supported: GitHub (gh), Forgejo/Gitea (tea)"
+        exit 1
+        ;;
+esac
+
+# --- forge CLI availability check ---
+if ! command -v "${FORGE_CLI}" >/dev/null 2>&1; then
+    fail "${FORGE_CLI} CLI (for ${PROVIDER}) is not installed"
+    case "${PROVIDER}" in
+        github) hint "install gh:  https://github.com/cli/cli#installation" ;;
+        *)      hint "install tea: https://gitea.com/gitea/tea#installation" ;;
+    esac
+    exit 1
+fi
+
+# --- authentication check (auto mode only) ---
 if [[ "${MODE}" == "auto" ]]; then
-    if ! gh auth status >/dev/null 2>&1; then
-        warn "gh not authenticated; cannot determine release state — re-run with explicit --mode=create or --mode=edit"
+    if ! forge_auth_ok "${PROVIDER}"; then
+        warn "${FORGE_CLI} not authenticated (${PROVIDER}); cannot determine release state — re-run with explicit --mode=create or --mode=edit"
+        case "${PROVIDER}" in
+            github) hint "authenticate with: gh auth login" ;;
+            *)      hint "authenticate with: tea login add" ;;
+        esac
         exit 1
     fi
 fi
 
 # --- release existence detection ---
-# Always probe GitHub (including --mode=create) so create-mode can detect an
-# existing release and suggest --mode=edit instead of failing later on gh.
+# Always probe the forge (including --mode=create) so create-mode can detect an
+# existing release and suggest --mode=edit instead of failing later in the CLI.
 RELEASE_JSON=""
 RELEASE_EXISTS=0
-RELEASE_JSON="$(gh release view "${TAG}" --json url,tagName,body 2>/dev/null || true)"
-if [[ -n "${RELEASE_JSON}" ]]; then
-    RELEASE_EXISTS=1
+if [[ "${PROVIDER}" == "github" ]]; then
+    RELEASE_JSON="$(gh release view "${TAG}" --json url,tagName,body 2>/dev/null || true)"
+    if [[ -n "${RELEASE_JSON}" ]]; then
+        RELEASE_EXISTS=1
+    fi
+else
+    # tea has no per-tag "view"; list releases as JSON and match the tag_name.
+    if tea release list --output json 2>/dev/null \
+        | grep -qE "\"tag_name\"[[:space:]]*:[[:space:]]*\"${TAG}\""; then
+        RELEASE_EXISTS=1
+    fi
 fi
 
 # --- mode conflict checks ---
@@ -186,10 +249,22 @@ case "${MODE}" in
 esac
 
 # --- build resolved command ---
-if [[ "${MODE}" == "create" ]]; then
-    RESOLVED_CMD="gh release create $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}") --title $(printf '%q' "${TAG}") --verify-tag"
+# github keeps its prior gh commands verbatim. tea (forgejo/gitea) uses
+# `tea release create --note-file` for create, but `tea release edit` has no
+# --note-file in 0.14.x, so edit passes the notes inline via --note.
+if [[ "${PROVIDER}" == "github" ]]; then
+    if [[ "${MODE}" == "create" ]]; then
+        RESOLVED_CMD="gh release create $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}") --title $(printf '%q' "${TAG}") --verify-tag"
+    else
+        RESOLVED_CMD="gh release edit $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}")"
+    fi
 else
-    RESOLVED_CMD="gh release edit $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}")"
+    if [[ "${MODE}" == "create" ]]; then
+        RESOLVED_CMD="tea release create --tag $(printf '%q' "${TAG}") --title $(printf '%q' "${TAG}") --note-file $(printf '%q' "${NOTES_FILE}")"
+    else
+        # `tea release edit` lacks --note-file; pass the notes file inline.
+        RESOLVED_CMD="tea release edit $(printf '%q' "${TAG}") --note \"\$(cat $(printf '%q' "${NOTES_FILE}"))\""
+    fi
 fi
 
 # --- print-only mode (no --confirm) ---
@@ -200,14 +275,28 @@ fi
 
 # --- confirm mode: warn before destructive edit ---
 if [[ "${MODE}" == "edit" ]]; then
-    existing_body="$(printf '%s' "${RELEASE_JSON}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("body","") or "")' 2>/dev/null || true)"
-    warn "about to overwrite release body for ${TAG}. Current body:"
-    printf '%s\n' "---" "${existing_body}" "---" >&2
+    if [[ "${PROVIDER}" == "github" ]]; then
+        existing_body="$(printf '%s' "${RELEASE_JSON}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("body","") or "")' 2>/dev/null || true)"
+        warn "about to overwrite release body for ${TAG}. Current body:"
+        printf '%s\n' "---" "${existing_body}" "---" >&2
+    else
+        warn "about to overwrite release notes for ${TAG} on ${PROVIDER}."
+    fi
 fi
 
 # --- execute ---
-if [[ "${MODE}" == "create" ]]; then
-    gh release create "${TAG}" --notes-file "${NOTES_FILE}" --title "${TAG}" --verify-tag
+if [[ "${PROVIDER}" == "github" ]]; then
+    if [[ "${MODE}" == "create" ]]; then
+        gh release create "${TAG}" --notes-file "${NOTES_FILE}" --title "${TAG}" --verify-tag
+    else
+        gh release edit "${TAG}" --notes-file "${NOTES_FILE}"
+    fi
 else
-    gh release edit "${TAG}" --notes-file "${NOTES_FILE}"
+    if [[ "${MODE}" == "create" ]]; then
+        tea release create --tag "${TAG}" --title "${TAG}" --note-file "${NOTES_FILE}"
+    else
+        # `tea release edit` lacks --note-file; read the notes file inline.
+        NOTES_BODY="$(cat "${NOTES_FILE}")"
+        tea release edit "${TAG}" --note "${NOTES_BODY}"
+    fi
 fi

--- a/.opencode-plugin/skills/research-to-issues/SKILL.md
+++ b/.opencode-plugin/skills/research-to-issues/SKILL.md
@@ -39,6 +39,22 @@ Parse arguments:
 
 ## Tool Preference Strategy
 
+### Step 0a: Detect forge provider
+
+Issue creation is provider-aware. Detect the forge provider on `origin` first
+(`forge_detect_provider origin`) and route through the matching CLI:
+`gh issue create --title --body` for `github`, `tea issues create --title
+--description` for `forgejo`/`gitea`. `validate-prerequisites.sh` runs the same
+detection and gates the per-provider issue prerequisites. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the operation-equivalence map. Log the resolved provider + CLI.
+
+**Forgejo/Gitea caveats**: repo-slug resolution (`gh repo view`) and some label
+operations (`gh label create`) are `gh`-only and have no `tea` equivalent — skip
+them on `forgejo`/`gitea` (create labels via the Forgejo/Gitea UI, and bind
+`tea` to the `origin`-bound repo rather than resolving an owner/name slug). The
+GitHub MCP path below applies only to `github`.
+
 ### Step 0: Detect GitHub MCP Server
 
 Check if GitHub MCP tools are available by looking for tools matching `mcp__github__*`.

--- a/.opencode-plugin/skills/research-to-issues/scripts/validate-prerequisites.sh
+++ b/.opencode-plugin/skills/research-to-issues/scripts/validate-prerequisites.sh
@@ -14,13 +14,21 @@ set -euo pipefail
 # Auto-detects type from path/content if --type is not specified.
 #
 # Checks:
-#   1. gh CLI is installed and authenticated
-#   2. Current directory is a git repo with a GitHub remote
+#   1. The forge CLI for the detected provider is installed and authenticated
+#      (gh for GitHub, tea for Forgejo/Gitea)
+#   2. Current directory is a git repo on a supported forge
 #   3. Source path exists and matches expected structure
 #
 # Exit codes:
 #   0 = all prerequisites met
 #   1 = missing prerequisite
+
+# Detect the forge provider and select the matching CLI (gh / tea).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../../shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="~/.config/opencode/shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
 
 SOURCE_PATH="${1:-}"
 EXPLICIT_TYPE=""
@@ -41,35 +49,60 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# --- Check gh CLI ---
-if ! command -v gh &>/dev/null; then
-  ERRORS+=("ERROR: GitHub CLI (gh) is not installed. Install: https://cli.github.com/")
-else
-  if ! gh auth status &>/dev/null 2>&1; then
-    ERRORS+=("ERROR: GitHub CLI is not authenticated. Run: gh auth login")
-  else
-    echo "OK: gh CLI installed and authenticated"
-  fi
-fi
-
-# --- Check git repo with GitHub remote ---
+# --- Check git repo and detect forge provider ---
+PROVIDER="unknown"
+FORGE_CLI=""
 if ! git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
   ERRORS+=("ERROR: Not inside a git repository")
 else
   REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
   if [[ -z "$REMOTE_URL" ]]; then
     ERRORS+=("ERROR: No 'origin' remote configured")
-  elif [[ "$REMOTE_URL" != *"github.com"* && "$REMOTE_URL" != *"github:"* ]]; then
-    ERRORS+=("WARNING: Remote may not be GitHub: $REMOTE_URL")
   else
-    REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
-    if [[ -n "$REPO" ]]; then
-      echo "OK: GitHub repo detected: $REPO"
-    else
-      ERRORS+=("ERROR: Could not determine GitHub repo from remote")
-    fi
+    PROVIDER="$(forge_detect_provider origin)"
+    FORGE_CLI="$(forge_cli "$PROVIDER")"
+
+    case "$PROVIDER" in
+      github|forgejo|gitea)
+        echo "OK: Forge provider detected: $PROVIDER (using $FORGE_CLI)"
+        ;;
+      gitlab|unknown)
+        ERRORS+=("ERROR: Issue creation requires GitHub (gh) or Forgejo/Gitea (tea); detected provider '$PROVIDER' (origin: $REMOTE_URL) is not supported")
+        ;;
+    esac
   fi
 fi
+
+# --- Check the matching forge CLI is installed and authenticated ---
+case "$PROVIDER" in
+  github|forgejo|gitea)
+    if ! command -v "$FORGE_CLI" &>/dev/null; then
+      case "$PROVIDER" in
+        github) ERRORS+=("ERROR: GitHub CLI (gh) is not installed. Install: https://cli.github.com/") ;;
+        *)      ERRORS+=("ERROR: tea CLI (for $PROVIDER) is not installed. Install: https://gitea.com/gitea/tea#installation") ;;
+      esac
+    elif ! forge_auth_ok "$PROVIDER"; then
+      case "$PROVIDER" in
+        github) ERRORS+=("ERROR: GitHub CLI is not authenticated. Run: gh auth login") ;;
+        *)      ERRORS+=("ERROR: tea is not authenticated for $PROVIDER. Run: tea login add") ;;
+      esac
+    else
+      echo "OK: $FORGE_CLI CLI installed and authenticated"
+      # GitHub-only: confirm the repo slug resolves via the host API. tea v0.14
+      # has no clean equivalent, so this sub-check is skipped on Forgejo/Gitea.
+      if [[ "$PROVIDER" == "github" ]]; then
+        REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+        if [[ -n "$REPO" ]]; then
+          echo "OK: GitHub repo detected: $REPO"
+        else
+          ERRORS+=("ERROR: Could not determine GitHub repo from remote")
+        fi
+      else
+        echo "NOTICE: Skipping repo-slug resolution check (no clean tea equivalent on $PROVIDER)"
+      fi
+    fi
+    ;;
+esac
 
 # --- Check source path ---
 if [[ -z "$SOURCE_PATH" ]]; then

--- a/.opencode-plugin/skills/review-fix/SKILL.md
+++ b/.opencode-plugin/skills/review-fix/SKILL.md
@@ -841,6 +841,16 @@ The transcript-output contract and shared caveats (worktree cwd, interactive fai
 
 ## Important Notes
 
+- **PR posting is GitHub-only**: The PR-coupled steps here use `gh` (resolving the
+  PR head via `gh pr view`, and the commit+push to the PR branch in worktree mode).
+  Those depend on GitHub plumbing that has no `tea` equivalent. Detect the forge
+  provider on `origin` (`forge_detect_provider origin`) before any `gh pr` call. On a
+  non-`github` provider, apply the fixes **locally** (Path A/B/C all edit files in the
+  working tree regardless of forge) and **skip the PR-posting step** with a notice:
+  "PR posting is GitHub-only on provider `<provider>`; fixes applied locally — commit
+  and push them yourself." Mark `REPORT_COMMITTED: n/a` in that case. The artifact
+  parse, filter, fix, Status updates, and Phase 5 validation are all provider-neutral.
+  See [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 - **In-place Status updates**: The source review file is the source of truth. This skill mutates it in place via `Edit`, updating only the `Status` line of each processed finding. All other content is preserved.
 - **No scope creep**: Each `review-fixer` agent is scope-disciplined — it fixes exactly what the finding specifies. If the fix reveals a larger issue, the agent reports it, but the skill does not chase down related problems.
 - **Resumable**: Re-running on the same review file skips already-processed findings.

--- a/ycc/skills/_shared/references/ci-monitoring.md
+++ b/ycc/skills/_shared/references/ci-monitoring.md
@@ -22,6 +22,27 @@ must not diverge from either.
 
 ---
 
+## Provider Support
+
+The CI-autofix loop is **GitHub-only**. Both `ci-monitor.sh` and
+`release-ci-monitor.sh` depend on `gh` run controls (`gh run view
+--log-failed`, `gh run rerun`, `gh run list`) that have no Forgejo/Gitea (`tea`)
+or GitLab (`glab`) equivalent. Before entering the loop the scripts detect the
+forge provider on the watched remote; on any non-GitHub remote they emit
+`RESULT=unsupported-provider` (exit 2) and do nothing else.
+
+The detection contract — provider values `github` / `forgejo` / `gitea` /
+`gitlab` / `unknown`, the `forge_detect_provider` / `forge_cli` law — lives in
+[`forge-detection.md`](forge-detection.md) (capability matrix: "CI-autofix loop
+(`--ci`)" is GitHub-only).
+
+**Skill loop handling:** treat `RESULT=unsupported-provider` exactly like
+`pr-not-found` / `refused-default-branch` — surface it directly and do **not**
+loop. State that the loop is GitHub-only, skip it cleanly, and never re-invoke
+the monitor. It is a terminal non-loop result, not an error to retry.
+
+---
+
 ## Trust Boundary
 
 `--ci` grants the following standing authorization for the duration of one skill
@@ -109,6 +130,7 @@ corresponding code.
 | `bail-timeout`           | 13        | Wall-clock ≥ `--ci-timeout-min`, or checks never registered              |
 | `pr-not-found`           | 2         | PR does not exist or is unreachable                                      |
 | `refused-default-branch` | 2         | Will not operate when head branch equals the default branch              |
+| `unsupported-provider`   | 2         | Remote is not GitHub; the CI-autofix loop is GitHub-only                 |
 
 Exit code 1 is reserved for argument/usage errors and never appears in the loop.
 
@@ -174,8 +196,10 @@ the skill.
      - The cap or constraint that fired
        Exit phase; do not push further.
 
-   - **`pr-not-found`** / **`refused-default-branch`** — surface the error
-     directly; do not enter the loop.
+   - **`pr-not-found`** / **`refused-default-branch`** / **`unsupported-provider`**
+     — surface the error directly; do not enter the loop. For
+     `unsupported-provider`, state that the CI-autofix loop is GitHub-only (see
+     the Provider Support section above) and skip it cleanly.
 
 ---
 

--- a/ycc/skills/_shared/references/forge-detection.md
+++ b/ycc/skills/_shared/references/forge-detection.md
@@ -1,0 +1,155 @@
+# Forge Provider Detection & Tooling Selection
+
+Single source of truth for how every git skill in the `ycc` bundle decides
+**which forge it is talking to** and **which CLI to drive**. Any skill that
+creates PRs, files issues, cuts releases, posts review comments, or watches CI
+must run this detection first and route accordingly.
+
+The programmatic counterpart is
+[`_shared/scripts/lib/forge.sh`](../scripts/lib/forge.sh) — a sourceable bash
+library that implements the detection law described here. Scripts source it;
+SKILL prose references this document. The two must never diverge.
+
+> **Why this exists.** The bundle was historically GitHub-only (`gh`
+> everywhere). Self-hosted **Forgejo** and **Gitea** repositories need the same
+> workflows driven through the `tea` CLI. Detection lets one skill serve both
+> without the user passing a `--provider` flag.
+
+---
+
+## Provider values
+
+| Provider  | Hosts                          | CLI    | Notes                                  |
+| --------- | ------------------------------ | ------ | -------------------------------------- |
+| `github`  | github.com, GitHub Enterprise  | `gh`   | Full feature support                   |
+| `forgejo` | self-hosted Forgejo            | `tea`  | Gitea fork; same tooling as `gitea`    |
+| `gitea`   | self-hosted Gitea              | `tea`  | Generic Gitea-family label             |
+| `gitlab`  | gitlab.com, self-hosted GitLab | `glab` | Pre-existing partial support           |
+| `unknown` | anything else                  | (none) | Skip host-API steps with a loud notice |
+
+`forgejo` and `gitea` are the **same tooling family** — both driven by `tea`.
+They are distinguished only for accurate user-facing messages. For command
+selection, treat them identically (`forge_cli` maps both to `tea`).
+
+---
+
+## Detection algorithm
+
+`forge_detect_provider [remote] [--probe]` (default remote: `origin`):
+
+1. Read `git remote get-url <remote>`. No remote → `unknown`.
+2. Extract the bare host from the URL (handles `git@host:owner/repo.git`,
+   `ssh://git@host:port/...`, `https://host/...`, `git://host/...`; strips a
+   trailing `.git`).
+3. **GitHub** if the host is `github.com` / `*.github.com`, equals `$GH_HOST`
+   or `$GITHUB_HOST`, or appears in `~/.config/gh/hosts.yml`.
+4. **GitLab** if the host is `gitlab.com` / `*.gitlab.com`, or appears in
+   `~/.config/glab-cli/config.yml`.
+5. **Gitea family** if the host matches a configured `tea login list` entry.
+   With `--probe`, a best-effort `GET https://<host>/api/v1/version` (plus the
+   Server header) distinguishes `forgejo` from `gitea`; offline, default to
+   `gitea`.
+6. With `--probe` and no local match, the `/api/v1/version` probe can still
+   classify an unconfigured Gitea/Forgejo host.
+7. Otherwise → `unknown`.
+
+Steps 3–4 and the `tea login list` read in step 5 are **local only** — no
+network, no rate-limit cost. The `/api/v1/version` probe in steps 5–6 is
+opt-in via `--probe` so default detection stays fast and offline-friendly.
+
+---
+
+## Auth probes (run once, cache the result)
+
+Never call the host API to check auth — use the local status commands:
+
+```bash
+# github
+command -v gh   >/dev/null && gh   auth status >/dev/null 2>&1   # → authed
+
+# forgejo / gitea  (tea has no `auth status`; a configured login is the signal)
+command -v tea  >/dev/null && tea login list 2>/dev/null | grep -q '://'
+
+# gitlab
+command -v glab >/dev/null && glab auth status >/dev/null 2>&1
+```
+
+The lib exposes these as `forge_auth_ok <provider>`. If the matched provider's
+CLI is missing or unauthenticated, surface a precise remediation (`gh auth
+login`, `tea login add`, `glab auth login`) and fall back to local-only mode
+rather than guessing.
+
+---
+
+## Operation equivalence map
+
+Core operations are supported on **both** families. Drive them through the CLI
+that `forge_cli <provider>` returns.
+
+| Operation             | GitHub (`gh`)                            | Forgejo / Gitea (`tea`)                          |
+| --------------------- | ---------------------------------------- | ------------------------------------------------ |
+| Default branch        | `gh repo view --json defaultBranchRef`   | `git symbolic-ref refs/remotes/origin/HEAD`      |
+| Create PR             | `gh pr create --title --body [--draft]`  | `tea pull create --title --description [--head]` |
+| PR for current branch | `gh pr list --head <branch>`             | `tea pull list` (filter by head branch)          |
+| View PR state         | `gh pr view <n> --json state`            | `tea pull <n>`                                   |
+| List open issues      | `gh issue list`                          | `tea issues list`                                |
+| Create issue          | `gh issue create --title --body`         | `tea issues create --title --description`        |
+| Close issue           | `gh issue close <n>`                     | `tea issues close <n>`                           |
+| Create release        | `gh release create <tag> [--notes-file]` | `tea release create --tag <tag> [--note-file]`   |
+| Delete remote branch  | `git push <remote> --delete <branch>`    | `git push <remote> --delete <branch>` (same)     |
+
+`tea` operates on the repo bound to the current directory's `origin` remote (it
+reads `.git/config`); pass `--repo owner/name` only when overriding.
+
+---
+
+## Capability matrix — GitHub-only features
+
+Some advanced features depend on APIs that **do not exist** on Forgejo/Gitea.
+These degrade gracefully: detect the provider, and on a non-GitHub remote emit
+`forge_unsupported_notice` and exit cleanly rather than faking parity.
+
+| Feature                              | GitHub | Forgejo / Gitea | Why                                                         |
+| ------------------------------------ | ------ | --------------- | ----------------------------------------------------------- |
+| PR / issue / release create + list   | ✅     | ✅              | Covered by `gh` and `tea`                                   |
+| Review-thread resolution (`resolve`) | ✅     | ❌              | Requires GraphQL `resolveReviewThread`; no GraphQL on Gitea |
+| Per-comment PR autofix harvesting    | ✅     | ❌              | `fetch-pr-comments.sh` uses the GitHub GraphQL API          |
+| CI-autofix loop (`--ci`)             | ✅     | ❌              | Depends on `gh run view --log-failed` / `gh run rerun`      |
+| Emoji reactions on comments          | ✅     | ❌              | GraphQL `addReaction`                                       |
+
+For ❌ features on a non-GitHub remote, the skill must:
+
+1. Detect the provider in its Phase 0.
+2. Tell the user the feature is GitHub-only and **why** (one line).
+3. Offer the manual alternative (e.g. "resolve the thread in the Forgejo UI").
+4. Continue with whatever **is** supported (e.g. still create the PR via `tea`),
+   skipping only the unsupported step.
+
+Never silently no-op and never pretend an unsupported step succeeded.
+
+---
+
+## Skill integration pattern (Phase 0)
+
+Every git-operation skill adds a detection step before any host call:
+
+```bash
+# shellcheck source=/dev/null
+source "${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+provider="$(forge_detect_provider origin)"
+cli="$(forge_cli "$provider")"
+forge_auth_ok "$provider" || { echo "Auth needed for $provider"; exit 2; }
+```
+
+Then branch on `$provider` for the operation, or call a script that does the
+branching internally. Log the resolved provider + CLI so the user sees which
+forge the workflow targeted.
+
+---
+
+## References
+
+- [`_shared/scripts/lib/forge.sh`](../scripts/lib/forge.sh) — the detection lib
+- [`git-cleanup/references/host-detection.md`](../../git-cleanup/references/host-detection.md)
+  — the older GitHub/GitLab host-detection notes this generalizes
+- [`ci-monitoring.md`](ci-monitoring.md) — CI-autofix loop (GitHub-only; gated here)

--- a/ycc/skills/_shared/scripts/ci-monitor.sh
+++ b/ycc/skills/_shared/scripts/ci-monitor.sh
@@ -38,6 +38,16 @@ VERSION="1.0.0"
 . "$(dirname "$0")/lib/ci-classify.sh"
 
 # ---------------------------------------------------------------------------
+# Forge provider detection (sourced)
+# ---------------------------------------------------------------------------
+# The CI-autofix loop depends on `gh run view --log-failed` / `gh run rerun`,
+# which have no Forgejo/Gitea equivalent. The loop is GitHub-only; on any other
+# provider this script exits early with RESULT=unsupported-provider.
+
+# shellcheck source=lib/forge.sh
+. "$(dirname "$0")/lib/forge.sh"
+
+# ---------------------------------------------------------------------------
 # Usage
 # ---------------------------------------------------------------------------
 
@@ -383,6 +393,18 @@ main() {
     log_jsonl "$log_file" "$ts" "$iteration" "$pr" "0" "" "success" "" "green" "$push_count" "" '"dry_run":true'
     printf 'RESULT=green\n'
     exit 0
+  fi
+
+  # -------------------------------------------------------------------------
+  # Step 0: Forge provider gate (GitHub-only feature)
+  # -------------------------------------------------------------------------
+
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "the --ci auto-fix loop"
+    printf 'RESULT=unsupported-provider\n'
+    exit 2
   fi
 
   # -------------------------------------------------------------------------

--- a/ycc/skills/_shared/scripts/lib/forge.sh
+++ b/ycc/skills/_shared/scripts/lib/forge.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# forge.sh — Git forge provider detection and tooling selection.
+#
+# Sourceable library. Sourcing it has NO side effects (no network, no writes,
+# no `set` changes that leak to the caller). Every consumer that talks to a
+# remote git host (GitHub / Forgejo / Gitea / GitLab) routes through these
+# helpers so a single detection law governs the whole bundle.
+#
+# Provider values returned by forge_detect_provider:
+#   github   — GitHub.com or GitHub Enterprise        → CLI: gh
+#   forgejo  — Forgejo instance (Gitea fork)          → CLI: tea
+#   gitea    — Gitea instance                          → CLI: tea
+#   gitlab   — GitLab.com or self-hosted GitLab        → CLI: glab
+#   unknown  — could not be determined                 → CLI: (none)
+#
+# `forgejo` and `gitea` are the same tooling family (both driven by `tea`);
+# they are distinguished only for accurate messaging. Treat them identically
+# for command selection — forge_cli maps both to `tea`.
+#
+# Contract: see _shared/references/forge-detection.md (single source of truth).
+
+# ---------------------------------------------------------------------------
+# URL parsing
+# ---------------------------------------------------------------------------
+
+# forge_strip_git_suffix <url> — strip a trailing ".git".
+forge_strip_git_suffix() {
+  printf '%s' "${1%.git}"
+}
+
+# forge_remote_url [remote] — print the fetch URL for a remote (default origin).
+# Prints nothing and returns 1 if the remote does not exist.
+forge_remote_url() {
+  local remote="${1:-origin}"
+  git remote get-url "$remote" 2>/dev/null
+}
+
+# forge_host_from_url <url> — extract the bare hostname from an ssh, https, or
+# git:// remote URL. Handles:
+#   git@host:owner/repo.git
+#   ssh://git@host:22/owner/repo.git
+#   https://host/owner/repo.git
+#   git://host/owner/repo.git
+forge_host_from_url() {
+  local url="$1"
+  url="$(forge_strip_git_suffix "$url")"
+
+  case "$url" in
+    *://*)
+      # scheme://[user@]host[:port]/path
+      local rest="${url#*://}"
+      rest="${rest#*@}"      # drop optional user@
+      rest="${rest%%/*}"     # keep host[:port]
+      printf '%s' "${rest%%:*}"  # drop :port
+      ;;
+    *@*:*)
+      # scp-like: [user@]host:path
+      local rest="${url#*@}"
+      printf '%s' "${rest%%:*}"
+      ;;
+    *:*)
+      # host:path with no user
+      printf '%s' "${url%%:*}"
+      ;;
+    *)
+      printf '%s' "$url"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Configured-host probes (local only — no network)
+# ---------------------------------------------------------------------------
+
+# forge_host_is_github <host> — true if the host is GitHub.com, a configured
+# GH_HOST/GITHUB_HOST enterprise host, or listed in ~/.config/gh/hosts.yml.
+forge_host_is_github() {
+  local host="$1"
+  case "$host" in
+    github.com|*.github.com) return 0 ;;
+  esac
+  if [[ -n "${GH_HOST:-}" && "$host" == "${GH_HOST}" ]]; then return 0; fi
+  if [[ -n "${GITHUB_HOST:-}" && "$host" == "${GITHUB_HOST}" ]]; then return 0; fi
+  local hosts_yml="${HOME}/.config/gh/hosts.yml"
+  if [[ -f "$hosts_yml" ]] && grep -qE "^${host}:" "$hosts_yml" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# forge_host_is_gitlab <host> — true if GitLab.com or a configured glab host.
+forge_host_is_gitlab() {
+  local host="$1"
+  case "$host" in
+    gitlab.com|*.gitlab.com) return 0 ;;
+  esac
+  local glab_cfg="${HOME}/.config/glab-cli/config.yml"
+  if [[ -f "$glab_cfg" ]] && grep -qE "^[[:space:]]*${host}:" "$glab_cfg" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# forge_host_in_tea <host> — true if the host matches a configured `tea` login
+# (Gitea/Forgejo). Reads `tea login list` so no network call is made.
+forge_host_in_tea() {
+  local host="$1"
+  command -v tea >/dev/null 2>&1 || return 1
+  # `tea login list` prints a table containing the URL and SSH host columns.
+  tea login list 2>/dev/null | grep -qiF "$host"
+}
+
+# ---------------------------------------------------------------------------
+# Optional network probe — distinguishes Forgejo from Gitea, and confirms a
+# gitea-family host when no local config exists. Best-effort; never required.
+# ---------------------------------------------------------------------------
+
+# forge_probe_gitea_family <host> — echo "forgejo" or "gitea" if the host serves
+# the Gitea REST API, else echo nothing and return 1. Hits /api/v1/version,
+# which is public on virtually all instances.
+forge_probe_gitea_family() {
+  local host="$1"
+  command -v curl >/dev/null 2>&1 || return 1
+  local body
+  body="$(curl -fsSL --max-time 5 "https://${host}/api/v1/version" 2>/dev/null)" || return 1
+  # The version endpoint returns {"version":"..."}. Forgejo advertises itself in
+  # the Server header; fall back to assuming gitea for the bare version payload.
+  case "$body" in
+    *version*)
+      local server
+      server="$(curl -fsSLI --max-time 5 "https://${host}/api/v1/version" 2>/dev/null | tr -d '\r')"
+      if printf '%s' "$server" | grep -qi 'forgejo'; then
+        printf 'forgejo'
+      else
+        printf 'gitea'
+      fi
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Provider detection
+# ---------------------------------------------------------------------------
+
+# forge_detect_provider [remote] [--probe]
+#   Detect the forge provider for a remote (default origin).
+#   Pass --probe to allow the network /api/v1/version fallback (off by default
+#   so detection stays fast and offline-friendly).
+#   Echoes one of: github | forgejo | gitea | gitlab | unknown
+forge_detect_provider() {
+  local remote="origin" probe="false"
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --probe) probe="true" ;;
+      *) remote="$arg" ;;
+    esac
+  done
+
+  local url host
+  url="$(forge_remote_url "$remote")" || { printf 'unknown'; return 0; }
+  [[ -z "$url" ]] && { printf 'unknown'; return 0; }
+  host="$(forge_host_from_url "$url")"
+  [[ -z "$host" ]] && { printf 'unknown'; return 0; }
+
+  if forge_host_is_github "$host"; then printf 'github'; return 0; fi
+  if forge_host_is_gitlab "$host"; then printf 'gitlab'; return 0; fi
+  if forge_host_in_tea "$host"; then
+    if [[ "$probe" == "true" ]]; then
+      local fam
+      fam="$(forge_probe_gitea_family "$host")" && { printf '%s' "$fam"; return 0; }
+    fi
+    # tea is configured for this host but we can't tell Forgejo from Gitea
+    # offline — default to the generic family label.
+    printf 'gitea'
+    return 0
+  fi
+  if [[ "$probe" == "true" ]]; then
+    local fam
+    fam="$(forge_probe_gitea_family "$host")" && { printf '%s' "$fam"; return 0; }
+  fi
+  printf 'unknown'
+}
+
+# ---------------------------------------------------------------------------
+# Tooling selection
+# ---------------------------------------------------------------------------
+
+# forge_cli <provider> — echo the CLI binary name for a provider.
+#   github → gh, forgejo|gitea → tea, gitlab → glab, unknown → (empty)
+forge_cli() {
+  case "$1" in
+    github) printf 'gh' ;;
+    forgejo|gitea) printf 'tea' ;;
+    gitlab) printf 'glab' ;;
+    *) printf '' ;;
+  esac
+}
+
+# forge_is_gitea_family <provider> — true for forgejo or gitea.
+forge_is_gitea_family() {
+  case "$1" in
+    forgejo|gitea) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# forge_cli_available <provider> — true if the provider's CLI is installed.
+forge_cli_available() {
+  local cli
+  cli="$(forge_cli "$1")"
+  [[ -n "$cli" ]] && command -v "$cli" >/dev/null 2>&1
+}
+
+# forge_auth_ok <provider> — true if the provider's CLI is authenticated.
+# Uses only local auth-status checks (no API/rate-limit cost).
+forge_auth_ok() {
+  case "$1" in
+    github) command -v gh   >/dev/null 2>&1 && gh   auth status >/dev/null 2>&1 ;;
+    forgejo|gitea)
+      # `tea` has no `auth status`; a configured login list is the local signal.
+      command -v tea  >/dev/null 2>&1 && tea login list 2>/dev/null | grep -q '://'
+      ;;
+    gitlab) command -v glab >/dev/null 2>&1 && glab auth status >/dev/null 2>&1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# forge_default_branch <provider> — echo the repository default branch, or
+# fall back to "main". Provider-neutral.
+forge_default_branch() {
+  local provider="$1" b=""
+  case "$provider" in
+    github)
+      b="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null)"
+      ;;
+    forgejo|gitea)
+      # `tea repos search`/`tea` lacks a stable default-branch field across
+      # versions; infer from the remote HEAD instead.
+      b="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+      ;;
+    gitlab)
+      b="$(glab repo view --output json 2>/dev/null | grep -o '"default_branch":"[^"]*"' | head -n1 | sed 's/.*:"//;s/"//')"
+      ;;
+  esac
+  if [[ -z "$b" ]]; then
+    b="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@')"
+  fi
+  printf '%s' "${b:-main}"
+}
+
+# forge_unsupported_notice <provider> <feature> — print a uniform, honest
+# message to stderr when an advanced feature is GitHub-only. Returns 0 so the
+# caller controls the exit code.
+forge_unsupported_notice() {
+  local provider="$1" feature="$2"
+  printf '%s: %s is a GitHub-only feature; provider "%s" is not supported.\n' \
+    "${0##*/}" "$feature" "$provider" >&2
+  printf '  Reason: Forgejo/Gitea expose only the REST v1 API (no GraphQL) and\n' >&2
+  printf '  the tea CLI does not surface CI-run logs/rerun controls. Run this\n' >&2
+  printf '  feature on a GitHub remote, or do the action manually on %s.\n' "$provider" >&2
+}

--- a/ycc/skills/_shared/scripts/release-ci-monitor.sh
+++ b/ycc/skills/_shared/scripts/release-ci-monitor.sh
@@ -35,6 +35,11 @@ VERSION="1.0.0"
 # shellcheck source=lib/ci-classify.sh
 . "$(dirname "$0")/lib/ci-classify.sh"
 
+# Forge provider detection. The release CI-autofix loop depends on
+# `gh run` controls with no Forgejo/Gitea equivalent — GitHub-only.
+# shellcheck source=lib/forge.sh
+. "$(dirname "$0")/lib/forge.sh"
+
 # ---------------------------------------------------------------------------
 # Usage
 # ---------------------------------------------------------------------------
@@ -417,6 +422,15 @@ main() {
     log_jsonl "$log_file" "$ts" "$iteration" "$tag" "0" "" "success" "" "green" "$push_count" "" '"dry_run":true'
     printf 'RESULT=green\n'
     exit 0
+  fi
+
+  # Forge provider gate (GitHub-only feature).
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "the release --ci auto-fix loop"
+    printf 'RESULT=unsupported-provider\n'
+    exit 2
   fi
 
   # Workflow file must be resolvable in non-dry-run mode.

--- a/ycc/skills/code-review/SKILL.md
+++ b/ycc/skills/code-review/SKILL.md
@@ -349,6 +349,15 @@ write an artifact here — quick-review owns the artifact lifecycle.
 
 Comprehensive GitHub PR review — fetches diff, reads full files, runs validation, posts review.
 
+**GitHub-only.** PR mode is GitHub-only: it reads and posts on PRs through the
+`gh` PR/review plumbing (`gh pr view`/`gh pr diff`/`gh pr review` + the GitHub
+review-comments API), which has no `tea` equivalent. Detect the forge provider
+on `origin` first (`forge_detect_provider origin`); if it is **not** `github`,
+state that PR mode is GitHub-only and offer **Local Review Mode** instead
+(local-diff review works on any provider). Do not attempt the `gh` PR calls on a
+non-GitHub remote. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
+
 Detect whether GitHub MCP tools are available (look for `mcp__github__*`). If they are, prefer those for PR fetch/view/review operations. Otherwise fall back to the `gh` CLI examples shown below.
 
 ### Phase 1 — FETCH

--- a/ycc/skills/git-cleanup/SKILL.md
+++ b/ycc/skills/git-cleanup/SKILL.md
@@ -53,13 +53,21 @@ Parse `$ARGUMENTS`:
 1. **Verify working tree is a git repo**: `git rev-parse --git-dir`. Abort if not.
 2. **Determine default branch**: `git symbolic-ref refs/remotes/origin/HEAD` →
    fall back to `main` / `master` if unset.
-3. **Detect host CLIs and MCP tools**. See
-   `${CLAUDE_PLUGIN_ROOT}/skills/git-cleanup/references/host-detection.md` for
-   the full decision table. Summary:
+3. **Detect host CLIs and MCP tools**. Detection follows the bundle-wide
+   contract in
+   `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/forge-detection.md`
+   (`forge_detect_provider origin` → `github` / `forgejo` / `gitea` / `gitlab` /
+   `unknown`; `forge_cli` → `gh` / `tea` / `glab`); the git-cleanup-specific
+   operation map lives in
+   `${CLAUDE_PLUGIN_ROOT}/skills/git-cleanup/references/host-detection.md`.
+   Summary:
    - Prefer `mcp__github__*` tools if available for GitHub operations.
-   - Else `gh auth status` for GitHub, `glab auth status` for GitLab.
-   - If `--host=auto`, parse `git remote get-url origin`. Unknown hosts skip
-     the remote-domain audits with a loud notice.
+   - Else `gh auth status` for GitHub, `tea login list` for the Forgejo/Gitea
+     family, `glab auth status` for GitLab.
+   - If `--host=auto`, parse `git remote get-url origin` via the shared lib.
+     A Forgejo/Gitea remote (matched against `tea login list`) routes PR/issue
+     cleanup through `tea` (`tea pull list/close`, `tea issues list/close`).
+     Unknown hosts skip the remote-domain audits with a loud notice.
 4. **Check working-tree state**: Capture `git status --porcelain` and
    `git stash list`. Record whether the current branch has unpushed commits.
 5. **Initialize progress tracking** with TodoWrite (one entry per phase).

--- a/ycc/skills/git-cleanup/references/host-detection.md
+++ b/ycc/skills/git-cleanup/references/host-detection.md
@@ -1,5 +1,14 @@
 # Host Detection and Client Selection
 
+> **Canonical source of truth:** the bundle-wide forge-detection contract lives at
+> [`../../_shared/references/forge-detection.md`](../../_shared/references/forge-detection.md)
+> (provider values `github` / `forgejo` / `gitea` / `gitlab` / `unknown`; CLIs
+> `gh` / `tea` / `glab`; the `forge_detect_provider`, `forge_cli`, `forge_auth_ok`
+> detection law implemented in `_shared/scripts/lib/forge.sh`). Prefer that document
+> and library for detection. This file is the **git-cleanup-specific supplement**:
+> it maps the resolved provider to the concrete read/write cleanup operations this
+> skill performs. When the two disagree on detection, the canonical reference wins.
+
 Reference for Phase 0 of `ycc/skills/git-cleanup/SKILL.md`. Given a repository,
 determine (1) which remote host the audit should query and (2) which client
 library / CLI / MCP server to use for each operation.
@@ -17,6 +26,12 @@ For GitLab repositories, pick the first available:
 1. **`glab` CLI** — authenticated (`glab auth status` returns 0).
 2. **Local-only mode** — skip `--prs` and `--issues` with a loud notice.
 
+For Forgejo / Gitea repositories (provider `forgejo` or `gitea` — same tooling
+family, both driven by `tea`), pick the first available:
+
+1. **`tea` CLI** — a configured login (`tea login list` shows a `://` entry).
+2. **Local-only mode** — skip `--prs` and `--issues` with a loud notice.
+
 Never mix clients within a single audit. Decide once in Phase 0 and log the
 decision in `.git-cleanup/report.md` under "Host-API notes".
 
@@ -24,13 +39,14 @@ decision in `.git-cleanup/report.md` under "Host-API notes".
 
 When `--host=auto` (default), parse `git remote get-url origin`:
 
-| Pattern match                                 | Inferred host |
-| --------------------------------------------- | ------------- |
-| `github.com:`, `github.com/`, `*.github.com/` | GitHub        |
-| `gitlab.com:`, `gitlab.com/`, `/api/v4/`      | GitLab        |
-| Self-hosted GitHub Enterprise (`GHE_HOST`)    | GitHub        |
-| Self-hosted GitLab                            | GitLab        |
-| Anything else                                 | Unknown       |
+| Pattern match                                 | Inferred host   |
+| --------------------------------------------- | --------------- |
+| `github.com:`, `github.com/`, `*.github.com/` | GitHub          |
+| `gitlab.com:`, `gitlab.com/`, `/api/v4/`      | GitLab          |
+| Self-hosted GitHub Enterprise (`GHE_HOST`)    | GitHub          |
+| Self-hosted GitLab                            | GitLab          |
+| Self-hosted Forgejo / Gitea                   | Forgejo / Gitea |
+| Anything else                                 | Unknown         |
 
 Accept SSH, HTTPS, and `git://` URLs. Strip any `.git` suffix before matching.
 
@@ -40,6 +56,12 @@ as GitHub and route `gh` calls to that host.
 
 **Self-hosted GitLab:** `glab` reads its host list from `~/.config/glab-cli/`.
 If the `origin` host matches one of its configured hosts, treat as GitLab.
+
+**Self-hosted Forgejo / Gitea:** `tea` reads its login list from
+`~/.config/tea/`. If the `origin` host matches a configured `tea login list`
+entry, treat as the Gitea family and route `tea` calls to that host. The two are
+the same tooling family (`forge_cli` maps both to `tea`); the canonical reference
+distinguishes `forgejo` from `gitea` only for messaging.
 
 ## Detecting MCP availability
 
@@ -101,6 +123,25 @@ GitLab's "Merge Request" maps to GitHub's "Pull Request" one-for-one for this
 skill's purposes. Both concepts share the same R-rules (see
 `active-code-rules.md`).
 
+### Forgejo / Gitea (`tea` fallbacks)
+
+```bash
+# Open PRs ("pulls") for the current repo
+tea pull list --state open
+
+# Merged/closed PRs (filter the list output for merged state)
+tea pull list --state closed
+
+# Open issues
+tea issues list --state open
+```
+
+`tea` operates on the repo bound to the current directory's `origin` remote (it
+reads `.git/config`); pass `--repo owner/name` only when overriding. Forgejo's
+"Pull Request" maps to GitHub's one-for-one and shares the same R-rules (see
+`active-code-rules.md`). `tea` paginates with `--limit` (alias for page size);
+bound large lists the same way `--limit` bounds `gh` output.
+
 ## Write operations (only with `--apply` + user approval)
 
 ### GitHub
@@ -119,6 +160,15 @@ skill's purposes. Both concepts share the same R-rules (see
 | Close an MR    | `glab mr close <iid>`                 |
 | Close an issue | `glab issue close <iid>`              |
 | Add a label    | `glab issue update <iid> --label ...` |
+
+### Forgejo / Gitea
+
+| Action                 | `tea` command                                     |
+| ---------------------- | ------------------------------------------------- |
+| Close a PR             | `tea pull close <n>`                              |
+| Close an issue         | `tea issues close <n>`                            |
+| Add a label            | `tea issues edit <n> --add-labels ...`            |
+| Delete a remote branch | (n/a — use git) `git push origin --delete <name>` |
 
 ## Rate-limit awareness
 

--- a/ycc/skills/git-workflow/SKILL.md
+++ b/ycc/skills/git-workflow/SKILL.md
@@ -650,6 +650,15 @@ This provides:
 - Documentation changes
 - Suggested PR title and scope
 
+**Forge provider detection**: `create-pr.sh` runs forge detection on `origin`
+first and routes PR creation through the matching CLI — `gh` for `github`,
+`tea` for `forgejo`/`gitea` (`gh pr create` ↔ `tea pull create`). The MCP-first
+path above applies only to `github`; on a `forgejo`/`gitea` remote the script
+drives `tea` directly. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the detection algorithm and operation-equivalence map. Log the resolved
+provider + CLI so the user sees which forge the PR targeted.
+
 ### Step 25: Generate PR Title
 
 PR titles **MUST** follow the conventional commit format: `<type>(<scope>): <description>`
@@ -901,6 +910,15 @@ If repository has `.github/PULL_REQUEST_TEMPLATE.md`:
 
 **Trigger:** This phase runs ONLY when `--ci ∈ flags`. Skip silently otherwise. Phase 6 does not require Phase 5 to have run — bare `--ci` and `--push --ci` both reach this phase by design.
 
+**GitHub-only:** The CI auto-fix loop is GitHub-only — it depends on `gh run`
+controls (`gh run view --log-failed`, `gh run rerun`). On a non-GitHub remote
+`ci-monitor.sh` returns `RESULT=unsupported-provider` (exit 2). Treat this like
+`pr-not-found`/`refused-default-branch`: report it directly and **skip the loop
+without erroring**. State that the loop is GitHub-only and why, then end Phase 6
+cleanly. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+and [`../_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md).
+
 ### Step 32: Discover PR for the current branch
 
 If a `PR_NUMBER` was captured in Phase 5 (either newly created in Steps 23-30 or detected as existing in Step 22a), use it directly and skip ahead to Step 33.
@@ -971,6 +989,7 @@ Branch on stdout `RESULT=...` per the **Loop Protocol** section of `ci-monitorin
 - `rerun-pending` → Flake-suspected; the script already triggered `gh run rerun --failed`. Do NOT apply any fix. Sleep 30 seconds (`sleep 30`), then goto Step 36.
 - `bail-recurrence` / `bail-nonfixable` / `bail-pushes` / `bail-timeout` → Render a diagnosis block citing the audit log path, the `RESULT=` value, the `REASON=` line if present, and the cap that fired. End Phase 6 (do NOT push further).
 - `pr-not-found` / `refused-default-branch` → Surface the error directly; do not retry.
+- `unsupported-provider` → Remote is not GitHub; the CI auto-fix loop is GitHub-only. Report that the loop is GitHub-only and skip it cleanly; do not retry and do not treat as an error.
 
 ### Step 37: Final report
 

--- a/ycc/skills/git-workflow/scripts/create-pr.sh
+++ b/ycc/skills/git-workflow/scripts/create-pr.sh
@@ -44,24 +44,54 @@ if ! git rev-parse --git-dir > /dev/null 2>&1; then
     exit 1
 fi
 
-# Check if gh CLI is available
-if ! command -v gh &> /dev/null; then
-    echo -e "${RED}Error: GitHub CLI (gh) is not installed${NC}" >&2
+# Detect the forge provider and select the matching CLI (gh / tea / glab).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
+PROVIDER="$(forge_detect_provider origin)"
+FORGE_CLI="$(forge_cli "$PROVIDER")"
+
+case "$PROVIDER" in
+    github|forgejo|gitea) ;;  # supported for PR creation
+    gitlab)
+        echo -e "${RED}Error: GitLab PR creation is not yet supported by this script${NC}" >&2
+        echo "Create the merge request with: glab mr create" >&2
+        exit 1
+        ;;
+    *)
+        echo -e "${RED}Error: Could not determine the forge provider for 'origin'${NC}" >&2
+        echo "origin = $(forge_remote_url origin)" >&2
+        echo "Supported: GitHub (gh), Forgejo/Gitea (tea)." >&2
+        exit 1
+        ;;
+esac
+
+# Check the matching CLI is installed
+if ! command -v "$FORGE_CLI" &> /dev/null; then
+    echo -e "${RED}Error: ${FORGE_CLI} CLI (for ${PROVIDER}) is not installed${NC}" >&2
     echo "" >&2
-    echo "Install with:" >&2
-    echo "  macOS:   brew install gh" >&2
-    echo "  Linux:   See https://github.com/cli/cli/blob/trunk/docs/install_linux.md" >&2
+    case "$PROVIDER" in
+        github) echo "Install gh:  https://github.com/cli/cli#installation" >&2 ;;
+        *)      echo "Install tea: https://gitea.com/gitea/tea#installation" >&2 ;;
+    esac
     exit 1
 fi
 
-# Check if authenticated with gh
-if ! gh auth status &> /dev/null; then
-    echo -e "${RED}Error: Not authenticated with GitHub CLI${NC}" >&2
+# Check authentication for the detected provider
+if ! forge_auth_ok "$PROVIDER"; then
+    echo -e "${RED}Error: Not authenticated with ${FORGE_CLI} (${PROVIDER})${NC}" >&2
     echo "" >&2
-    echo "Authenticate with:" >&2
-    echo "  gh auth login" >&2
+    case "$PROVIDER" in
+        github) echo "Authenticate with: gh auth login" >&2 ;;
+        *)      echo "Authenticate with: tea login add" >&2 ;;
+    esac
     exit 1
 fi
+
+echo -e "${BLUE}Forge provider:${NC} ${PROVIDER} (using ${FORGE_CLI})" >&2
 
 # Get current branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -71,8 +101,8 @@ if [ "$CURRENT_BRANCH" = "HEAD" ]; then
     exit 1
 fi
 
-# Get default branch (usually main or master)
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+# Get default branch (usually main or master) — provider-neutral
+DEFAULT_BRANCH=$(forge_default_branch "$PROVIDER")
 
 # Check if branch exists on remote
 if ! git ls-remote --exit-code --heads origin "$CURRENT_BRANCH" &> /dev/null; then
@@ -219,8 +249,13 @@ echo ""
 if [ "$MODE" = "analyze" ]; then
     echo -e "${BLUE}=== Analysis Complete ===${NC}\n"
     echo "To create PR:"
-    echo "  Regular: gh pr create --web"
-    echo "  Draft:   gh pr create --draft --web"
+    if [ "$PROVIDER" = "github" ]; then
+        echo "  Regular: gh pr create --web"
+        echo "  Draft:   gh pr create --draft --web"
+    else
+        echo "  Regular: tea pull create --head $CURRENT_BRANCH --base $DEFAULT_BRANCH"
+        echo "  (Forgejo/Gitea: 'tea' has no --draft or --web; open the PR in the web UI to mark it draft)"
+    fi
     exit 0
 fi
 
@@ -228,13 +263,22 @@ fi
 echo -e "${BLUE}=== Creating Pull Request ===${NC}\n"
 
 # Check if PR already exists
-EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+if [ "$PROVIDER" = "github" ]; then
+    EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+else
+    # tea pull list — match the head branch column; best-effort across tea versions
+    EXISTING_PR=$(tea pull list --output simple 2>/dev/null | grep -F "$CURRENT_BRANCH" | grep -oE '^#?[0-9]+' | head -n1 | tr -d '#' || echo "")
+fi
 
 if [ -n "$EXISTING_PR" ]; then
     echo -e "${YELLOW}⚠ PR already exists for this branch: #$EXISTING_PR${NC}"
     echo ""
-    echo "View PR: gh pr view $EXISTING_PR"
-    echo "Edit PR: gh pr edit $EXISTING_PR"
+    if [ "$PROVIDER" = "github" ]; then
+        echo "View PR: gh pr view $EXISTING_PR"
+        echo "Edit PR: gh pr edit $EXISTING_PR"
+    else
+        echo "View PR: tea pull $EXISTING_PR"
+    fi
     exit 1
 fi
 
@@ -309,32 +353,58 @@ Closes #
 echo "Creating PR..."
 echo ""
 
-if [ "$DRAFT" = true ]; then
-    set +e
-    gh pr create \
-        --title "$PR_TITLE" \
-        --body "$PR_DESCRIPTION" \
-        --draft \
-        --web
-    rc=$?
-    set -e
+if [ "$PROVIDER" = "github" ]; then
+    if [ "$DRAFT" = true ]; then
+        set +e
+        gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_DESCRIPTION" \
+            --draft \
+            --web
+        rc=$?
+        set -e
 
-    if [ $rc -eq 0 ]; then
-        echo ""
-        echo -e "${GREEN}✓ Draft PR created successfully${NC}"
-        echo ""
-        echo "Mark ready when complete: gh pr ready"
+        if [ $rc -eq 0 ]; then
+            echo ""
+            echo -e "${GREEN}✓ Draft PR created successfully${NC}"
+            echo ""
+            echo "Mark ready when complete: gh pr ready"
+        else
+            echo ""
+            echo -e "${RED}✗ Failed to create PR${NC}"
+            exit 1
+        fi
     else
-        echo ""
-        echo -e "${RED}✗ Failed to create PR${NC}"
-        exit 1
+        set +e
+        gh pr create \
+            --title "$PR_TITLE" \
+            --body "$PR_DESCRIPTION" \
+            --web
+        rc=$?
+        set -e
+
+        if [ $rc -eq 0 ]; then
+            echo ""
+            echo -e "${GREEN}✓ PR created successfully${NC}"
+        else
+            echo ""
+            echo -e "${RED}✗ Failed to create PR${NC}"
+            exit 1
+        fi
     fi
 else
+    # Forgejo / Gitea via tea. No --draft or --web support; create directly.
+    if [ "$DRAFT" = true ]; then
+        echo -e "${YELLOW}⚠ 'tea' does not support draft PRs; creating a normal PR.${NC}" >&2
+        echo "  Mark it draft in the ${PROVIDER} web UI if needed." >&2
+        echo ""
+    fi
     set +e
-    gh pr create \
+    tea pull create \
         --title "$PR_TITLE" \
-        --body "$PR_DESCRIPTION" \
-        --web
+        --description "$PR_DESCRIPTION" \
+        --head "$CURRENT_BRANCH" \
+        --base "$DEFAULT_BRANCH"
     rc=$?
     set -e
 

--- a/ycc/skills/pr-autofix/SKILL.md
+++ b/ycc/skills/pr-autofix/SKILL.md
@@ -44,6 +44,16 @@ Vendor-neutral counterpart to `coderabbit:autofix`. Pulls **every** comment surf
 **Golden rule**: Never mutate a comment body. Reply with the result, then resolve. The audit trail lives in the PR threads, not in this skill's report file.
 
 > Sister skills: `/ycc:review-fix` consumes `/ycc:code-review` artifacts (review-finding ID + Status fields). `/ycc:pr-autofix` (this) consumes GitHub PR comments directly. The two cover different inputs but share the per-finding agent dispatch model and the CI auto-fix loop.
+>
+> **GitHub-only.** This skill is GitHub-only. Forgejo/Gitea expose only the REST
+> v1 API — no GraphQL `resolveReviewThread`, no review-thread resolution, no
+> per-comment harvesting — and the CI loop depends on `gh run` controls. There
+> is no `tea` equivalent for any of these, so the workflow cannot degrade to a
+> partial mode here. Phase 0 detects the provider; on a non-`github` remote it
+> tells the user the skill is GitHub-only and **why**, then stops gracefully.
+> See [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+> (capability matrix: "Review-thread resolution", "Per-comment PR autofix
+> harvesting", "CI-autofix loop").
 
 ---
 
@@ -100,10 +110,21 @@ gh pr view "$PR_NUMBER" --json number,headRefName,baseRefName,headRepositoryOwne
 
 Record `HEAD_BRANCH`, `BASE_BRANCH`, `STATE`.
 
+### Provider detection
+
+Before the GitHub checks below, detect the forge provider on `origin` per
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+(`forge_detect_provider origin`). If the provider is **not** `github`, stop
+gracefully: "`/ycc:pr-autofix` is GitHub-only. Provider `<provider>` lacks the
+GraphQL review-thread resolution and per-comment harvesting this skill requires
+(Forgejo/Gitea expose only the REST v1 API). Resolve threads in the `<provider>`
+UI, or use local review tooling." Do not proceed to FETCH.
+
 ### Preflight refusals
 
 | Check                              | Action on failure                                                                                                  |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Provider is `github`               | Stop: GitHub-only (see Provider detection above).                                                                  |
 | `gh auth status` succeeds          | Stop: "Run `gh auth login` first."                                                                                 |
 | `STATE == "OPEN"`                  | Stop: "PR #<N> is <state>; nothing to autofix."                                                                    |
 | `HEAD_BRANCH != $(default-branch)` | Stop: "Refusing: PR head equals the default branch." (Same constraint as `ci-monitor.sh` — never push to default.) |
@@ -385,6 +406,8 @@ Track closure results in the status map: `closed_ok`, `closed_failed`, `reply_on
 **Trigger**: `--ci` was passed AND at least one fixer returned `Fixed` AND the push in Phase 5 succeeded. Skip silently otherwise.
 
 This phase is a thin wrapper over the same loop used by `/ycc:prp-pr` Phase 7 and `/ycc:git-workflow` Phase 6. **The policy lives in `${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/ci-monitoring.md` — do not restate it here.**
+
+The `--ci` loop is GitHub-only (it depends on `gh run` controls); since this entire skill is already gated to `github` in Phase 0, the loop never reaches a non-GitHub remote. If `ci-monitor.sh` ever returns `RESULT=unsupported-provider`, treat it like the other non-loop terminal results below: surface it and exit.
 
 ### Step 1 — Authorization prompt (skip if `--ci-yes`)
 

--- a/ycc/skills/pr-autofix/scripts/fetch-pr-comments.sh
+++ b/ycc/skills/pr-autofix/scripts/fetch-pr-comments.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # fetch-pr-comments.sh — Fetch all actionable PR comments via GitHub GraphQL
 #
+# GitHub-only. Forgejo/Gitea are unsupported: they expose no GraphQL API, so
+# review-thread harvesting cannot be replicated. On a non-GitHub remote this
+# script emits a uniform unsupported notice and exits 2.
+#
 # Purpose:
 #   Single-source fetcher used by ycc:pr-autofix. Pulls every actionable
 #   comment surface on a PR — review threads (file/line anchored) and
@@ -36,12 +40,21 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
   fetch-pr-comments.sh --pr <number> --out <file> [--owner <owner>] [--repo <repo>]
   fetch-pr-comments.sh --help
   fetch-pr-comments.sh --version
+
+GitHub-only. Forgejo/Gitea are unsupported (no GraphQL API); on a non-GitHub
+remote this script prints an unsupported notice and exits 2.
 
 Options:
   --pr <number>     PR number to fetch comments for (required)
@@ -133,6 +146,18 @@ for dep in gh jq; do
     exit 1
   fi
 done
+
+# ---------------------------------------------------------------------------
+# Forge provider gate (GitHub-only feature)
+# ---------------------------------------------------------------------------
+# Review-thread harvesting uses the GitHub GraphQL API. Forgejo/Gitea have no
+# GraphQL API, so detect the provider before any gh call and degrade gracefully.
+
+PROVIDER="$(forge_detect_provider origin)"
+if [[ "$PROVIDER" != "github" ]]; then
+  forge_unsupported_notice "$PROVIDER" "PR review-comment harvesting"
+  exit 2
+fi
 
 if ! gh auth status >/dev/null 2>&1; then
   printf 'fetch-pr-comments.sh: gh not authenticated. Run `gh auth login`.\n' >&2

--- a/ycc/skills/pr-autofix/scripts/post-summary.sh
+++ b/ycc/skills/pr-autofix/scripts/post-summary.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # post-summary.sh — Post a single consolidated summary comment on a PR
 #
+# GitHub-only. Forgejo/Gitea are unsupported: this script is part of the
+# GraphQL-driven pr-autofix flow and posts via `gh`. On a non-GitHub remote it
+# emits a uniform unsupported notice and exits 2 (the --dry-run render still
+# works on any provider).
+#
 # Purpose:
 #   At the end of a ycc:pr-autofix run, render and post one summary comment to
 #   the PR conversation. Built only from local counters — never echoes raw
@@ -34,12 +39,22 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
   post-summary.sh --pr <number> --fixed <N> --failed <N> --skipped <N> --deferred <N> \
                   --commit-sha <sha> --branch <name> \
                   [--ci-result <value>] [--ci-iterations <N>] [--ci-pushes <N>] [--dry-run]
+
+GitHub-only. Forgejo/Gitea are unsupported (part of the GraphQL-driven autofix
+flow); on a non-GitHub remote this script prints an unsupported notice and exits
+2. The --dry-run render works on any provider.
 
 Exit codes:
   0  success (or skipped as no-op)
@@ -182,6 +197,19 @@ ${body_footer}"
 if [[ "$DRY_RUN" == "true" ]]; then
   printf '%s\n' "$BODY"
   exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Forge provider gate (GitHub-only feature)
+# ---------------------------------------------------------------------------
+# This script posts via `gh` as part of the GraphQL-driven pr-autofix flow.
+# Detect the provider before the gh-auth check so a non-GitHub remote gets the
+# honest "GitHub-only" message instead of a confusing auth error.
+
+PROVIDER="$(forge_detect_provider origin)"
+if [[ "$PROVIDER" != "github" ]]; then
+  forge_unsupported_notice "$PROVIDER" "PR summary posting"
+  exit 2
 fi
 
 if ! command -v gh >/dev/null 2>&1; then

--- a/ycc/skills/pr-autofix/scripts/resolve-thread.sh
+++ b/ycc/skills/pr-autofix/scripts/resolve-thread.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # resolve-thread.sh — Mutate PR review threads and conversation comments
 #
+# GitHub-only. Forgejo/Gitea are unsupported: review-thread resolution and emoji
+# reactions require the GitHub GraphQL API (resolveReviewThread, addReaction),
+# which has no Forgejo/Gitea equivalent. On a non-GitHub remote this script emits
+# a uniform unsupported notice and exits 2.
+#
 # Purpose:
 #   Wraps the four mutations ycc:pr-autofix needs to close out comments:
 #     resolve      — resolveReviewThread(threadId) via GraphQL
@@ -35,6 +40,12 @@ IFS=$'\n\t'
 
 VERSION="1.0.0"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -45,6 +56,10 @@ Usage:
 
   resolve-thread.sh --help
   resolve-thread.sh --version
+
+GitHub-only. Forgejo/Gitea are unsupported (no GraphQL API for review-thread
+resolution or reactions); on a non-GitHub remote this script prints an
+unsupported notice and exits 2.
 
 Reaction values:
   THUMBS_UP THUMBS_DOWN LAUGH HOORAY CONFUSED HEART ROCKET EYES
@@ -177,6 +192,7 @@ main() {
     exit 1
   fi
 
+  # Handle help/version before any forge or auth checks so they work anywhere.
   case "$1" in
     --help|-h)
       usage
@@ -186,6 +202,28 @@ main() {
       printf 'resolve-thread.sh %s\n' "$VERSION"
       exit 0
       ;;
+  esac
+
+  # -------------------------------------------------------------------------
+  # Forge provider gate (GitHub-only feature)
+  # -------------------------------------------------------------------------
+  # resolveReviewThread/addReaction are GraphQL-only. Forgejo/Gitea have no
+  # GraphQL API, so detect the provider and short-circuit before the gh-auth
+  # check so a non-GitHub remote gets the honest "GitHub-only" message.
+
+  local provider
+  provider="$(forge_detect_provider origin)"
+  if [[ "$provider" != "github" ]]; then
+    forge_unsupported_notice "$provider" "PR review-thread resolution"
+    exit 2
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    printf 'resolve-thread.sh: gh not authenticated. Run `gh auth login`.\n' >&2
+    exit 2
+  fi
+
+  case "$1" in
     resolve)
       shift
       cmd_resolve "$@"
@@ -209,10 +247,5 @@ main() {
       ;;
   esac
 }
-
-if ! gh auth status >/dev/null 2>&1; then
-  printf 'resolve-thread.sh: gh not authenticated. Run `gh auth login`.\n' >&2
-  exit 2
-fi
 
 main "$@"

--- a/ycc/skills/prp-pr/SKILL.md
+++ b/ycc/skills/prp-pr/SKILL.md
@@ -173,12 +173,27 @@ Use this default format:
 
 ### Create the PR
 
+PR creation is provider-aware. Detect the forge provider on `origin` first
+(`forge_detect_provider origin`) and route through the matching CLI: `gh pr
+create` for `github`, `tea pull create --title --description [--head]` for
+`forgejo`/`gitea`. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the operation-equivalence map. Log the resolved provider + CLI so the user
+sees which forge the PR targeted.
+
 ```bash
+# github
 gh pr create \
   --title "<PR title>" \
   --base <base-branch> \
   --body "<PR body>"
   # Add --draft if the --draft flag was parsed from $ARGUMENTS
+
+# forgejo / gitea
+tea pull create \
+  --title "<PR title>" \
+  --base <base-branch> \
+  --description "<PR body>"
 ```
 
 ---
@@ -233,6 +248,13 @@ were printed (otherwise `n/a`).
 **Trigger:** Runs ONLY when `--ci` was passed AND a PR is in scope (created in
 Phase 4, or an existing PR confirmed for monitoring per the Phase 1 modification
 above). Skip silently otherwise.
+
+**GitHub-only:** The CI auto-fix loop is GitHub-only (it depends on `gh run`
+controls). On a non-GitHub remote `ci-monitor.sh` returns
+`RESULT=unsupported-provider` (exit 2). Treat this like
+`pr-not-found`/`refused-default-branch`: report that the loop is GitHub-only and
+skip it cleanly — do not retry, do not error. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 
 **Step 1 — Verify PR is monitorable:** Confirm a PR number is in scope. If not,
 hard-stop: `--ci was passed but no PR is in scope to monitor.`
@@ -294,6 +316,7 @@ Branch on stdout `RESULT=...` per the Loop Protocol in `ci-monitoring.md`:
   goto Step 5 (do NOT apply any fix).
 - `bail-*` → Go to Step 6 (diagnosis). Do not push further.
 - `pr-not-found` / `refused-default-branch` → Surface the error; do not retry.
+- `unsupported-provider` → Remote is not GitHub; the CI auto-fix loop is GitHub-only. Report that the loop is GitHub-only and skip it cleanly; do not retry or treat as an error.
 
 **Step 6 — Final report:**
 

--- a/ycc/skills/releaser/SKILL.md
+++ b/ycc/skills/releaser/SKILL.md
@@ -280,6 +280,17 @@ If `--ci-config=generate` ran, append:
 # build the matrix and attach artifacts to the GitHub release.
 ```
 
+**Forge provider detection**: release creation is provider-aware.
+`publish-release.sh` detects the forge provider on `origin` first and routes
+through the matching CLI — `gh release create` for `github`, `tea release
+create --tag <tag> [--note-file]` for `forgejo`/`gitea` (per the
+operation-equivalence map). The `gh release create`/`gh release upload` commands
+emitted in the Phase 8 block above are the `github` path; on a `forgejo`/`gitea`
+remote the helper drives `tea release create` instead. Log the resolved provider
+
+- CLI. See
+  [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
+
 When the user passed `--publish[=create|edit|auto]`, after they review the rendered
 notes, run:
 
@@ -317,6 +328,15 @@ The contract (exit codes, `RESULT=` signaling, JSONL audit log, failure classifi
 signature dedup, default-branch refusal) mirrors `ci-monitor.sh` verbatim. See
 [`_shared/references/ci-monitoring.md`](../_shared/references/ci-monitoring.md),
 section "Release mode", for the single source of truth.
+
+**GitHub-only:** the release-CI auto-fix loop is GitHub-only — it depends on
+`gh run list`, `gh workflow run`, and `gh release` controls that have no `tea`
+equivalent. On a non-GitHub remote `release-ci-monitor.sh` returns
+`RESULT=unsupported-provider` (exit 2). Treat it like `not-found`: report that
+the loop is GitHub-only, render an 8.5.4-style diagnosis, and exit Phase 8.5
+cleanly without retrying. (Release _creation_ in Phase 8 remains provider-aware
+via `tea release create`; only this post-publish monitoring loop is gated.) See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 
 ### 8.5.0 Detect re-cut strategy
 
@@ -392,16 +412,17 @@ one human approval the bounded, destructive-capable loop depends on. Therefore:
 
 3. Branch on the exit code (identical contract to `ci-monitor.sh`):
 
-   | Exit | `RESULT=`         | Action                                                |
-   | ---- | ----------------- | ----------------------------------------------------- |
-   | 0    | `green`           | Success. Exit Phase 8.5, continue to Phase 9.         |
-   | 20   | `handoff`         | Step **8.5.3** (fix and re-cut), then loop to step 2. |
-   | 21   | `rerun-pending`   | `sleep 30`, then loop to step 2 (no fix applied).     |
-   | 10   | `bail-recurrence` | Step **8.5.4** (diagnosis), exit Phase 8.5.           |
-   | 11   | `bail-nonfixable` | Step **8.5.4**, exit Phase 8.5.                       |
-   | 12   | `bail-pushes`     | Step **8.5.4**, exit Phase 8.5.                       |
-   | 13   | `bail-timeout`    | Step **8.5.4**, exit Phase 8.5.                       |
-   | 2    | `not-found`       | Step **8.5.4**, exit Phase 8.5.                       |
+   | Exit | `RESULT=`              | Action                                                                     |
+   | ---- | ---------------------- | -------------------------------------------------------------------------- |
+   | 0    | `green`                | Success. Exit Phase 8.5, continue to Phase 9.                              |
+   | 20   | `handoff`              | Step **8.5.3** (fix and re-cut), then loop to step 2.                      |
+   | 21   | `rerun-pending`        | `sleep 30`, then loop to step 2 (no fix applied).                          |
+   | 10   | `bail-recurrence`      | Step **8.5.4** (diagnosis), exit Phase 8.5.                                |
+   | 11   | `bail-nonfixable`      | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 12   | `bail-pushes`          | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 13   | `bail-timeout`         | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 2    | `not-found`            | Step **8.5.4**, exit Phase 8.5.                                            |
+   | 2    | `unsupported-provider` | Remote is not GitHub; loop is GitHub-only. Step **8.5.4**, exit Phase 8.5. |
 
 ### 8.5.3 Fix and re-cut on handoff
 

--- a/ycc/skills/releaser/scripts/publish-release.sh
+++ b/ycc/skills/releaser/scripts/publish-release.sh
@@ -1,14 +1,29 @@
 #!/usr/bin/env bash
-# publish-release.sh — Publish or update a GitHub release for a given tag.
+# publish-release.sh — Publish or update a release for a given tag.
+#
+# Provider-aware: routes through the CLI that matches the detected forge.
+#   github          → gh release create/edit  (behavior unchanged)
+#   forgejo / gitea → tea release create/edit
+#   gitlab / unknown→ release creation is not supported here; exits 1 with the
+#                     manual command to run.
 #
 # Usage:
 #   publish-release.sh [--mode=create|edit|auto] [--confirm] <tag> <notes-file>
 #
-# By default (no --confirm) prints the resolved gh command and exits 0.
+# By default (no --confirm) prints the resolved command and exits 0.
 # With --confirm the resolved command is executed.
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+# --- forge detection -------------------------------------------------------
+# Detect the forge provider and select the matching CLI (gh / tea). Prefer the
+# plugin-root install path; fall back to the source-tree relative path.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
 
 # --- diagnostic helpers ---
 fail()  { echo "${SCRIPT_NAME}: FAIL: $*" >&2; }
@@ -19,8 +34,9 @@ usage() {
     cat <<EOF
 Usage: ${SCRIPT_NAME} [options] <tag> <notes-file>
 
-Publish (create or update) a GitHub release for <tag> using <notes-file> as
-the release body.
+Publish (create or update) a release for <tag> using <notes-file> as the
+release body. The forge provider is auto-detected from origin (GitHub via gh,
+Forgejo/Gitea via tea).
 
 Arguments:
   <tag>          Git tag (e.g. v1.4.0 or 1.4.0 — normalised to v-prefix if semver)
@@ -30,16 +46,18 @@ Options:
   --mode=create  Create a new release (fails if release already exists)
   --mode=edit    Edit an existing release (fails if release does not exist)
   --mode=auto    Auto-detect: create if missing, edit if present (default)
-  --confirm      Actually run the resolved gh command (default: print only)
+  --confirm      Actually run the resolved command (default: print only)
   -h, --help     Show this help
 
 Print-only mode (no --confirm):
-  Prints the exact gh command that would be run, then exits 0. gh is NOT called.
+  Prints the exact command that would be run, then exits 0. The forge CLI is
+  NOT called.
 
 Authentication:
-  In --mode=auto, gh auth status is checked. If unauthenticated, the script
-  exits 1 with a warning. In --mode=create or --mode=edit, gh itself will
-  surface authentication errors when --confirm is used.
+  In --mode=auto, the detected forge CLI's auth state is checked. If
+  unauthenticated, the script exits 1 with a warning. In --mode=create or
+  --mode=edit, the CLI itself surfaces authentication errors when --confirm
+  is used.
 
 Examples:
   # Preview what would be run for tag v1.4.0:
@@ -144,22 +162,67 @@ if ! git show-ref --verify --quiet "refs/tags/${TAG}"; then
     exit 1
 fi
 
-# --- gh authentication check (auto mode only) ---
+# --- provider routing -------------------------------------------------------
+# Resolve the forge provider for origin and reject providers this script cannot
+# create releases for. github keeps its exact prior semantics; forgejo/gitea
+# route through tea; gitlab/unknown exit with the manual command.
+PROVIDER="$(forge_detect_provider origin)"
+FORGE_CLI="$(forge_cli "${PROVIDER}")"
+
+case "${PROVIDER}" in
+    github|forgejo|gitea)
+        ;;  # supported for release create/edit
+    gitlab)
+        fail "GitLab release creation is not supported by this script"
+        hint "create the release manually: glab release create ${TAG} --notes-file ${NOTES_FILE}"
+        exit 1
+        ;;
+    *)
+        fail "could not determine the forge provider for 'origin'"
+        hint "origin = $(forge_remote_url origin)"
+        hint "supported: GitHub (gh), Forgejo/Gitea (tea)"
+        exit 1
+        ;;
+esac
+
+# --- forge CLI availability check ---
+if ! command -v "${FORGE_CLI}" >/dev/null 2>&1; then
+    fail "${FORGE_CLI} CLI (for ${PROVIDER}) is not installed"
+    case "${PROVIDER}" in
+        github) hint "install gh:  https://github.com/cli/cli#installation" ;;
+        *)      hint "install tea: https://gitea.com/gitea/tea#installation" ;;
+    esac
+    exit 1
+fi
+
+# --- authentication check (auto mode only) ---
 if [[ "${MODE}" == "auto" ]]; then
-    if ! gh auth status >/dev/null 2>&1; then
-        warn "gh not authenticated; cannot determine release state — re-run with explicit --mode=create or --mode=edit"
+    if ! forge_auth_ok "${PROVIDER}"; then
+        warn "${FORGE_CLI} not authenticated (${PROVIDER}); cannot determine release state — re-run with explicit --mode=create or --mode=edit"
+        case "${PROVIDER}" in
+            github) hint "authenticate with: gh auth login" ;;
+            *)      hint "authenticate with: tea login add" ;;
+        esac
         exit 1
     fi
 fi
 
 # --- release existence detection ---
-# Always probe GitHub (including --mode=create) so create-mode can detect an
-# existing release and suggest --mode=edit instead of failing later on gh.
+# Always probe the forge (including --mode=create) so create-mode can detect an
+# existing release and suggest --mode=edit instead of failing later in the CLI.
 RELEASE_JSON=""
 RELEASE_EXISTS=0
-RELEASE_JSON="$(gh release view "${TAG}" --json url,tagName,body 2>/dev/null || true)"
-if [[ -n "${RELEASE_JSON}" ]]; then
-    RELEASE_EXISTS=1
+if [[ "${PROVIDER}" == "github" ]]; then
+    RELEASE_JSON="$(gh release view "${TAG}" --json url,tagName,body 2>/dev/null || true)"
+    if [[ -n "${RELEASE_JSON}" ]]; then
+        RELEASE_EXISTS=1
+    fi
+else
+    # tea has no per-tag "view"; list releases as JSON and match the tag_name.
+    if tea release list --output json 2>/dev/null \
+        | grep -qE "\"tag_name\"[[:space:]]*:[[:space:]]*\"${TAG}\""; then
+        RELEASE_EXISTS=1
+    fi
 fi
 
 # --- mode conflict checks ---
@@ -186,10 +249,22 @@ case "${MODE}" in
 esac
 
 # --- build resolved command ---
-if [[ "${MODE}" == "create" ]]; then
-    RESOLVED_CMD="gh release create $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}") --title $(printf '%q' "${TAG}") --verify-tag"
+# github keeps its prior gh commands verbatim. tea (forgejo/gitea) uses
+# `tea release create --note-file` for create, but `tea release edit` has no
+# --note-file in 0.14.x, so edit passes the notes inline via --note.
+if [[ "${PROVIDER}" == "github" ]]; then
+    if [[ "${MODE}" == "create" ]]; then
+        RESOLVED_CMD="gh release create $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}") --title $(printf '%q' "${TAG}") --verify-tag"
+    else
+        RESOLVED_CMD="gh release edit $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}")"
+    fi
 else
-    RESOLVED_CMD="gh release edit $(printf '%q' "${TAG}") --notes-file $(printf '%q' "${NOTES_FILE}")"
+    if [[ "${MODE}" == "create" ]]; then
+        RESOLVED_CMD="tea release create --tag $(printf '%q' "${TAG}") --title $(printf '%q' "${TAG}") --note-file $(printf '%q' "${NOTES_FILE}")"
+    else
+        # `tea release edit` lacks --note-file; pass the notes file inline.
+        RESOLVED_CMD="tea release edit $(printf '%q' "${TAG}") --note \"\$(cat $(printf '%q' "${NOTES_FILE}"))\""
+    fi
 fi
 
 # --- print-only mode (no --confirm) ---
@@ -200,14 +275,28 @@ fi
 
 # --- confirm mode: warn before destructive edit ---
 if [[ "${MODE}" == "edit" ]]; then
-    existing_body="$(printf '%s' "${RELEASE_JSON}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("body","") or "")' 2>/dev/null || true)"
-    warn "about to overwrite release body for ${TAG}. Current body:"
-    printf '%s\n' "---" "${existing_body}" "---" >&2
+    if [[ "${PROVIDER}" == "github" ]]; then
+        existing_body="$(printf '%s' "${RELEASE_JSON}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("body","") or "")' 2>/dev/null || true)"
+        warn "about to overwrite release body for ${TAG}. Current body:"
+        printf '%s\n' "---" "${existing_body}" "---" >&2
+    else
+        warn "about to overwrite release notes for ${TAG} on ${PROVIDER}."
+    fi
 fi
 
 # --- execute ---
-if [[ "${MODE}" == "create" ]]; then
-    gh release create "${TAG}" --notes-file "${NOTES_FILE}" --title "${TAG}" --verify-tag
+if [[ "${PROVIDER}" == "github" ]]; then
+    if [[ "${MODE}" == "create" ]]; then
+        gh release create "${TAG}" --notes-file "${NOTES_FILE}" --title "${TAG}" --verify-tag
+    else
+        gh release edit "${TAG}" --notes-file "${NOTES_FILE}"
+    fi
 else
-    gh release edit "${TAG}" --notes-file "${NOTES_FILE}"
+    if [[ "${MODE}" == "create" ]]; then
+        tea release create --tag "${TAG}" --title "${TAG}" --note-file "${NOTES_FILE}"
+    else
+        # `tea release edit` lacks --note-file; read the notes file inline.
+        NOTES_BODY="$(cat "${NOTES_FILE}")"
+        tea release edit "${TAG}" --note "${NOTES_BODY}"
+    fi
 fi

--- a/ycc/skills/research-to-issues/SKILL.md
+++ b/ycc/skills/research-to-issues/SKILL.md
@@ -33,6 +33,22 @@ Parse arguments:
 
 ## Tool Preference Strategy
 
+### Step 0a: Detect forge provider
+
+Issue creation is provider-aware. Detect the forge provider on `origin` first
+(`forge_detect_provider origin`) and route through the matching CLI:
+`gh issue create --title --body` for `github`, `tea issues create --title
+--description` for `forgejo`/`gitea`. `validate-prerequisites.sh` runs the same
+detection and gates the per-provider issue prerequisites. See
+[`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md)
+for the operation-equivalence map. Log the resolved provider + CLI.
+
+**Forgejo/Gitea caveats**: repo-slug resolution (`gh repo view`) and some label
+operations (`gh label create`) are `gh`-only and have no `tea` equivalent — skip
+them on `forgejo`/`gitea` (create labels via the Forgejo/Gitea UI, and bind
+`tea` to the `origin`-bound repo rather than resolving an owner/name slug). The
+GitHub MCP path below applies only to `github`.
+
 ### Step 0: Detect GitHub MCP Server
 
 Check if GitHub MCP tools are available by looking for tools matching `mcp__github__*`.

--- a/ycc/skills/research-to-issues/scripts/validate-prerequisites.sh
+++ b/ycc/skills/research-to-issues/scripts/validate-prerequisites.sh
@@ -14,13 +14,21 @@ set -euo pipefail
 # Auto-detects type from path/content if --type is not specified.
 #
 # Checks:
-#   1. gh CLI is installed and authenticated
-#   2. Current directory is a git repo with a GitHub remote
+#   1. The forge CLI for the detected provider is installed and authenticated
+#      (gh for GitHub, tea for Forgejo/Gitea)
+#   2. Current directory is a git repo on a supported forge
 #   3. Source path exists and matches expected structure
 #
 # Exit codes:
 #   0 = all prerequisites met
 #   1 = missing prerequisite
+
+# Detect the forge provider and select the matching CLI (gh / tea).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+FORGE_LIB="${SCRIPT_DIR}/../../_shared/scripts/lib/forge.sh"
+[[ -f "$FORGE_LIB" ]] || FORGE_LIB="${CLAUDE_PLUGIN_ROOT}/skills/_shared/scripts/lib/forge.sh"
+# shellcheck source=/dev/null
+source "$FORGE_LIB"
 
 SOURCE_PATH="${1:-}"
 EXPLICIT_TYPE=""
@@ -41,35 +49,60 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# --- Check gh CLI ---
-if ! command -v gh &>/dev/null; then
-  ERRORS+=("ERROR: GitHub CLI (gh) is not installed. Install: https://cli.github.com/")
-else
-  if ! gh auth status &>/dev/null 2>&1; then
-    ERRORS+=("ERROR: GitHub CLI is not authenticated. Run: gh auth login")
-  else
-    echo "OK: gh CLI installed and authenticated"
-  fi
-fi
-
-# --- Check git repo with GitHub remote ---
+# --- Check git repo and detect forge provider ---
+PROVIDER="unknown"
+FORGE_CLI=""
 if ! git rev-parse --is-inside-work-tree &>/dev/null 2>&1; then
   ERRORS+=("ERROR: Not inside a git repository")
 else
   REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
   if [[ -z "$REMOTE_URL" ]]; then
     ERRORS+=("ERROR: No 'origin' remote configured")
-  elif [[ "$REMOTE_URL" != *"github.com"* && "$REMOTE_URL" != *"github:"* ]]; then
-    ERRORS+=("WARNING: Remote may not be GitHub: $REMOTE_URL")
   else
-    REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
-    if [[ -n "$REPO" ]]; then
-      echo "OK: GitHub repo detected: $REPO"
-    else
-      ERRORS+=("ERROR: Could not determine GitHub repo from remote")
-    fi
+    PROVIDER="$(forge_detect_provider origin)"
+    FORGE_CLI="$(forge_cli "$PROVIDER")"
+
+    case "$PROVIDER" in
+      github|forgejo|gitea)
+        echo "OK: Forge provider detected: $PROVIDER (using $FORGE_CLI)"
+        ;;
+      gitlab|unknown)
+        ERRORS+=("ERROR: Issue creation requires GitHub (gh) or Forgejo/Gitea (tea); detected provider '$PROVIDER' (origin: $REMOTE_URL) is not supported")
+        ;;
+    esac
   fi
 fi
+
+# --- Check the matching forge CLI is installed and authenticated ---
+case "$PROVIDER" in
+  github|forgejo|gitea)
+    if ! command -v "$FORGE_CLI" &>/dev/null; then
+      case "$PROVIDER" in
+        github) ERRORS+=("ERROR: GitHub CLI (gh) is not installed. Install: https://cli.github.com/") ;;
+        *)      ERRORS+=("ERROR: tea CLI (for $PROVIDER) is not installed. Install: https://gitea.com/gitea/tea#installation") ;;
+      esac
+    elif ! forge_auth_ok "$PROVIDER"; then
+      case "$PROVIDER" in
+        github) ERRORS+=("ERROR: GitHub CLI is not authenticated. Run: gh auth login") ;;
+        *)      ERRORS+=("ERROR: tea is not authenticated for $PROVIDER. Run: tea login add") ;;
+      esac
+    else
+      echo "OK: $FORGE_CLI CLI installed and authenticated"
+      # GitHub-only: confirm the repo slug resolves via the host API. tea v0.14
+      # has no clean equivalent, so this sub-check is skipped on Forgejo/Gitea.
+      if [[ "$PROVIDER" == "github" ]]; then
+        REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || echo "")
+        if [[ -n "$REPO" ]]; then
+          echo "OK: GitHub repo detected: $REPO"
+        else
+          ERRORS+=("ERROR: Could not determine GitHub repo from remote")
+        fi
+      else
+        echo "NOTICE: Skipping repo-slug resolution check (no clean tea equivalent on $PROVIDER)"
+      fi
+    fi
+    ;;
+esac
 
 # --- Check source path ---
 if [[ -z "$SOURCE_PATH" ]]; then

--- a/ycc/skills/review-fix/SKILL.md
+++ b/ycc/skills/review-fix/SKILL.md
@@ -871,6 +871,16 @@ ${CLAUDE_PLUGIN_ROOT}/skills/_shared/references/goal-pairing.md
 
 ## Important Notes
 
+- **PR posting is GitHub-only**: The PR-coupled steps here use `gh` (resolving the
+  PR head via `gh pr view`, and the commit+push to the PR branch in worktree mode).
+  Those depend on GitHub plumbing that has no `tea` equivalent. Detect the forge
+  provider on `origin` (`forge_detect_provider origin`) before any `gh pr` call. On a
+  non-`github` provider, apply the fixes **locally** (Path A/B/C all edit files in the
+  working tree regardless of forge) and **skip the PR-posting step** with a notice:
+  "PR posting is GitHub-only on provider `<provider>`; fixes applied locally — commit
+  and push them yourself." Mark `REPORT_COMMITTED: n/a` in that case. The artifact
+  parse, filter, fix, Status updates, and Phase 5 validation are all provider-neutral.
+  See [`../_shared/references/forge-detection.md`](../_shared/references/forge-detection.md).
 - **In-place Status updates**: The source review file is the source of truth. This skill mutates it in place via `Edit`, updating only the `Status` line of each processed finding. All other content is preserved.
 - **No scope creep**: Each `ycc:review-fixer` agent is scope-disciplined — it fixes exactly what the finding specifies. If the fix reveals a larger issue, the agent reports it, but the skill does not chase down related problems.
 - **Resumable**: Re-running on the same review file skips already-processed findings.


### PR DESCRIPTION
## Summary

The git-focused ycc skills were GitHub-only (`gh` everywhere). This adds **forge provider autodetection** so they also work on self-hosted **Forgejo/Gitea** repos: each skill detects the forge from the `origin` remote and routes to the matching CLI (`gh` for GitHub, `tea` for Forgejo/Gitea), or degrades gracefully when a feature is GitHub-only.

Closes #105

## Changes

- **Foundation (single source of truth)**
  - `_shared/scripts/lib/forge.sh` — sourceable detection lib: `forge_detect_provider`, `forge_cli`, `forge_auth_ok`, `forge_default_branch`, `forge_unsupported_notice`.
  - `_shared/references/forge-detection.md` — detection algorithm, `gh`↔`tea` operation equivalence map, and a capability matrix of GitHub-only features.
- **Core operations made provider-aware (full gh/tea support)**
  - `git-workflow/scripts/create-pr.sh` — `gh pr create` ↔ `tea pull create`.
  - `releaser/scripts/publish-release.sh` — `gh release` ↔ `tea release` (GitHub path unchanged; `--confirm` gating preserved).
  - `research-to-issues/scripts/validate-prerequisites.sh` — `gh`/`tea` issue prerequisites.
- **GitHub-only features gated with graceful degradation** (Forgejo/Gitea lack GraphQL; `tea` has no CI-run controls)
  - `_shared/scripts/ci-monitor.sh`, `release-ci-monitor.sh` — emit `RESULT=unsupported-provider` on non-GitHub remotes.
  - `pr-autofix/scripts/{fetch-pr-comments,resolve-thread,post-summary}.sh`.
- **SKILL prose + references threaded** with provider detection + capability notes: git-workflow, pr-autofix, prp-pr, releaser, code-review, review-fix, research-to-issues, git-cleanup, and `_shared/references/ci-monitoring.md`.
- **Compatibility bundles regenerated** (Cursor / Codex / opencode) via `./scripts/sync.sh`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- [x] Linter passes (`npm run lint:modified` — prettier + shellcheck clean)
- [x] `./scripts/validate.sh` passes (inventory, cursor, codex, opencode, json)
- [x] `shellcheck --severity=warning` clean on all changed scripts
- [x] Detection smoke-tested: `origin` (Forgejo) → `tea`; `github` remote → `gh`; CI-monitor gate returns `RESULT=unsupported-provider` on the Forgejo remote

## Reviewer Notes

GitHub behavior is preserved byte-for-byte on every changed script — non-GitHub providers take new code paths only. The honest design choice: PR-comment GraphQL machinery and the `gh run` CI-autofix loop are **GitHub-only** and decline cleanly on Forgejo/Gitea rather than faking parity the upstream API can't support. See `_shared/references/forge-detection.md` for the full capability matrix.